### PR TITLE
[Feature]: Improvements to the picker state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ import com.kez.picker.util.currentMinute
 fun TimePicker24hExample() {
     val state = rememberTimePickerState(
         initialHour = currentHour,
-        initialMinute = currentMinute
+        initialMinute = currentMinute,
+        timeFormat = TimeFormat.HOUR_24
     )
 
     TimePicker(
-        state = state,
-        timeFormat = TimeFormat.HOUR_24
+        state = state
     )
 }
 ```
@@ -79,18 +79,15 @@ import com.kez.picker.util.currentMinute
 
 @Composable
 fun TimePicker12hExample() {
-    val currentPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
-    val currentHour12 = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour
-
+    // Handling of 12-hour format conversion is now done internally by the state
     val state = rememberTimePickerState(
-        initialHour = currentHour12,
+        initialHour = currentHour,
         initialMinute = currentMinute,
-        initialPeriod = currentPeriod
+        timeFormat = TimeFormat.HOUR_12
     )
 
     TimePicker(
-        state = state,
-        timeFormat = TimeFormat.HOUR_12
+        state = state
     )
 }
 ```
@@ -160,7 +157,6 @@ fun BottomSheetPickerExample() {
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberTimePickerState()` |
-| `timeFormat` | The format of time to display (`HOUR_12` or `HOUR_24`). | `HOUR_24` |
 | `startTime` | The initial time to set the picker to. | `currentDateTime` |
 | `visibleItemsCount` | Number of items visible in the list. | `3` |
 | `textStyle` | Style for unselected items. | `16.sp` |

--- a/README_KO.md
+++ b/README_KO.md
@@ -56,12 +56,12 @@ import com.kez.picker.util.currentMinute
 fun TimePicker24hExample() {
     val state = rememberTimePickerState(
         initialHour = currentHour,
-        initialMinute = currentMinute
+        initialMinute = currentMinute,
+        timeFormat = TimeFormat.HOUR_24
     )
 
     TimePicker(
-        state = state,
-        timeFormat = TimeFormat.HOUR_24
+        state = state
     )
 }
 ```
@@ -79,18 +79,15 @@ import com.kez.picker.util.currentMinute
 
 @Composable
 fun TimePicker12hExample() {
-    val currentPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
-    val currentHour12 = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour
-
+    // 12시간 형식 변환은 이제 state 내부에서 처리됩니다.
     val state = rememberTimePickerState(
-        initialHour = currentHour12,
+        initialHour = currentHour,
         initialMinute = currentMinute,
-        initialPeriod = currentPeriod
+        timeFormat = TimeFormat.HOUR_12
     )
 
     TimePicker(
-        state = state,
-        timeFormat = TimeFormat.HOUR_12
+        state = state
     )
 }
 ```
@@ -160,7 +157,6 @@ fun BottomSheetPickerExample() {
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberTimePickerState()` |
-| `timeFormat` | 표시할 시간 형식입니다 (`HOUR_12` 또는 `HOUR_24`). | `HOUR_24` |
 | `startTime` | Picker에 설정될 초기 시간입니다. | `currentDateTime` |
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 | `textStyle` | 선택되지 않은 아이템의 텍스트 스타일입니다. | `16.sp` |

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,24 +1,24 @@
 # Compose DateTimePicker
 
-[![Read in Korean](https://img.shields.io/badge/README-Korean-green)](./README_KO.md)
+[![Read in English](https://img.shields.io/badge/README-English-blue)](./README.md)
 
-A generic, customizable, and multiplatform date and time picker library for Compose Multiplatform.
-It provides consistent UI components across Android, iOS, Desktop (JVM), and Web (Wasm).
+Compose Multiplatform을 위한 범용적이고 커스터마이징 가능한 날짜 및 시간 선택 라이브러리입니다.
+Android, iOS, Desktop (JVM), Web (Wasm) 등 다양한 플랫폼에서 일관된 UI 컴포넌트를 제공합니다.
 
-## Features
+## 주요 기능
 
-*   **Multiplatform Support**: seamless integration for Android, iOS, Desktop (JVM), and Web (Wasm).
-*   **TimePicker**: Supports both 12-hour (AM/PM) and 24-hour formats.
-*   **YearMonthPicker**: A dedicated component for selecting years and months.
-*   **Customizable**: Extensible API allowing custom content rendering, styling, and configuration.
-*   **State Management**: simplified state handling with `rememberTimePickerState` and `rememberYearMonthPickerState`.
-*   **Accessibility**: Built with accessibility in mind, supporting screen readers and navigation.
+*   **멀티플랫폼 지원**: Android, iOS, Desktop (JVM), Web (Wasm) 환경을 지원하며 원활한 통합이 가능합니다.
+*   **TimePicker**: 12시간(오전/오후) 및 24시간 형식을 모두 지원합니다.
+*   **YearMonthPicker**: 년도와 월을 선택할 수 있는 전용 컴포넌트를 제공합니다.
+*   **커스터마이징**: 커스텀 아이템 렌더링, 스타일링, 구성 변경이 가능한 유연한 API를 제공합니다.
+*   **상태 관리**: `rememberTimePickerState` 및 `rememberYearMonthPickerState`를 통해 간편하게 상태를 관리할 수 있습니다.
+*   **접근성**: 스크린 리더 및 내비게이션 지원 등 접근성을 고려하여 설계되었습니다.
 
-## Installation
+## 설치 방법
 
-Add the dependency to your version catalog or build file.
+버전 카탈로그 또는 빌드 파일에 의존성을 추가하여 사용할 수 있습니다.
 
-### Version Catalog (libs.versions.toml)
+### 버전 카탈로그 (libs.versions.toml)
 
 ```toml
 [versions]
@@ -36,13 +36,13 @@ dependencies {
 }
 ```
 
-## Usage
+## 사용법
 
 ### TimePicker
 
-Use `TimePicker` for time selection. It supports both 12-hour and 24-hour formats.
+시간 선택을 위해 `TimePicker`를 사용합니다. 12시간 및 24시간 형식을 지원합니다.
 
-#### 1. 24-Hour Format
+#### 1. 24시간 형식
 
 ```kotlin
 import androidx.compose.runtime.Composable
@@ -66,7 +66,7 @@ fun TimePicker24hExample() {
 }
 ```
 
-#### 2. 12-Hour Format (AM/PM)
+#### 2. 12시간 형식 (오전/오후)
 
 ```kotlin
 import androidx.compose.runtime.Composable
@@ -97,7 +97,7 @@ fun TimePicker12hExample() {
 
 ### YearMonthPicker
 
-Use `YearMonthPicker` for selecting a specific month in a year.
+특정 연도와 월을 선택할 때 `YearMonthPicker`를 사용합니다.
 
 ```kotlin
 import androidx.compose.runtime.Composable
@@ -118,9 +118,9 @@ fun YearMonthPickerExample() {
 }
 ```
 
-### BottomSheet Integration
+### BottomSheet 통합
 
-The pickers work seamlessly within a `ModalBottomSheet` or other dialog components.
+Picker 컴포넌트는 `ModalBottomSheet`나 다른 다이얼로그 컴포넌트 내에서도 원활하게 작동합니다.
 
 ```kotlin
 import androidx.compose.material3.*
@@ -138,7 +138,7 @@ fun BottomSheetPickerExample() {
     val scope = rememberCoroutineScope()
 
     Button(onClick = { showBottomSheet = true }) {
-        Text("Select Time")
+        Text("시간 선택")
     }
 
     if (showBottomSheet) {
@@ -147,37 +147,37 @@ fun BottomSheetPickerExample() {
             sheetState = sheetState
         ) {
             TimePicker(state = state)
-            // Add confirmation buttons logic here
+            // 확인 버튼 로직 등 추가 가능
         }
     }
 }
 ```
 
-## API Reference
+## API 레퍼런스
 
 ### TimePicker
 
-| Parameter | Description | Default |
+| 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
-| `state` | The state object to control the picker. | `rememberTimePickerState()` |
-| `timeFormat` | The format of time to display (`HOUR_12` or `HOUR_24`). | `HOUR_24` |
-| `startTime` | The initial time to set the picker to. | `currentDateTime` |
-| `visibleItemsCount` | Number of items visible in the list. | `3` |
-| `textStyle` | Style for unselected items. | `16.sp` |
-| `selectedTextStyle` | Style for selected item. | `22.sp` |
-| `dividerColor` | Color of the selection dividers. | `LocalContentColor.current` |
+| `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberTimePickerState()` |
+| `timeFormat` | 표시할 시간 형식입니다 (`HOUR_12` 또는 `HOUR_24`). | `HOUR_24` |
+| `startTime` | Picker에 설정될 초기 시간입니다. | `currentDateTime` |
+| `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
+| `textStyle` | 선택되지 않은 아이템의 텍스트 스타일입니다. | `16.sp` |
+| `selectedTextStyle` | 선택된 아이템의 텍스트 스타일입니다. | `22.sp` |
+| `dividerColor` | 구분선의 색상입니다. | `LocalContentColor.current` |
 
 ### YearMonthPicker
 
-| Parameter | Description | Default |
+| 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
-| `state` | The state object to control the picker. | `rememberYearMonthPickerState()` |
-| `startLocalDate` | The initial date to set the picker to. | `currentDate` |
-| `yearItems` | List of years available for selection. | `1900..2100` |
-| `monthItems` | List of months available for selection. | `1..12` |
-| `visibleItemsCount` | Number of items visible in the list. | `3` |
+| `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberYearMonthPickerState()` |
+| `startLocalDate` | Picker에 설정될 초기 날짜입니다. | `currentDate` |
+| `yearItems` | 선택 가능한 연도 목록입니다. | `1900..2100` |
+| `monthItems` | 선택 가능한 월 목록입니다. | `1..12` |
+| `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 
-## License
+## 라이선스
 
 ```
 Copyright 2024 KEZ Lab

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -75,8 +75,8 @@ import kotlin.math.abs
 fun <T> Picker(
     items: List<T>,
     state: PickerState<T>,
-    startIndex: Int = 0,
     modifier: Modifier = Modifier,
+    startIndex: Int = 0,
     visibleItemsCount: Int = 3,
     textStyle: TextStyle = LocalTextStyle.current,
     selectedTextStyle: TextStyle = LocalTextStyle.current,
@@ -94,7 +94,8 @@ fun <T> Picker(
     dividerThickness: Dp = 1.dp,
     dividerShape: Shape = RoundedCornerShape(10.dp),
     isDividerVisible: Boolean = true,
-    isInfinity: Boolean = true
+    isInfinity: Boolean = true,
+    content: @Composable ((T) -> Unit)? = null
 ) {
     val density = LocalDensity.current
     val visibleItemsMiddle = remember { visibleItemsCount / 2 }
@@ -205,14 +206,14 @@ fun <T> Picker(
                     }
                 }
 
-                val currentItemText = getItem(index)?.toString().orEmpty()
-
+                val item = getItem(index)
+                
                 Box(
                     modifier = Modifier
                         .height(itemHeight)
                         .fillMaxWidth()
                         .clickable(
-                            enabled = getItem(index) != null,
+                            enabled = item != null,
                             role = Role.Button,
                             indication = null,
                             interactionSource = remember { MutableInteractionSource() },
@@ -230,30 +231,35 @@ fun <T> Picker(
                         .padding(itemPadding),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(
-                        text = currentItemText,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        style = textStyle.copy(
-                            fontSize = lerp(
-                                selectedTextStyle.fontSize,
-                                textStyle.fontSize,
-                                fraction
-                            ),
-                            color = lerp(
-                                selectedTextStyle.color,
-                                textStyle.color,
-                                fraction
-                            ),
-                        ),
-                        textAlign = TextAlign.Center
-                    )
+                    if (item != null) {
+                        if (content != null) {
+                            content(item)
+                        } else {
+                            Text(
+                                text = item.toString(),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                style = textStyle.copy(
+                                    fontSize = lerp(
+                                        selectedTextStyle.fontSize,
+                                        textStyle.fontSize,
+                                        fraction
+                                    ),
+                                    color = lerp(
+                                        selectedTextStyle.color,
+                                        textStyle.color,
+                                        fraction
+                                    ),
+                                ),
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    }
                 }
             }
         }
     }
 }
-
 /**
  * Apply a fading edge effect to a modifier.
  *

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -1,14 +1,21 @@
 package com.kez.picker
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.kez.picker.util.TimePeriod
+import com.kez.picker.util.currentDate
+import com.kez.picker.util.currentHour
+import com.kez.picker.util.currentMinute
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
 
 /**
  * Remember a [PickerState] with the given initial item.
- * 
+ *
  * @param initialItem The initial selected item.
  * @return A [PickerState] with the given initial item.
  */
@@ -20,6 +27,7 @@ fun <T> rememberPickerState(initialItem: T) = remember { PickerState(initialItem
  *
  * @param initialItem The initial selected item.
  */
+@Stable
 class PickerState<T>(
     initialItem: T
 ) {
@@ -27,4 +35,60 @@ class PickerState<T>(
      * The currently selected item.
      */
     var selectedItem by mutableStateOf(initialItem)
-} 
+}
+
+@Composable
+fun rememberYearMonthPickerState(
+    initialYear: Int = currentDate.year,
+    initialMonth: Int = currentDate.month.number
+): YearMonthPickerState {
+    return remember(initialYear, initialMonth) {
+        YearMonthPickerState(initialYear, initialMonth)
+    }
+}
+
+@Stable
+class YearMonthPickerState(
+    initialYear: Int,
+    initialMonth: Int
+) {
+    val yearState = PickerState(initialYear)
+    val monthState = PickerState(initialMonth)
+
+    val selectedYear: Int
+        get() = yearState.selectedItem
+
+    val selectedMonth: Int
+        get() = monthState.selectedItem
+}
+
+@Composable
+fun rememberTimePickerState(
+    initialHour: Int = currentHour,
+    initialMinute: Int = currentMinute,
+    initialPeriod: TimePeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+): TimePickerState {
+    return remember(initialHour, initialMinute, initialPeriod) {
+        TimePickerState(initialHour, initialMinute, initialPeriod)
+    }
+}
+
+@Stable
+class TimePickerState(
+    initialHour: Int,
+    initialMinute: Int,
+    initialPeriod: TimePeriod
+) {
+    val hourState = PickerState(initialHour)
+    val minuteState = PickerState(initialMinute)
+    val periodState = PickerState(initialPeriod)
+
+    val selectedHour: Int
+        get() = hourState.selectedItem
+
+    val selectedMinute: Int
+        get() = minuteState.selectedItem
+
+    val selectedPeriod: TimePeriod
+        get() = periodState.selectedItem
+}

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -10,7 +10,6 @@ import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDate
 import com.kez.picker.util.currentHour
 import com.kez.picker.util.currentMinute
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.number
 
 /**

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -36,6 +36,13 @@ class PickerState<T>(
     var selectedItem by mutableStateOf(initialItem)
 }
 
+/**
+ * Creates and remembers a [YearMonthPickerState].
+ *
+ * @param initialYear The initial year to be selected. Defaults to the current year.
+ * @param initialMonth The initial month to be selected. Defaults to the current month.
+ * @return A [YearMonthPickerState] initialized with the given year and month.
+ */
 @Composable
 fun rememberYearMonthPickerState(
     initialYear: Int = currentDate.year,
@@ -46,6 +53,14 @@ fun rememberYearMonthPickerState(
     }
 }
 
+/**
+ * State holder for the [YearMonthPicker].
+ *
+ * Manages the state of the year and month pickers.
+ *
+ * @param initialYear The initial year to be selected.
+ * @param initialMonth The initial month to be selected.
+ */
 @Stable
 class YearMonthPickerState(
     initialYear: Int,
@@ -61,6 +76,14 @@ class YearMonthPickerState(
         get() = monthState.selectedItem
 }
 
+/**
+ * Creates and remembers a [TimePickerState].
+ *
+ * @param initialHour The initial hour to be selected. Defaults to the current hour.
+ * @param initialMinute The initial minute to be selected. Defaults to the current minute.
+ * @param initialPeriod The initial period (AM/PM) to be selected. Defaults to the current period based on the current hour.
+ * @return A [TimePickerState] initialized with the given time values.
+ */
 @Composable
 fun rememberTimePickerState(
     initialHour: Int = currentHour,
@@ -72,6 +95,15 @@ fun rememberTimePickerState(
     }
 }
 
+/**
+ * State holder for the [TimePicker].
+ *
+ * Manages the state of the hour, minute, and period (AM/PM) pickers.
+ *
+ * @param initialHour The initial hour to be selected.
+ * @param initialMinute The initial minute to be selected.
+ * @param initialPeriod The initial period (AM/PM) to be selected.
+ */
 @Stable
 class TimePickerState(
     initialHour: Int,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDate
 import com.kez.picker.util.currentHour
@@ -54,7 +55,7 @@ fun rememberYearMonthPickerState(
 }
 
 /**
- * State holder for the [YearMonthPicker].
+ * State holder for the [com.kez.picker.date.YearMonthPicker].
  *
  * Manages the state of the year and month pickers.
  *
@@ -80,18 +81,34 @@ class YearMonthPickerState(
  * Creates and remembers a [TimePickerState].
  *
  * @param initialHour The initial hour to be selected. Defaults to the current hour.
+ * If [timeFormat] is [TimeFormat.HOUR_12], this value is automatically adjusted to the 12-hour format (1-12).
  * @param initialMinute The initial minute to be selected. Defaults to the current minute.
  * @param initialPeriod The initial period (AM/PM) to be selected. Defaults to the current period based on the current hour.
+ * @param timeFormat The time format (12-hour or 24-hour). Defaults to [TimeFormat.HOUR_24].
  * @return A [TimePickerState] initialized with the given time values.
  */
 @Composable
 fun rememberTimePickerState(
     initialHour: Int = currentHour,
     initialMinute: Int = currentMinute,
-    initialPeriod: TimePeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+    initialPeriod: TimePeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+    timeFormat: TimeFormat = TimeFormat.HOUR_24
 ): TimePickerState {
-    return remember(initialHour, initialMinute, initialPeriod) {
-        TimePickerState(initialHour, initialMinute, initialPeriod)
+    val adjustedHour = remember(initialHour, timeFormat) {
+        if (timeFormat == TimeFormat.HOUR_12) {
+            val h = initialHour % 12
+            if (h == 0) 12 else h
+        } else {
+            initialHour
+        }
+    }
+    return remember(adjustedHour, initialMinute, initialPeriod) {
+        TimePickerState(
+            initialHour = adjustedHour,
+            initialMinute = initialMinute,
+            initialPeriod = initialPeriod,
+            timeFormat = timeFormat,
+        )
     }
 }
 
@@ -103,12 +120,14 @@ fun rememberTimePickerState(
  * @param initialHour The initial hour to be selected.
  * @param initialMinute The initial minute to be selected.
  * @param initialPeriod The initial period (AM/PM) to be selected.
+ * @param timeFormat The time format (12-hour or 24-hour).
  */
 @Stable
 class TimePickerState(
     initialHour: Int,
     initialMinute: Int,
-    initialPeriod: TimePeriod
+    initialPeriod: TimePeriod,
+    val timeFormat: TimeFormat
 ) {
     val hourState = PickerState(initialHour)
     val minuteState = PickerState(initialMinute)

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -91,7 +91,7 @@ class YearMonthPickerState(
 fun rememberTimePickerState(
     initialHour: Int = currentHour,
     initialMinute: Int = currentMinute,
-    initialPeriod: TimePeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+    initialPeriod: TimePeriod = if (initialHour >= 12) TimePeriod.PM else TimePeriod.AM,
     timeFormat: TimeFormat = TimeFormat.HOUR_24
 ): TimePickerState {
     val adjustedHour = remember(initialHour, timeFormat) {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -102,7 +102,7 @@ fun rememberTimePickerState(
             initialHour
         }
     }
-    return remember(adjustedHour, initialMinute, initialPeriod) {
+    return remember(adjustedHour, initialMinute, initialPeriod, timeFormat) {
         TimePickerState(
             initialHour = adjustedHour,
             initialMinute = initialMinute,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kez.picker.Picker
-import com.kez.picker.PickerState
-import com.kez.picker.rememberPickerState
+import com.kez.picker.YearMonthPickerState
+import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.util.MONTH_RANGE
 import com.kez.picker.util.YEAR_RANGE
 import com.kez.picker.util.currentDate
@@ -58,8 +58,7 @@ import kotlinx.datetime.number
 fun YearMonthPicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
-    yearPickerState: PickerState<Int> = rememberPickerState(currentDate.year),
-    monthPickerState: PickerState<Int> = rememberPickerState(currentDate.month.number),
+    state: YearMonthPickerState = rememberYearMonthPickerState(),
     startLocalDate: LocalDate = currentDate,
     yearItems: List<Int> = YEAR_RANGE,
     monthItems: List<Int> = MONTH_RANGE,
@@ -104,7 +103,7 @@ fun YearMonthPicker(
                 ),
             ) {
                 Picker(
-                    state = yearPickerState,
+                    state = state.yearState,
                     modifier = pickerModifier.weight(1f),
                     items = yearItems,
                     startIndex = yearStartIndex,
@@ -123,7 +122,7 @@ fun YearMonthPicker(
                     isDividerVisible = isDividerVisible,
                 )
                 Picker(
-                    state = monthPickerState,
+                    state = state.monthState,
                     items = monthItems,
                     startIndex = monthStartIndex,
                     visibleItemsCount = visibleItemsCount,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -23,15 +23,14 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kez.picker.Picker
-import com.kez.picker.PickerState
+import com.kez.picker.TimePickerState
+import com.kez.picker.rememberTimePickerState
 import com.kez.picker.util.HOUR12_RANGE
 import com.kez.picker.util.HOUR24_RANGE
 import com.kez.picker.util.MINUTE_RANGE
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDateTime
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
 import kotlinx.datetime.LocalDateTime
 
 /**
@@ -66,9 +65,7 @@ import kotlinx.datetime.LocalDateTime
 fun TimePicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
-    minutePickerState: PickerState<Int> = remember { PickerState(currentMinute) },
-    hourPickerState: PickerState<Int> = remember { PickerState(currentHour) },
-    periodPickerState: PickerState<TimePeriod> = remember { PickerState(TimePeriod.AM) },
+    state: TimePickerState = rememberTimePickerState(),
     timeFormat: TimeFormat = TimeFormat.HOUR_24,
     startTime: LocalDateTime = currentDateTime,
     minuteItems: List<Int> = MINUTE_RANGE,
@@ -131,7 +128,7 @@ fun TimePicker(
             ) {
                 if (timeFormat == TimeFormat.HOUR_12) {
                     Picker(
-                        state = periodPickerState,
+                        state = state.periodState,
                         items = periodItems,
                         visibleItemsCount = visibleItemsCount,
                         modifier = pickerModifier.weight(1f),
@@ -153,7 +150,7 @@ fun TimePicker(
                     Spacer(modifier = Modifier.width(spacingBetweenPickers))
                 }
                 Picker(
-                    state = hourPickerState,
+                    state = state.hourState,
                     modifier = pickerModifier.weight(1f),
                     items = hourItems,
                     startIndex = hourStartIndex,
@@ -173,7 +170,7 @@ fun TimePicker(
                 )
                 Spacer(modifier = Modifier.width(spacingBetweenPickers))
                 Picker(
-                    state = minutePickerState,
+                    state = state.minuteState,
                     items = minuteItems,
                     startIndex = minuteStartIndex,
                     visibleItemsCount = visibleItemsCount,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -38,10 +38,7 @@ import kotlinx.datetime.LocalDateTime
  *
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
- * @param minutePickerState The state for the minute picker.
- * @param hourPickerState The state for the hour picker.
- * @param periodPickerState The state for the AM/PM period picker.
- * @param timeFormat The time format (12-hour or 24-hour).
+ * @param state The state object to control the picker.
  * @param startTime The initial time to display.
  * @param minuteItems The list of minute values to display.
  * @param hourItems The list of hour values to display.
@@ -66,10 +63,9 @@ fun TimePicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
     state: TimePickerState = rememberTimePickerState(),
-    timeFormat: TimeFormat = TimeFormat.HOUR_24,
     startTime: LocalDateTime = currentDateTime,
     minuteItems: List<Int> = MINUTE_RANGE,
-    hourItems: List<Int> = when (timeFormat) {
+    hourItems: List<Int> = when (state.timeFormat) {
         TimeFormat.HOUR_12 -> HOUR12_RANGE
         TimeFormat.HOUR_24 -> HOUR24_RANGE
     },
@@ -105,7 +101,7 @@ fun TimePicker(
             }
 
             val hourStartIndex = remember {
-                val startHour = when (timeFormat) {
+                val startHour = when (state.timeFormat) {
                     TimeFormat.HOUR_12 -> {
                         val hour = startTime.hour % 12
                         if (hour == 0) 12 else hour
@@ -126,7 +122,7 @@ fun TimePicker(
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (timeFormat == TimeFormat.HOUR_12) {
+                if (state.timeFormat == TimeFormat.HOUR_12) {
                     Picker(
                         state = state.periodState,
                         items = periodItems,
@@ -197,7 +193,7 @@ fun TimePicker(
 @Composable
 fun TimePickerPreview24Hour() {
     TimePicker(
-        timeFormat = TimeFormat.HOUR_24
+        state = rememberTimePickerState(timeFormat = TimeFormat.HOUR_24)
     )
 }
 
@@ -205,7 +201,7 @@ fun TimePickerPreview24Hour() {
 @Composable
 fun TimePickerPreview12Hour() {
     TimePicker(
-        timeFormat = TimeFormat.HOUR_12
+        state = rememberTimePickerState(timeFormat = TimeFormat.HOUR_12)
     )
 }
 
@@ -213,7 +209,7 @@ fun TimePickerPreview12Hour() {
 @Composable
 fun TimePickerNoDividerPreview() {
     TimePicker(
-        timeFormat = TimeFormat.HOUR_24,
+        state = rememberTimePickerState(timeFormat = TimeFormat.HOUR_24),
         isDividerVisible = false
     )
 }
@@ -222,7 +218,7 @@ fun TimePickerNoDividerPreview() {
 @Composable
 fun TimePickerCustomColorsPreview() {
     TimePicker(
-        timeFormat = TimeFormat.HOUR_12,
+        state = rememberTimePickerState(timeFormat = TimeFormat.HOUR_12),
         textStyle = TextStyle(fontSize = 16.sp, color = Color.Gray),
         selectedTextStyle = TextStyle(fontSize = 22.sp, color = Color(0xFF6200EE)),
         dividerColor = Color(0xFF6200EE)
@@ -233,7 +229,7 @@ fun TimePickerCustomColorsPreview() {
 @Composable
 fun TimePickerLargeTextPreview() {
     TimePicker(
-        timeFormat = TimeFormat.HOUR_24,
+        state = rememberTimePickerState(timeFormat = TimeFormat.HOUR_24),
         textStyle = TextStyle(fontSize = 20.sp),
         selectedTextStyle = TextStyle(fontSize = 28.sp),
         visibleItemsCount = 5

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
@@ -31,7 +31,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kez.picker.date.YearMonthPicker
-import com.kez.picker.rememberPickerState
+import com.kez.picker.rememberTimePickerState
+import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.formatTime12
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.time.TimePicker
@@ -49,19 +50,22 @@ import kotlinx.datetime.number
 internal fun BackgroundStylePickerScreen(
     onBackPressed: () -> Unit = {},
 ) {
-    val yearState = rememberPickerState(currentDate.year)
-    val monthState = rememberPickerState(currentDate.month.number)
-    val hourState =
-        rememberPickerState(if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour)
-    val minuteState = rememberPickerState(currentMinute)
-    val periodState = rememberPickerState(if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM)
+    val yearMonthState = rememberYearMonthPickerState(
+        initialYear = currentDate.year,
+        initialMonth = currentDate.monthNumber
+    )
+    val timeState = rememberTimePickerState(
+        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
+        initialMinute = currentMinute,
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+    )
 
-    val selectedDateText = remember(yearState.selectedItem, monthState.selectedItem) {
-        "${yearState.selectedItem}년 ${getMonthName(monthState.selectedItem)}"
+    val selectedDateText = remember(yearMonthState.selectedYear, yearMonthState.selectedMonth) {
+        "${yearMonthState.selectedYear}년 ${getMonthName(yearMonthState.selectedMonth)}"
     }
     val selectedTimeText =
-        remember(hourState.selectedItem, minuteState.selectedItem, periodState.selectedItem) {
-            formatTime12(hourState.selectedItem, minuteState.selectedItem, periodState.selectedItem)
+        remember(timeState.selectedHour, timeState.selectedMinute, timeState.selectedPeriod) {
+            formatTime12(timeState.selectedHour, timeState.selectedMinute, timeState.selectedPeriod)
         }
 
     Scaffold(
@@ -118,8 +122,7 @@ internal fun BackgroundStylePickerScreen(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     YearMonthPicker(
-                        yearPickerState = yearState,
-                        monthPickerState = monthState,
+                        state = yearMonthState,
                         textStyle = TextStyle(
                             fontSize = 18.sp,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
@@ -152,9 +155,7 @@ internal fun BackgroundStylePickerScreen(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     TimePicker(
-                        hourPickerState = hourState,
-                        minutePickerState = minuteState,
-                        periodPickerState = periodState,
+                        state = timeState,
                         timeFormat = TimeFormat.HOUR_12,
                         textStyle = TextStyle(
                             fontSize = 18.sp,

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
@@ -55,9 +55,10 @@ internal fun BackgroundStylePickerScreen(
         initialMonth = currentDate.monthNumber
     )
     val timeState = rememberTimePickerState(
-        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
+        initialHour = currentHour,
         initialMinute = currentMinute,
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        timeFormat = TimeFormat.HOUR_12
     )
 
     val selectedDateText = remember(yearMonthState.selectedYear, yearMonthState.selectedMonth) {
@@ -156,7 +157,6 @@ internal fun BackgroundStylePickerScreen(
                 ) {
                     TimePicker(
                         state = timeState,
-                        timeFormat = TimeFormat.HOUR_12,
                         textStyle = TextStyle(
                             fontSize = 18.sp,
                             color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
@@ -38,7 +38,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.kez.picker.date.YearMonthPicker
-import com.kez.picker.rememberPickerState
+import com.kez.picker.rememberTimePickerState
+import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.formatTime12
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.time.TimePicker
@@ -60,12 +61,15 @@ internal fun BottomSheetSampleScreen(
     onBackPressed: () -> Unit = {},
 ) {
     // Date/time state management
-    val yearState = rememberPickerState(currentDate.year)
-    val monthState = rememberPickerState(currentDate.month.number)
-    val hourState =
-        rememberPickerState(if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour)
-    val minuteState = rememberPickerState(currentMinute)
-    val periodState = rememberPickerState(if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM)
+    val yearMonthState = rememberYearMonthPickerState(
+        initialYear = currentDate.year,
+        initialMonth = currentDate.monthNumber
+    )
+    val timeState = rememberTimePickerState(
+        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
+        initialMinute = currentMinute,
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+    )
 
     // Selected date/time text
     var selectedDateText by remember {
@@ -74,9 +78,9 @@ internal fun BottomSheetSampleScreen(
     var selectedTimeText by remember {
         mutableStateOf(
             formatTime12(
-                hourState.selectedItem,
-                minuteState.selectedItem,
-                periodState.selectedItem
+                timeState.selectedHour,
+                timeState.selectedMinute,
+                timeState.selectedPeriod
             )
         )
     }
@@ -240,8 +244,7 @@ internal fun BottomSheetSampleScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         YearMonthPicker(
-                            yearPickerState = yearState,
-                            monthPickerState = monthState,
+                            state = yearMonthState,
                             textStyle = TextStyle(
                                 fontSize = 18.sp,
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
@@ -261,7 +264,7 @@ internal fun BottomSheetSampleScreen(
                         onClick = {
                             // Update selected date
                             selectedDateText =
-                                "${yearState.selectedItem}년 ${getMonthName(monthState.selectedItem)}"
+                                "${yearMonthState.selectedYear}년 ${getMonthName(yearMonthState.selectedMonth)}"
                             scope.launch {
                                 dateSheetState.hide()
                                 showDateBottomSheet = false
@@ -305,9 +308,7 @@ internal fun BottomSheetSampleScreen(
                         contentAlignment = Alignment.Center
                     ) {
                         TimePicker(
-                            hourPickerState = hourState,
-                            minutePickerState = minuteState,
-                            periodPickerState = periodState,
+                            state = timeState,
                             timeFormat = TimeFormat.HOUR_12,
                             textStyle = TextStyle(
                                 fontSize = 18.sp,
@@ -328,9 +329,9 @@ internal fun BottomSheetSampleScreen(
                         onClick = {
                             // Update selected time
                             selectedTimeText = formatTime12(
-                                hourState.selectedItem,
-                                minuteState.selectedItem,
-                                periodState.selectedItem
+                                timeState.selectedHour,
+                                timeState.selectedMinute,
+                                timeState.selectedPeriod
                             )
                             scope.launch {
                                 timeSheetState.hide()

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
@@ -66,9 +66,10 @@ internal fun BottomSheetSampleScreen(
         initialMonth = currentDate.monthNumber
     )
     val timeState = rememberTimePickerState(
-        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
+        initialHour = currentHour,
         initialMinute = currentMinute,
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        timeFormat = TimeFormat.HOUR_12
     )
 
     // Selected date/time text
@@ -309,7 +310,6 @@ internal fun BottomSheetSampleScreen(
                     ) {
                         TimePicker(
                             state = timeState,
-                            timeFormat = TimeFormat.HOUR_12,
                             textStyle = TextStyle(
                                 fontSize = 18.sp,
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kez.picker.date.YearMonthPicker
-import com.kez.picker.rememberPickerState
+import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.util.currentDate
 import compose.icons.FeatherIcons
@@ -43,13 +43,15 @@ import kotlinx.datetime.number
 internal fun DatePickerSampleScreen(
     onBackPressed: () -> Unit = {},
 ) {
-    val yearState = rememberPickerState(currentDate.year)
-    val monthState = rememberPickerState(currentDate.month.number)
+    val state = rememberYearMonthPickerState(
+        initialYear = currentDate.year,
+        initialMonth = currentDate.monthNumber
+    )
 
     // Calculate selected date text
     val selectedDateText by remember {
         derivedStateOf {
-            "${yearState.selectedItem}년 ${getMonthName(monthState.selectedItem)}"
+            "${state.selectedYear}년 ${getMonthName(state.selectedMonth)}"
         }
     }
 
@@ -105,8 +107,7 @@ internal fun DatePickerSampleScreen(
 
             YearMonthPicker(
                 modifier = Modifier.padding(horizontal = 12.dp),
-                yearPickerState = yearState,
-                monthPickerState = monthState
+                state = state
             )
 
             // TODO: Add day selection capability

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
@@ -76,7 +76,7 @@ internal fun IntegratedPickerScreen(
         initialMonth = currentDate.monthNumber
     )
     val timeState = rememberTimePickerState(
-        initialHour = currentHour,
+        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
         initialMinute = currentMinute,
         initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
     )

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
@@ -51,7 +51,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.rememberNavController
 import com.kez.picker.date.YearMonthPicker
-import com.kez.picker.rememberPickerState
+import com.kez.picker.rememberTimePickerState
+import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.formatTime12
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.time.TimePicker
@@ -70,21 +71,24 @@ import compose.icons.feathericons.Clock
 internal fun IntegratedPickerScreen(
     onBackPressed: () -> Unit = {},
 ) {
-    val yearState = rememberPickerState(currentDate.year)
-    val monthState = rememberPickerState(currentDate.monthNumber)
-    val hourState =
-        rememberPickerState(if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour)
-    val minuteState = rememberPickerState(currentMinute)
-    val periodState = rememberPickerState(if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM)
+    val yearMonthState = rememberYearMonthPickerState(
+        initialYear = currentDate.year,
+        initialMonth = currentDate.monthNumber
+    )
+    val timeState = rememberTimePickerState(
+        initialHour = currentHour,
+        initialMinute = currentMinute,
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+    )
 
     var selectedTabIndex by remember { mutableIntStateOf(0) }
 
-    val selectedDateText = remember(yearState.selectedItem, monthState.selectedItem) {
-        "${yearState.selectedItem}년 ${getMonthName(monthState.selectedItem)}"
+    val selectedDateText = remember(yearMonthState.selectedYear, yearMonthState.selectedMonth) {
+        "${yearMonthState.selectedYear}년 ${getMonthName(yearMonthState.selectedMonth)}"
     }
     val selectedTimeText =
-        remember(hourState.selectedItem, minuteState.selectedItem, periodState.selectedItem) {
-            formatTime12(hourState.selectedItem, minuteState.selectedItem, periodState.selectedItem)
+        remember(timeState.selectedHour, timeState.selectedMinute, timeState.selectedPeriod) {
+            formatTime12(timeState.selectedHour, timeState.selectedMinute, timeState.selectedPeriod)
         }
 
     Scaffold(
@@ -162,8 +166,7 @@ internal fun IntegratedPickerScreen(
                         ) {
                             if (tabIndex == 0) {
                                 YearMonthPicker(
-                                    yearPickerState = yearState,
-                                    monthPickerState = monthState,
+                                    state = yearMonthState,
                                     textStyle = TextStyle(
                                         fontSize = 18.sp,
                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
@@ -177,9 +180,7 @@ internal fun IntegratedPickerScreen(
                                 )
                             } else {
                                 TimePicker(
-                                    hourPickerState = hourState,
-                                    minutePickerState = minuteState,
-                                    periodPickerState = periodState,
+                                    state = timeState,
                                     timeFormat = TimeFormat.HOUR_12,
                                     textStyle = TextStyle(
                                         fontSize = 18.sp,

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.compose.rememberNavController
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.rememberYearMonthPickerState
@@ -65,6 +64,7 @@ import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
 import compose.icons.feathericons.Clock
+import kotlinx.datetime.number
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,12 +73,13 @@ internal fun IntegratedPickerScreen(
 ) {
     val yearMonthState = rememberYearMonthPickerState(
         initialYear = currentDate.year,
-        initialMonth = currentDate.monthNumber
+        initialMonth = currentDate.month.number
     )
     val timeState = rememberTimePickerState(
-        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
+        initialHour = currentHour,
         initialMinute = currentMinute,
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        timeFormat = TimeFormat.HOUR_12
     )
 
     var selectedTabIndex by remember { mutableIntStateOf(0) }
@@ -181,7 +182,6 @@ internal fun IntegratedPickerScreen(
                             } else {
                                 TimePicker(
                                     state = timeState,
-                                    timeFormat = TimeFormat.HOUR_12,
                                     textStyle = TextStyle(
                                         fontSize = 18.sp,
                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.kez.picker.rememberPickerState
+import com.kez.picker.rememberTimePickerState
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
@@ -54,11 +54,15 @@ internal fun TimePickerSampleScreen(
     onBackPressed: () -> Unit = {},
 ) {
     var selectedFormat by remember { mutableIntStateOf(0) }
-    val hour12State =
-        rememberPickerState(if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour)
-    val hour24State = rememberPickerState(currentHour)
-    val minuteState = rememberPickerState(currentMinute)
-    val periodState = rememberPickerState(if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM)
+    val timeState12 = rememberTimePickerState(
+        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
+        initialMinute = currentMinute,
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+    )
+    val timeState24 = rememberTimePickerState(
+        initialHour = currentHour,
+        initialMinute = currentMinute
+    )
 
     val ktxTimeFormat12 = LocalTime.Format {
         amPmHour(padding = Padding.ZERO)
@@ -77,9 +81,9 @@ internal fun TimePickerSampleScreen(
     val selectedTimeText by remember {
         derivedStateOf {
             if (selectedFormat == 0) {
-                val hour12 = hour12State.selectedItem // (1 ~ 12)
-                val minute = minuteState.selectedItem
-                val isAm = periodState.selectedItem == TimePeriod.AM
+                val hour12 = timeState12.selectedHour // (1 ~ 12)
+                val minute = timeState12.selectedMinute
+                val isAm = timeState12.selectedPeriod == TimePeriod.AM
 
                 val hour24 = when {
                     isAm && hour12 == 12 -> 0    // 12:xx AM (midnight) -> 0
@@ -90,7 +94,7 @@ internal fun TimePickerSampleScreen(
                 time.format(ktxTimeFormat12)
 
             } else {
-                val time = LocalTime(hour24State.selectedItem, minuteState.selectedItem)
+                val time = LocalTime(timeState24.selectedHour, timeState24.selectedMinute)
                 time.format(ktxTimeFormat24)
             }
         }
@@ -159,15 +163,12 @@ internal fun TimePickerSampleScreen(
             Spacer(modifier = Modifier.height(32.dp))
             if (selectedFormat == 0) {
                 TimePicker(
-                    hourPickerState = hour12State,
-                    minutePickerState = minuteState,
-                    periodPickerState = periodState,
+                    state = timeState12,
                     timeFormat = TimeFormat.HOUR_12
                 )
             } else {
                 TimePicker(
-                    hourPickerState = hour24State,
-                    minutePickerState = minuteState,
+                    state = timeState24,
                     visibleItemsCount = 5,
                     timeFormat = TimeFormat.HOUR_24
                 )

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -55,9 +55,10 @@ internal fun TimePickerSampleScreen(
 ) {
     var selectedFormat by remember { mutableIntStateOf(0) }
     val timeState12 = rememberTimePickerState(
-        initialHour = if (currentHour > 12) currentHour - 12 else if (currentHour == 0) 12 else currentHour,
+        initialHour = currentHour,
         initialMinute = currentMinute,
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM
+        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        timeFormat = TimeFormat.HOUR_12
     )
     val timeState24 = rememberTimePickerState(
         initialHour = currentHour,
@@ -163,14 +164,12 @@ internal fun TimePickerSampleScreen(
             Spacer(modifier = Modifier.height(32.dp))
             if (selectedFormat == 0) {
                 TimePicker(
-                    state = timeState12,
-                    timeFormat = TimeFormat.HOUR_12
+                    state = timeState12
                 )
             } else {
                 TimePicker(
                     state = timeState24,
-                    visibleItemsCount = 5,
-                    timeFormat = TimeFormat.HOUR_24
+                    visibleItemsCount = 5
                 )
             }
         }


### PR DESCRIPTION
This pull request introduces significant improvements to the picker state management in the datetime picker library. It centralizes and simplifies the handling of complex picker states (such as year/month and time pickers) by introducing new state holder classes and composable state creators. This leads to cleaner, more maintainable code and easier integration in UI screens. Additionally, the `Picker` component is made more flexible by allowing custom item content rendering.

**State Management Refactoring:**

* Introduced `YearMonthPickerState` and `TimePickerState` classes, along with their corresponding `rememberYearMonthPickerState` and `rememberTimePickerState` composable creators, to encapsulate year/month and time picker state logic in a single object. This replaces the previous pattern of passing multiple `PickerState` objects for each part of the picker. (`datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt`)
* Updated the `YearMonthPicker` and `TimePicker` components to accept the new state holder objects, simplifying their APIs and usage. (`datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt`, `datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt`) [[1]](diffhunk://#diff-25e92f204177cffd6912aada1d7678839a06ec054be9dbf5dadaa06d58069d2fL61-R61) [[2]](diffhunk://#diff-216ee57c3709d96fa3d33334c1d136bc5c7abdda1d82536cca627031f98ac416L69-R68)

**Picker Component Enhancements:**

* Added a `content` parameter to the generic `Picker` composable, allowing consumers to provide custom composable content for each item, increasing flexibility in UI rendering. (`datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt`) [[1]](diffhunk://#diff-646ddbc5763a205e7fb192a318383a12c4e4796c49ab07484d71ac0bda9e5917L97-R98) [[2]](diffhunk://#diff-646ddbc5763a205e7fb192a318383a12c4e4796c49ab07484d71ac0bda9e5917R234-R239)

**Sample Code Updates:**

* Refactored all sample screens to use the new state holder objects (`YearMonthPickerState` and `TimePickerState`) instead of managing individual picker states. This results in more concise and less error-prone sample code. (`sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt`, `sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt`) [[1]](diffhunk://#diff-8c77e0ce5dfc978e3f2280eaaef5631b1b548926c91dde469c5541d021b9103cL52-R68) [[2]](diffhunk://#diff-37706bb91a56f1582d7e3c73b408ad953f73387d421f17f9138dc24e43968b52L63-R72)

**Internal Improvements:**

* Marked `PickerState`, `YearMonthPickerState`, and `TimePickerState` as `@Stable` to improve Compose state handling and performance. (`datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt`)

**Minor Cleanups:**

* Reordered parameters in the `Picker` composable for improved consistency and clarity. (`datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt`)

These changes make the picker components easier to use, more robust, and more flexible for future enhancements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional custom rendering for picker items
  * Composite date/time state objects with remember helpers and sensible defaults

* **Improvements**
  * Simplified picker APIs to accept bundled state objects
  * Stable state accessors for selected date/time values; sample screens updated to use new state APIs

* **Documentation**
  * README rewritten with concise examples and usage
  * Added Korean README with examples and API summary

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->