### PR TITLE
Add tests for calculateTime

### DIFF
--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/util/TimeCalculationTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/util/TimeCalculationTest.kt
@@ -2,9 +2,18 @@ package com.kez.picker.util
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toLocalDateTime
 
 class TimeCalculationTest {
+    // 현재 날짜를 고정하여 가져온다
+    private val testDate: LocalDate = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    private val currentYear: Int = testDate.year
+    private val currentMonth: Int = testDate.monthNumber
+    private val currentDate: LocalDate = testDate
 
     // 24시간 형식에서 23:45 입력 시 동일한 시간이 반환되는지 확인
     @Test


### PR DESCRIPTION
## Summary
- add a `commonTest` source set
- add unit tests verifying `calculateTime` for 12h and 24h cases
- document each test in `TimeCalculationTest`

## Testing
- `./gradlew :datetimepicker:desktopTest`

------
https://chatgpt.com/codex/tasks/task_e_68596c365cd88326a55c9cc0ca0ceda8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added unit tests to verify time calculation functionality for various input formats, including 24-hour and 12-hour (AM/PM), as well as edge cases like midnight and noon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->