### PR TITLE
feat: Add clickable functionality to Picker items and set visibleItem…

### DIFF
--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -212,6 +212,7 @@ fun <T> Picker(
                         .height(itemHeight)
                         .fillMaxWidth()
                         .clickable(
+                            enabled = getItem(index) != null,
                             role = Role.Button,
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() },

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -1,7 +1,9 @@
 package com.kez.picker
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,10 +22,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -42,6 +46,7 @@ import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
 import kotlin.math.abs
 
 /**
@@ -93,6 +98,7 @@ fun <T> Picker(
 ) {
     val density = LocalDensity.current
     val visibleItemsMiddle = remember { visibleItemsCount / 2 }
+    val scope = rememberCoroutineScope()
 
     val adjustedItems = if (!isInfinity) {
         listOf(null) + items + listOf(null)
@@ -205,6 +211,17 @@ fun <T> Picker(
                     modifier = Modifier
                         .height(itemHeight)
                         .fillMaxWidth()
+                        .clickable(
+                            role = Role.Button,
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() },
+                            onClick = {
+                                scope.launch {
+                                    val targetIndex = index - visibleItemsMiddle
+                                    listState.animateScrollToItem(targetIndex)
+                                }
+                            }
+                        )
                         .padding(itemPadding),
                     contentAlignment = Alignment.Center
                 ) {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -216,9 +216,13 @@ fun <T> Picker(
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() },
                             onClick = {
-                                scope.launch {
-                                    val targetIndex = index - visibleItemsMiddle
-                                    listState.animateScrollToItem(targetIndex)
+                                val currentCenterIndex = listState.firstVisibleItemIndex + visibleItemsMiddle
+                                if (index != currentCenterIndex) {
+                                    scope.launch {
+                                        val targetIndex = (index - visibleItemsMiddle)
+                                            .coerceIn(0, listScrollCount - 1)
+                                        listState.animateScrollToItem(targetIndex)
+                                    }
                                 }
                             }
                         )

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -34,8 +34,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.kez.picker.rememberPickerState
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
@@ -170,6 +168,7 @@ internal fun TimePickerSampleScreen(
                 TimePicker(
                     hourPickerState = hour24State,
                     minutePickerState = minuteState,
+                    visibleItemsCount = 5,
                     timeFormat = TimeFormat.HOUR_24
                 )
             }


### PR DESCRIPTION
close #18 

This pull request enhances the `Picker` component in the `datetimepicker` module by making picker items clickable, allowing users to jump directly to a selected item. It also updates the sample screen to display more visible items in the time picker. The most important changes are grouped below:

**Picker component improvements:**

* Added a `Modifier.clickable` to each picker item in `Picker.kt`, enabling users to click on an item to animate-scroll it into the selected position. This uses a coroutine scope to perform the scroll and improves accessibility by setting the role to `Button`.
* Introduced `rememberCoroutineScope` to manage the coroutine for animated scrolling when an item is clicked.
* Added necessary imports for click handling, interaction source, coroutine launching, and accessibility roles. [[1]](diffhunk://#diff-646ddbc5763a205e7fb192a318383a12c4e4796c49ab07484d71ac0bda9e5917R4-R6) [[2]](diffhunk://#diff-646ddbc5763a205e7fb192a318383a12c4e4796c49ab07484d71ac0bda9e5917R25-R30) [[3]](diffhunk://#diff-646ddbc5763a205e7fb192a318383a12c4e4796c49ab07484d71ac0bda9e5917R49)

**Sample screen update:**

* Updated the `TimePickerSampleScreen` to set `visibleItemsCount = 5`, making the picker show five items at a time for improved usability and demonstration.

**Code cleanup:**

* Removed unused navigation imports from the sample screen for tidiness.…sCount in TimePicker

### ScreenShot

https://github.com/user-attachments/assets/04bf1a77-8278-4360-99aa-eb9f7f88f51a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Picker items are now interactive and clickable, letting users tap items to navigate directly with smooth animated scrolling.
  * Enhanced accessibility with button role designation and visual feedback during interactions.
  * Sample 24-hour TimePicker now displays more items at once (visible items increased) for improved scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->