### PR TITLE
Add TimePicker Dialog

### DIFF
--- a/app/src/main/java/com/kez/picker/MainActivity.kt
+++ b/app/src/main/java/com/kez/picker/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.kez.picker.date.YearMonthPicker
@@ -61,6 +62,7 @@ class MainActivity : ComponentActivity() {
                                 dismissOnBackPress = true,
                                 dismissOnClickOutside = true
                             ),
+                            dividerColor = Color.Gray,
                             onDismissRequest = {
                                 isShowTimePicker.value = false
                             },

--- a/app/src/main/java/com/kez/picker/MainActivity.kt
+++ b/app/src/main/java/com/kez/picker/MainActivity.kt
@@ -1,12 +1,12 @@
 package com.kez.picker
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
@@ -16,11 +16,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.kez.picker.date.YearMonthPicker
+import com.kez.picker.time.TimePickerDialog
 import com.kez.picker.ui.theme.ComposePickerTheme
-import com.kez.picker.util.TimeFormat
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -55,20 +55,24 @@ class MainActivity : ComponentActivity() {
                     }
 
                     if (isShowTimePicker.value) {
-                        Dialog(
-                            onDismissRequest = {
-                                isShowTimePicker.value = false
-                            },
+                        TimePickerDialog(
+                            modifier = Modifier.wrapContentSize(),
                             properties = DialogProperties(
                                 dismissOnBackPress = true,
                                 dismissOnClickOutside = true
-                            )
-                        ) {
-                            TimePicker(
-                                modifier = Modifier.wrapContentSize(),
-                                timeFormat = TimeFormat.HOUR_12
-                            )
-                        }
+                            ),
+                            onDismissRequest = {
+                                isShowTimePicker.value = false
+                            },
+                            onDoneClickListener = { localDateTime ->
+                                isShowTimePicker.value = false
+                                Toast.makeText(
+                                    this@MainActivity,
+                                    "Selected Time: $localDateTime",
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        )
                     }
 
                     if (isShowYearMonthPicker.value) {

--- a/picker/src/main/java/com/kez/picker/Picker.kt
+++ b/picker/src/main/java/com/kez/picker/Picker.kt
@@ -63,7 +63,7 @@ fun <T> Picker(
     ),
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     itemTextAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    dividerThickness: Dp = 2.dp,
+    dividerThickness: Dp = 1.dp,
     dividerShape: Shape = RoundedCornerShape(10.dp),
     isInfinity: Boolean = true
 ) {

--- a/picker/src/main/java/com/kez/picker/PickerState.kt
+++ b/picker/src/main/java/com/kez/picker/PickerState.kt
@@ -7,8 +7,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 
 @Composable
-fun rememberPickerState() = remember { PickerState() }
+fun <T> rememberPickerState(initialItem: T) = remember { PickerState(initialItem) }
 
-class PickerState {
-    var selectedItem by mutableStateOf("")
+class PickerState<T>(
+    initialItem: T
+) {
+    var selectedItem by mutableStateOf(initialItem)
 }

--- a/picker/src/main/java/com/kez/picker/date/YearMonthPicker.kt
+++ b/picker/src/main/java/com/kez/picker/date/YearMonthPicker.kt
@@ -1,4 +1,4 @@
-package com.kez.picker
+package com.kez.picker.date
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,6 +21,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kez.picker.Picker
+import com.kez.picker.PickerState
+import com.kez.picker.rememberPickerState
 import com.kez.picker.util.MONTH_RANGE
 import com.kez.picker.util.YEAR_RANGE
 import com.kez.picker.util.currentDate
@@ -29,11 +32,11 @@ import kotlinx.datetime.LocalDate
 @Composable
 fun YearMonthPicker(
     modifier: Modifier = Modifier,
-    yearPickerState: PickerState = rememberPickerState(),
-    monthPickerState: PickerState = rememberPickerState(),
+    yearPickerState: PickerState<Int> = rememberPickerState(currentDate.year),
+    monthPickerState: PickerState<Int> = rememberPickerState(currentDate.monthNumber),
     startLocalDate: LocalDate = currentDate,
-    yearItems: List<String> = YEAR_RANGE,
-    monthItems: List<String> = MONTH_RANGE,
+    yearItems: List<Int> = YEAR_RANGE,
+    monthItems: List<Int> = MONTH_RANGE,
     visibleItemsCount: Int = 3,
     itemPadding: PaddingValues = PaddingValues(8.dp),
     textStyle: TextStyle = TextStyle(fontSize = 16.sp),
@@ -59,10 +62,10 @@ fun YearMonthPicker(
         ) {
 
             val yearStartIndex = remember {
-                yearItems.indexOf(startLocalDate.year.toString())
+                yearItems.indexOf(startLocalDate.year)
             }
             val monthStartIndex = remember {
-                monthItems.indexOf(startLocalDate.monthNumber.toString())
+                monthItems.indexOf(startLocalDate.monthNumber)
             }
 
             Row(

--- a/picker/src/main/java/com/kez/picker/time/TimePicker.kt
+++ b/picker/src/main/java/com/kez/picker/time/TimePicker.kt
@@ -60,7 +60,7 @@ fun TimePicker(
     ),
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    dividerThickness: Dp = 2.dp,
+    dividerThickness: Dp = 1.dp,
     dividerShape: Shape = RoundedCornerShape(10.dp),
     spacingBetweenPickers: Dp = 20.dp,
     pickerWidth: Dp = 80.dp

--- a/picker/src/main/java/com/kez/picker/time/TimePicker.kt
+++ b/picker/src/main/java/com/kez/picker/time/TimePicker.kt
@@ -1,7 +1,6 @@
-package com.kez.picker
+package com.kez.picker.time
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -23,27 +22,32 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kez.picker.Picker
+import com.kez.picker.PickerState
 import com.kez.picker.util.HOUR12_RANGE
 import com.kez.picker.util.HOUR24_RANGE
 import com.kez.picker.util.MINUTE_RANGE
 import com.kez.picker.util.TimeFormat
+import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDateTime
+import com.kez.picker.util.currentHour
+import com.kez.picker.util.currentMinute
 import kotlinx.datetime.LocalDateTime
 
 @Composable
 fun TimePicker(
     modifier: Modifier = Modifier,
-    minutePickerState: PickerState = rememberPickerState(),
-    hourPickerState: PickerState = rememberPickerState(),
-    periodPickerState: PickerState = rememberPickerState(),
+    minutePickerState: PickerState<Int> = remember { PickerState(currentMinute) },
+    hourPickerState: PickerState<Int> = remember { PickerState(currentHour) },
+    periodPickerState: PickerState<TimePeriod> = remember { PickerState(TimePeriod.AM) },
     timeFormat: TimeFormat = TimeFormat.HOUR_24,
     startTime: LocalDateTime = currentDateTime,
-    minuteItems: List<String> = MINUTE_RANGE,
-    hourItems: List<String> = when (timeFormat) {
+    minuteItems: List<Int> = MINUTE_RANGE,
+    hourItems: List<Int> = when (timeFormat) {
         TimeFormat.HOUR_12 -> HOUR12_RANGE
         TimeFormat.HOUR_24 -> HOUR24_RANGE
     },
-    periodItems: List<String> = listOf("AM", "PM"),
+    periodItems: List<TimePeriod> = TimePeriod.entries,
     visibleItemsCount: Int = 3,
     itemPadding: PaddingValues = PaddingValues(8.dp),
     textStyle: TextStyle = TextStyle(fontSize = 16.sp),
@@ -59,7 +63,7 @@ fun TimePicker(
     dividerThickness: Dp = 2.dp,
     dividerShape: Shape = RoundedCornerShape(10.dp),
     spacingBetweenPickers: Dp = 20.dp,
-    pickerWidth: Dp = 100.dp
+    pickerWidth: Dp = 80.dp
 ) {
     Surface(modifier = modifier) {
         Column(
@@ -69,7 +73,7 @@ fun TimePicker(
         ) {
 
             val minuteStartIndex = remember {
-                minuteItems.indexOf(startTime.minute.toString())
+                minuteItems.indexOf(startTime.minute)
             }
 
             val hourStartIndex = remember {
@@ -81,7 +85,7 @@ fun TimePicker(
 
                     TimeFormat.HOUR_24 -> startTime.hour
                 }
-                hourItems.indexOf(startHour.toString())
+                hourItems.indexOf(startHour)
             }
 
             val periodStartIndex = remember {
@@ -96,9 +100,49 @@ fun TimePicker(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                if (timeFormat == TimeFormat.HOUR_12) {
+                    Picker(
+                        state = periodPickerState,
+                        items = periodItems,
+                        visibleItemsCount = visibleItemsCount,
+                        modifier = Modifier.width(pickerWidth),
+                        textStyle = textStyle,
+                        selectedTextStyle = selectedTextStyle,
+                        textModifier = Modifier.padding(itemPadding),
+                        dividerColor = dividerColor,
+                        itemPadding = itemPadding,
+                        startIndex = periodStartIndex,
+                        fadingEdgeGradient = fadingEdgeGradient,
+                        horizontalAlignment = horizontalAlignment,
+                        itemTextAlignment = verticalAlignment,
+                        dividerThickness = dividerThickness,
+                        dividerShape = dividerShape,
+                        isInfinity = false,
+                    )
+                    Spacer(modifier = Modifier.width(spacingBetweenPickers))
+                }
                 Picker(
-                    state = periodPickerState,
-                    items = periodItems,
+                    state = hourPickerState,
+                    modifier = Modifier.width(pickerWidth),
+                    items = hourItems,
+                    startIndex = hourStartIndex,
+                    visibleItemsCount = visibleItemsCount,
+                    textModifier = Modifier.padding(itemPadding),
+                    textStyle = textStyle,
+                    selectedTextStyle = selectedTextStyle,
+                    dividerColor = dividerColor,
+                    itemPadding = itemPadding,
+                    fadingEdgeGradient = fadingEdgeGradient,
+                    horizontalAlignment = horizontalAlignment,
+                    itemTextAlignment = verticalAlignment,
+                    dividerThickness = dividerThickness,
+                    dividerShape = dividerShape
+                )
+                Spacer(modifier = Modifier.width(spacingBetweenPickers))
+                Picker(
+                    state = minutePickerState,
+                    items = minuteItems,
+                    startIndex = minuteStartIndex,
                     visibleItemsCount = visibleItemsCount,
                     modifier = Modifier.width(pickerWidth),
                     textStyle = textStyle,
@@ -106,60 +150,12 @@ fun TimePicker(
                     textModifier = Modifier.padding(itemPadding),
                     dividerColor = dividerColor,
                     itemPadding = itemPadding,
-                    startIndex = periodStartIndex,
                     fadingEdgeGradient = fadingEdgeGradient,
                     horizontalAlignment = horizontalAlignment,
                     itemTextAlignment = verticalAlignment,
                     dividerThickness = dividerThickness,
                     dividerShape = dividerShape,
-                    isInfinity = false,
                 )
-
-                Spacer(modifier = Modifier.width(spacingBetweenPickers))
-
-                Box(contentAlignment = Alignment.Center) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Picker(
-                            state = hourPickerState,
-                            modifier = Modifier.width(pickerWidth),
-                            items = hourItems,
-                            startIndex = hourStartIndex,
-                            visibleItemsCount = visibleItemsCount,
-                            textModifier = Modifier.padding(itemPadding),
-                            textStyle = textStyle,
-                            selectedTextStyle = selectedTextStyle,
-                            dividerColor = dividerColor,
-                            itemPadding = itemPadding,
-                            fadingEdgeGradient = fadingEdgeGradient,
-                            horizontalAlignment = horizontalAlignment,
-                            itemTextAlignment = verticalAlignment,
-                            dividerThickness = dividerThickness,
-                            dividerShape = dividerShape
-                        )
-
-                        Spacer(modifier = Modifier.width(spacingBetweenPickers))
-
-                        Picker(
-                            state = minutePickerState,
-                            items = minuteItems,
-                            startIndex = minuteStartIndex,
-                            visibleItemsCount = visibleItemsCount,
-                            modifier = Modifier.width(pickerWidth),
-                            textStyle = textStyle,
-                            selectedTextStyle = selectedTextStyle,
-                            textModifier = Modifier.padding(itemPadding),
-                            dividerColor = dividerColor,
-                            itemPadding = itemPadding,
-                            fadingEdgeGradient = fadingEdgeGradient,
-                            horizontalAlignment = horizontalAlignment,
-                            itemTextAlignment = verticalAlignment,
-                            dividerThickness = dividerThickness,
-                            dividerShape = dividerShape,
-                        )
-                    }
-                }
             }
         }
     }

--- a/picker/src/main/java/com/kez/picker/time/TimePickerDialog.kt
+++ b/picker/src/main/java/com/kez/picker/time/TimePickerDialog.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -14,10 +16,13 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -62,7 +67,7 @@ fun TimePickerDialog(
     ),
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    dividerThickness: Dp = 2.dp,
+    dividerThickness: Dp = 1.dp,
     dividerShape: Shape = RoundedCornerShape(10.dp),
     spacingBetweenPickers: Dp = 20.dp,
     pickerWidth: Dp = 80.dp,
@@ -74,9 +79,29 @@ fun TimePickerDialog(
         properties = properties
     ) {
         Surface(
-            modifier = modifier
+            modifier = modifier.clip(
+                shape = RoundedCornerShape(10.dp)
+            )
         ) {
             Column {
+                Text(
+                    text = "Time Picker",
+                    style = TextStyle(
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.SemiBold
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, top = 16.dp),
+                    textAlign = TextAlign.Start
+                )
+
+                HorizontalDivider(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                )
+
                 TimePicker(
                     modifier = Modifier.wrapContentSize(),
                     minutePickerState = minutePickerState,
@@ -100,10 +125,16 @@ fun TimePickerDialog(
                     spacingBetweenPickers = spacingBetweenPickers,
                     pickerWidth = pickerWidth
                 )
+                HorizontalDivider(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                )
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
+                    horizontalArrangement = Arrangement.End,
                 ) {
                     TextButton(
                         modifier = Modifier,

--- a/picker/src/main/java/com/kez/picker/time/TimePickerDialog.kt
+++ b/picker/src/main/java/com/kez/picker/time/TimePickerDialog.kt
@@ -1,0 +1,138 @@
+package com.kez.picker.time
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.kez.picker.PickerState
+import com.kez.picker.util.HOUR12_RANGE
+import com.kez.picker.util.HOUR24_RANGE
+import com.kez.picker.util.MINUTE_RANGE
+import com.kez.picker.util.TimeFormat
+import com.kez.picker.util.TimePeriod
+import com.kez.picker.util.calculateTime
+import com.kez.picker.util.currentDateTime
+import com.kez.picker.util.currentHour
+import com.kez.picker.util.currentMinute
+import kotlinx.datetime.LocalDateTime
+
+@Composable
+fun TimePickerDialog(
+    modifier: Modifier = Modifier,
+    properties: DialogProperties,
+    minutePickerState: PickerState<Int> = PickerState(currentMinute),
+    hourPickerState: PickerState<Int> = PickerState(currentHour),
+    periodPickerState: PickerState<TimePeriod> = PickerState(TimePeriod.AM),
+    timeFormat: TimeFormat = TimeFormat.HOUR_24,
+    startTime: LocalDateTime = currentDateTime,
+    minuteItems: List<Int> = MINUTE_RANGE,
+    hourItems: List<Int> = when (timeFormat) {
+        TimeFormat.HOUR_12 -> HOUR12_RANGE
+        TimeFormat.HOUR_24 -> HOUR24_RANGE
+    },
+    periodItems: List<TimePeriod> = TimePeriod.entries,
+    visibleItemsCount: Int = 3,
+    itemPadding: PaddingValues = PaddingValues(8.dp),
+    textStyle: TextStyle = TextStyle(fontSize = 16.sp),
+    selectedTextStyle: TextStyle = TextStyle(fontSize = 22.sp),
+    dividerColor: Color = LocalContentColor.current,
+    fadingEdgeGradient: Brush = Brush.verticalGradient(
+        0f to Color.Transparent,
+        0.5f to Color.Black,
+        1f to Color.Transparent
+    ),
+    horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+    verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
+    dividerThickness: Dp = 2.dp,
+    dividerShape: Shape = RoundedCornerShape(10.dp),
+    spacingBetweenPickers: Dp = 20.dp,
+    pickerWidth: Dp = 80.dp,
+    onDismissRequest: () -> Unit,
+    onDoneClickListener: (LocalDateTime) -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = properties
+    ) {
+        Surface(
+            modifier = modifier
+        ) {
+            Column {
+                TimePicker(
+                    modifier = Modifier.wrapContentSize(),
+                    minutePickerState = minutePickerState,
+                    hourPickerState = hourPickerState,
+                    periodPickerState = periodPickerState,
+                    timeFormat = timeFormat,
+                    startTime = startTime,
+                    minuteItems = minuteItems,
+                    hourItems = hourItems,
+                    periodItems = periodItems,
+                    visibleItemsCount = visibleItemsCount,
+                    itemPadding = itemPadding,
+                    textStyle = textStyle,
+                    selectedTextStyle = selectedTextStyle,
+                    dividerColor = dividerColor,
+                    fadingEdgeGradient = fadingEdgeGradient,
+                    horizontalAlignment = horizontalAlignment,
+                    verticalAlignment = verticalAlignment,
+                    dividerThickness = dividerThickness,
+                    dividerShape = dividerShape,
+                    spacingBetweenPickers = spacingBetweenPickers,
+                    pickerWidth = pickerWidth
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    TextButton(
+                        modifier = Modifier,
+                        onClick = onDismissRequest,
+                    ) {
+                        Text("Cancel")
+                    }
+
+                    TextButton(
+                        modifier = Modifier,
+                        onClick = {
+                            val hour = hourPickerState.selectedItem
+                            val minute = minutePickerState.selectedItem
+                            val period = periodPickerState.selectedItem
+
+                            onDoneClickListener(
+                                calculateTime(
+                                    hour = hour,
+                                    minute = minute,
+                                    period = period,
+                                    timeFormat = timeFormat,
+                                )
+                            )
+                        },
+                    ) {
+                        Text("Done")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/picker/src/main/java/com/kez/picker/util/TimeCalculation.kt
+++ b/picker/src/main/java/com/kez/picker/util/TimeCalculation.kt
@@ -1,0 +1,30 @@
+package com.kez.picker.util
+
+import kotlinx.datetime.LocalDateTime
+
+fun calculateTime(
+    hour: Int,
+    minute: Int,
+    timeFormat: TimeFormat,
+    period: TimePeriod? = null,
+): LocalDateTime {
+    val adjustHour = when (timeFormat) {
+        TimeFormat.HOUR_12 -> {
+            when (period) {
+                TimePeriod.AM -> if (hour == 12) 0 else hour
+                TimePeriod.PM -> if (hour == 12) 12 else hour + 12
+                null -> hour
+            }
+        }
+
+        TimeFormat.HOUR_24 -> hour
+    }
+
+    return LocalDateTime(
+        year = currentYear,
+        monthNumber = currentMonth,
+        dayOfMonth = currentDate.dayOfMonth,
+        hour = adjustHour.coerceIn(0, 23),
+        minute = minute.coerceIn(0, 59)
+    )
+}

--- a/picker/src/main/java/com/kez/picker/util/TimeUtil.kt
+++ b/picker/src/main/java/com/kez/picker/util/TimeUtil.kt
@@ -4,12 +4,12 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
-internal val YEAR_RANGE = (1000..9999).map { it.toString() }
-internal val MONTH_RANGE = (1..12).map { it.toString() }
+internal val YEAR_RANGE = (1000..9999).toList()
+internal val MONTH_RANGE = (1..12).toList()
 
-internal val HOUR24_RANGE = (0..23).map { it.toString() }
-internal val HOUR12_RANGE = (1..12).map { it.toString() }
-internal val MINUTE_RANGE = (0..59).map { it.toString() }
+internal val HOUR24_RANGE = (0..23).toList()
+internal val HOUR12_RANGE = (1..12).toList()
+internal val MINUTE_RANGE = (0..59).toList()
 
 internal val currentDateTime = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
 
@@ -21,4 +21,8 @@ internal val currentHour = currentDateTime.hour
 
 enum class TimeFormat {
     HOUR_12, HOUR_24
+}
+
+enum class TimePeriod {
+    AM, PM
 }


### PR DESCRIPTION
## PR 설명
### 스크린 샷
![KakaoTalk_Image_2024-11-15-13-57-03](https://github.com/user-attachments/assets/90cc3bbb-6e28-40e9-8480-4924b362d7c6)


### 변경 사항

1. **TimePickerDialog 구현**: `TimePickerDialog`는 사용자에게 시간 선택 UI를 제공하며, 12시간 또는 24시간 형식을 지원합니다. 사용자는 시간, 분, AM/PM(12시간 형식일 경우)을 선택할 수 있으며, 선택한 시간은 `LocalDateTime` 형식으로 반환됩니다.
   
2. **TimePicker 컴포넌트 개선**:
   - `Picker` 컴포넌트가 이제 제네릭 타입을 지원하여 `String`, `Int`, 또는 `TimePeriod` 등 다양한 데이터 타입을 처리할 수 있게 되었습니다.
   - `PickerState`는 선택된 아이템을 상태로 유지하며, 이 또한 제네릭 타입으로 변경되었습니다.
   
3. **시간 계산 로직 추가 (`TimeCalculation.kt`)**:
   - `calculateTime` 함수는 12시간 및 24시간 형식 모두를 지원하며, AM/PM이 적용된 시간을 정확하게 계산하여 `LocalDateTime` 객체로 반환합니다.
   - 12시간 형식일 경우 `TimePeriod`(AM/PM)를 고려하여 시간을 조정하고, 24시간 형식일 경우 단순히 시간을 반환합니다.

4. **UI 관련 개선**:
   - `YearMonthPicker`와 `TimePicker`의 항목 타입을 `String`에서 `Int`로 변경하여 더 직관적인 데이터 처리를 지원합니다.
   - `Picker`의 UI 요소인 `visibleItemsCount`, `dividerColor`, `spacingBetweenPickers` 등 다양한 속성이 추가되어 사용자 경험을 더욱 개선하였습니다.

### 주요 변경 파일
1. `MainActivity.kt`: 시간 선택 UI를 표시하는 `TimePickerDialog` 호출 로직이 추가되었습니다.
2. `Picker.kt`: `Picker`가 제네릭 타입을 지원하도록 수정되었으며, 스크롤 및 항목 선택 관련 로직이 개선되었습니다.
3. `PickerState.kt`: `PickerState` 클래스가 제네릭 타입을 지원하도록 수정되었습니다.
4. `TimePickerDialog.kt`: `TimePickerDialog` 컴포넌트가 추가되었습니다. 이 컴포넌트는 시간 선택을 위한 UI를 제공합니다.
5. `TimeCalculation.kt`: 시간 계산 로직이 포함된 유틸리티 파일이 추가되었습니다.
6. `TimeUtil.kt`: 시간 관련 유틸리티 값들이 개선되었습니다. `HOUR12_RANGE`, `HOUR24_RANGE`, `MINUTE_RANGE` 등의 값이 `String`에서 `Int`로 변경되었습니다.

### 변경 이유
- **제네릭 타입 지원**: `Picker`와 `PickerState`가 제네릭 타입을 지원함으로써 다양한 데이터 타입을 처리할 수 있게 되었으며, 코드의 재사용성을 높였습니다.
- **유연한 시간 선택**: 12시간 및 24시간 형식을 모두 지원하는 시간 선택 UI가 필요하였으며, 이를 통해 다양한 사용 사례를 처리할 수 있게 되었습니다.
- **UI 개선**: 사용자 경험을 개선하기 위해 `Picker` 컴포넌트의 여러 속성을 조정할 수 있도록 기능을 추가하였습니다.

### 유의할 점
- `Picker` 컴포넌트는 이제 제네릭 타입을 지원하게 되었으므로, 각 아이템을 화면에 표시할 때 `toString()` 메서드를 사용하여 텍스트로 변환하여 보여줍니다. 따라서 `Picker`에 전달되는 객체가 적절한 문자열 표현을 제공하도록 `toString()` 메서드를 적절하게 오버라이드하는 것이 중요합니다. 기본 `toString()` 메서드가 원하는 형식으로 데이터를 표시하지 않을 수 있으므로, 사용자 정의 타입을 사용하는 경우 이에 유의해야 합니다.


### 테스트
- 12시간 및 24시간 형식에서의 시간 선택이 정상적으로 작동하는지 테스트되었습니다.
- 다양한 데이터 타입을 사용하는 `Picker`가 정상적으로 항목을 표시하고 선택할 수 있는지 확인하였습니다.
