### PR TITLE
Fix TimePicker KDoc

### DIFF
--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -35,7 +35,7 @@ import com.kez.picker.util.currentMinute
 import kotlinx.datetime.LocalDateTime
 
 /**
- * A time picker component that allows the user to select hours and minutes.
+ * A time picker component that allows the user to select hours, minutes, and—when using the 12-hour format—the AM/PM period.
  * 
  * @param modifier The modifier to be applied to the component.
  * @param minutePickerState The state for the minute picker.


### PR DESCRIPTION
## Summary
- update `TimePicker` description to mention AM/PM period handling in 12-hour mode

## Testing
- `./gradlew build` *(fails: cannot find a Java 17 installation)*

------
https://chatgpt.com/codex/tasks/task_e_68596c26a3b883268a7728f06f39228f