### PR TITLE
Add saveable typed picker state values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,223 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Language Preference
+
+**Always respond in Korean (한국어)** when interacting with this codebase. All explanations, summaries, documentation, and guidance should be written in Korean. Code identifiers, file/folder names, and technical terms should remain in English, but conceptual explanations and context should be in Korean.
+
+## Project Overview
+
+Compose-DateTimePicker is a Kotlin Multiplatform library providing date and time picker components for Compose. It targets Android, iOS, Desktop (JVM), and Web with a shared codebase, published to Maven Central as `io.github.kez-lab:compose-date-time-picker`.
+
+**Current version**: 0.6.0
+**License**: Apache 2.0
+
+## Architecture
+
+### Component Hierarchy
+
+The library follows a **composition-based architecture** with a single generic `Picker<T>` component as the foundation:
+
+```
+Picker<T> (generic scrollable picker)
+  ↓ composed into
+TimePicker (hour + minute + optional AM/PM)
+YearMonthPicker (year + month)
+DatePicker (year + month + day)
+```
+
+**Key pattern**: Higher-level components (`TimePicker`, `YearMonthPicker`) are compositions of multiple `Picker` instances, not subclasses. Each `Picker` instance manages its own `PickerState<T>`.
+
+### Core Components
+
+**`Picker.kt`** (~440 lines)
+- Generic scrollable picker using `LazyColumn` with snap behavior
+- Supports infinite (`isInfinity=true`) and bounded scrolling
+- Uses a bounded cyclic buffer (`items.size * 1000`) for infinite mode
+- Fading edge effect via `graphicsLayer` + `BlendMode.DstIn`
+- State updates via `snapshotFlow { firstVisibleItemIndex }` in `LaunchedEffect`
+
+**`PickerState.kt`**
+- Shared state holders for `Picker`, `TimePicker`, and `YearMonthPicker`
+- Created via `rememberPickerState`, `rememberTimePickerState`, and `rememberYearMonthPickerState`
+- `TimePickerState` exposes `selectedTime: LocalTime` and `selectedHourOfDay`
+- `YearMonthPickerState` exposes `selectedMonthDate: LocalDate`
+- Specialized picker states use saveable state; generic `PickerState<T>` uses regular `remember` because arbitrary `T` is not guaranteed saveable
+
+**`DatePicker.kt`** / **`DatePickerState.kt`**
+- Compose year, month, and day pickers
+- Clamp selected day when the selected year/month has fewer days
+- `DatePickerState` exposes `selectedDate: LocalDate`
+
+**`TimePicker.kt`** / **`YearMonthPicker.kt`**
+- Compose multiple `Picker` instances in a `Row`
+- Handle 12/24-hour format conversion (TimePicker only)
+- Use `kotlinx-datetime` for date/time utilities
+
+### State Management Flow
+
+```
+User scrolls LazyColumn
+  → LazyListState.firstVisibleItemIndex changes
+  → snapshotFlow emits new index
+  → state.selectedItem updated
+  → Recomposition shows updated UI
+```
+
+### Multiplatform Structure
+
+```
+datetimepicker/src/
+├── commonMain/kotlin/    # Shared UI and logic
+├── androidMain/          # Android-specific (UI tooling preview)
+├── iosMain/              # iOS-specific (currently minimal)
+├── desktopMain/          # Desktop-specific (currently minimal)
+├── jsMain/               # Web-specific source set directory, currently minimal
+└── commonTest/           # Shared unit tests
+```
+
+Most logic lives in `commonMain`. Platform-specific code is minimal.
+
+## Development Commands
+
+## Maintainer Workflow Preferences
+
+- Use `feature/*` branch names for new implementation work in this repository.
+- Treat `main` as the integration branch. There is currently no `develop` branch on the remote.
+- After a substantial implementation step, run a six-agent feedback loop when the maintainer asks for autonomous improvement work: collect feedback, fix actionable issues, verify again, then open or update the PR.
+- Merge PRs only after relevant local verification and GitHub Actions checks pass.
+- Keep improving toward Android developer ergonomics first: state APIs, sample usability, documentation clarity, accessibility, and predictable behavior in real app lifecycles.
+- Keep repository guidance up to date in this `AGENTS.md` when the maintainer gives durable process feedback.
+- Do not include local agent/tooling folders such as `.agents/` or `.claude/` in product PRs unless the change is explicitly about agent workflow assets.
+
+### Build
+
+```bash
+# Build library module only
+./gradlew :datetimepicker:assemble --no-daemon
+
+# Build all targets (Android, iOS, Desktop, JS)
+./gradlew build --no-daemon
+
+# Compile specific targets
+./gradlew :datetimepicker:compileKotlinMetadata --no-daemon  # Common
+./gradlew :datetimepicker:compileKotlinDesktop --no-daemon   # Desktop
+./gradlew :datetimepicker:compileDebugKotlinAndroid --no-daemon
+```
+
+### Testing
+
+```bash
+# Run all tests
+./gradlew :datetimepicker:test --no-daemon
+
+# Run specific test suites
+./gradlew :datetimepicker:testDebugUnitTest --no-daemon
+./gradlew :datetimepicker:testReleaseUnitTest --no-daemon
+
+# Run checks (tests + lint)
+./gradlew :datetimepicker:check --no-daemon
+
+# Verify sample app compilation
+./gradlew :sample:compileKotlinDesktop --no-daemon
+./gradlew :sample:wasmJsBrowserDistribution --no-daemon
+```
+
+**Run a single test**: Use `--tests` filter:
+```bash
+./gradlew :datetimepicker:testDebugUnitTest --tests "com.kez.picker.PickerStateTest.pickerState_initialValue_isCorrect" --no-daemon
+```
+
+### Sample App
+
+```bash
+# Run sample on Desktop
+./gradlew :sample:desktopRun
+
+# Install sample on Android
+./gradlew :sample:installDebug
+adb shell am start -n com.kez.picker.sample/.MainActivity
+
+# iOS: open iosApp/iosApp.xcodeproj in Xcode
+```
+
+### Publishing
+
+```bash
+# Check version
+./gradlew printVersion
+
+# Test local publish
+./gradlew :datetimepicker:publishToMavenLocal
+
+# Production deploy: manually triggered by GitHub Actions workflow_dispatch
+# See .github/workflows/maven-central-deploy.yml
+```
+
+## Key Implementation Details
+
+### Infinite Scrolling
+
+The `Picker` uses a bounded cyclic buffer for infinite mode:
+
+```kotlin
+private const val INFINITE_SCROLL_MULTIPLIER = 1000
+val listScrollCount = adjustedItems.size * INFINITE_SCROLL_MULTIPLIER
+fun getItem(index: Int) = adjustedItems[index.mod(adjustedItems.size)]
+```
+
+This keeps the picker virtually cyclic without exposing `Int.MAX_VALUE` list sizes.
+
+### Snap Behavior
+
+Uses `rememberSnapFlingBehavior(lazyListState)` to snap items to the center position. The selected item is determined by:
+
+```kotlin
+listState.firstVisibleItemIndex + visibleItemsMiddle
+```
+
+### Text Scaling Animation
+
+The `Picker` interpolates font size and color based on item offset from center:
+
+```kotlin
+val fraction = abs(offset / itemHeight).coerceIn(0f, 1f)
+fontSize = lerp(selectedTextStyle.fontSize, textStyle.fontSize, fraction)
+color = lerp(selectedTextStyle.color, textStyle.color, fraction)
+```
+
+## Testing Strategy
+
+**Current coverage** (estimated):
+- Unit tests: picker states, date validation, time calculation, and picker index utility behavior
+- Missing: UI interaction tests, screenshot tests, accessibility behavior tests, and sample smoke tests
+
+**When adding tests**:
+- Unit tests → `datetimepicker/src/commonTest/kotlin/`
+- Android UI tests → add `datetimepicker/src/androidInstrumentedTest/kotlin/` when instrumentation coverage is introduced
+- Follow naming: `<ComponentName>Test.kt` or `<ComponentName>AndroidTest.kt`
+
+## Code Style
+
+- **Kotlin official style**: `kotlin.code.style=official`
+- **Naming**: PascalCase for composables (`TimePicker`), camelCase for functions (`rememberPickerState`)
+- **Documentation**: KDoc for all public APIs with `@param` descriptions
+- **Formatting**: Handled by Kotlin plugin (no explicit ktlint/detekt config found)
+
+## Version Management
+
+Version is set in `gradle.properties`:
+```properties
+VERSION_NAME=0.6.0
+```
+
+Follow **Semantic Versioning**: MAJOR.MINOR.PATCH
+
+## CI/CD
+
+GitHub Actions workflows:
+- **`integration-build-test.yml`**: Runs multiplatform library checks on pull requests to `main`
+- **`maven-central-deploy.yml`**: Publishes releases to Maven Central
+
+Build matrix: Ubuntu latest for Android/Desktop/Wasm and macOS 14 for iOS, using JDK 17 (Temurin)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the dependency to your version catalog or build file.
 
 ```toml
 [versions]
-composeDateTimePicker = "0.5.0"
+composeDateTimePicker = "0.6.0"
 
 [libraries]
 compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picker", version.ref = "composeDateTimePicker" }
@@ -35,7 +35,7 @@ compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picke
 
 ```kotlin
 dependencies {
-    implementation("io.github.kez-lab:compose-date-time-picker:0.5.0")
+    implementation("io.github.kez-lab:compose-date-time-picker:0.6.0")
 }
 ```
 
@@ -66,6 +66,8 @@ fun TimePicker24hExample() {
     TimePicker(
         state = state
     )
+
+    // Use state.selectedTime when passing the result to app logic.
 }
 ```
 
@@ -91,6 +93,8 @@ fun TimePicker12hExample() {
     TimePicker(
         state = state
     )
+
+    // state.selectedTime is always a kotlinx.datetime.LocalTime.
 }
 ```
 
@@ -118,8 +122,7 @@ fun DatePickerExample() {
         state = state
     )
 
-    // Access selected values
-    // state.selectedYear, state.selectedMonth, state.selectedDay
+    // Use state.selectedDate when passing the result to app logic.
 }
 ```
 
@@ -144,6 +147,8 @@ fun YearMonthPickerExample() {
     YearMonthPicker(
         state = state
     )
+
+    // state.selectedMonthDate is the first day of the selected month.
 }
 ```
 
@@ -195,6 +200,16 @@ fun BottomSheetPickerExample() {
 | `textStyles` | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
 | `isDividerVisible` | Whether selection dividers are visible. | `true` |
 
+**TimePickerState Properties:**
+
+- `selectedHour`: The selected hour shown by the picker.
+- `selectedMinute`: The selected minute (0-59).
+- `selectedPeriod`: The selected AM/PM period when using 12-hour format.
+- `selectedHourOfDay`: The selected hour converted to 24-hour clock time (0-23).
+- `selectedTime`: The selected value as `kotlinx.datetime.LocalTime`.
+
+`rememberTimePickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
+
 ### DatePicker
 
 | Parameter           | Description                             | Default                     |
@@ -212,7 +227,10 @@ fun BottomSheetPickerExample() {
 - `selectedYear`: The currently selected year.
 - `selectedMonth`: The currently selected month (1-12).
 - `selectedDay`: The currently selected day (1-31, auto-adjusted based on month).
+- `selectedDate`: The selected value as `kotlinx.datetime.LocalDate`.
 - `maxDay`: The maximum valid day for the selected year and month.
+
+`rememberDatePickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
 ### YearMonthPicker
 
@@ -225,6 +243,14 @@ fun BottomSheetPickerExample() {
 | `visibleItemsCount` | Number of items visible in the list. | `3` |
 | `colors` | Colors for text, selected text, dividers, and selected item background. | `PickerDefaults.colors()` |
 | `textStyles` | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
+
+**YearMonthPickerState Properties:**
+
+- `selectedYear`: The currently selected year.
+- `selectedMonth`: The currently selected month (1-12).
+- `selectedMonthDate`: The selected year/month represented as the first day of that month.
+
+`rememberYearMonthPickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
 ## License
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -23,7 +23,7 @@ Android, iOS, Desktop (JVM), Web (Wasm) 등 다양한 플랫폼에서 일관된 
 
 ```toml
 [versions]
-composeDateTimePicker = "0.5.0"
+composeDateTimePicker = "0.6.0"
 
 [libraries]
 compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picker", version.ref = "composeDateTimePicker" }
@@ -33,7 +33,7 @@ compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picke
 
 ```kotlin
 dependencies {
-    implementation("io.github.kez-lab:compose-date-time-picker:0.5.0")
+    implementation("io.github.kez-lab:compose-date-time-picker:0.6.0")
 }
 ```
 
@@ -64,6 +64,8 @@ fun TimePicker24hExample() {
     TimePicker(
         state = state
     )
+
+    // 앱 로직에 전달할 때는 state.selectedTime을 사용합니다.
 }
 ```
 
@@ -89,6 +91,8 @@ fun TimePicker12hExample() {
     TimePicker(
         state = state
     )
+
+    // state.selectedTime은 항상 kotlinx.datetime.LocalTime입니다.
 }
 ```
 
@@ -113,7 +117,7 @@ fun DatePickerExample() {
 
     DatePicker(state = state)
 
-    // state.selectedYear, state.selectedMonth, state.selectedDay
+    // 앱 로직에 전달할 때는 state.selectedDate를 사용합니다.
 }
 ```
 
@@ -138,6 +142,8 @@ fun YearMonthPickerExample() {
     YearMonthPicker(
         state = state
     )
+
+    // state.selectedMonthDate는 선택된 월의 1일을 나타냅니다.
 }
 ```
 
@@ -189,6 +195,16 @@ fun BottomSheetPickerExample() {
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
 | `isDividerVisible` | 선택 영역 구분선 표시 여부입니다. | `true` |
 
+**TimePickerState 속성:**
+
+- `selectedHour`: Picker에 표시되는 선택된 시간입니다.
+- `selectedMinute`: 현재 선택된 분입니다. (0-59)
+- `selectedPeriod`: 12시간 형식에서 선택된 오전/오후 값입니다.
+- `selectedHourOfDay`: 선택된 시간을 24시간 기준(0-23)으로 변환한 값입니다.
+- `selectedTime`: 선택된 값을 `kotlinx.datetime.LocalTime`으로 제공합니다.
+
+`rememberTimePickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
+
 ### DatePicker
 
 | 파라미터 | 설명 | 기본값 |
@@ -206,7 +222,10 @@ fun BottomSheetPickerExample() {
 - `selectedYear`: 현재 선택된 연도입니다.
 - `selectedMonth`: 현재 선택된 월입니다. (1-12)
 - `selectedDay`: 현재 선택된 일입니다. 선택된 월에 맞게 자동 보정됩니다.
+- `selectedDate`: 선택된 값을 `kotlinx.datetime.LocalDate`로 제공합니다.
 - `maxDay`: 현재 선택된 연도/월에서 선택 가능한 최대 일입니다.
+
+`rememberDatePickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
 ### YearMonthPicker
 
@@ -219,6 +238,14 @@ fun BottomSheetPickerExample() {
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 | `colors` | 텍스트, 선택 텍스트, 구분선, 선택 영역 배경 색상입니다. | `PickerDefaults.colors()` |
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
+
+**YearMonthPickerState 속성:**
+
+- `selectedYear`: 현재 선택된 연도입니다.
+- `selectedMonth`: 현재 선택된 월입니다. (1-12)
+- `selectedMonthDate`: 선택된 연/월을 해당 월의 1일 `LocalDate`로 제공합니다.
+
+`rememberYearMonthPickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
 ## 라이선스
 

--- a/datetimepicker/build.gradle.kts
+++ b/datetimepicker/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(libs.compose.runtime)
+            api(libs.compose.runtime.saveable)
             api(libs.compose.foundation)
             api(libs.compose.ui)
             api(libs.kotlinx.datetime)

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -5,12 +5,17 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDate
 import com.kez.picker.util.currentHour
 import com.kez.picker.util.currentMinute
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.number
 
 /**
@@ -54,7 +59,7 @@ fun rememberYearMonthPickerState(
     initialYear: Int = currentDate().year,
     initialMonth: Int = currentDate().month.number
 ): YearMonthPickerState {
-    return remember(initialYear, initialMonth) {
+    return rememberSaveable(initialYear, initialMonth, saver = YearMonthPickerState.Saver) {
         YearMonthPickerState(initialYear, initialMonth)
     }
 }
@@ -76,6 +81,12 @@ class YearMonthPickerState(
     internal val yearState = PickerState(initialYear)
     internal val monthState = PickerState(initialMonth)
 
+    init {
+        require(initialMonth in 1..12) {
+            "initialMonth must be in range [1, 12], but was $initialMonth"
+        }
+    }
+
     /**
      * The currently selected year.
      */
@@ -87,6 +98,27 @@ class YearMonthPickerState(
      */
     val selectedMonth: Int
         get() = monthState.selectedItem
+
+    /**
+     * The selected year and month represented as the first day of that month.
+     */
+    val selectedMonthDate: LocalDate
+        get() = LocalDate(selectedYear, selectedMonth, 1)
+
+    companion object {
+        /**
+         * Saves and restores [YearMonthPickerState] across configuration changes.
+         */
+        val Saver: Saver<YearMonthPickerState, Any> = listSaver(
+            save = { listOf(it.selectedYear, it.selectedMonth) },
+            restore = {
+                YearMonthPickerState(
+                    initialYear = it[0] as Int,
+                    initialMonth = it[1] as Int
+                )
+            }
+        )
+    }
 }
 
 /**
@@ -107,20 +139,33 @@ fun rememberTimePickerState(
     timeFormat: TimeFormat = TimeFormat.HOUR_24
 ): TimePickerState {
     val adjustedHour = remember(initialHour, timeFormat) {
-        if (timeFormat == TimeFormat.HOUR_12) {
-            val h = initialHour % 12
-            if (h == 0) 12 else h
-        } else {
-            initialHour
-        }
+        initialHourForTimeFormat(initialHour, timeFormat)
     }
-    return remember(adjustedHour, initialMinute, initialPeriod, timeFormat) {
+    return rememberSaveable(
+        adjustedHour,
+        initialMinute,
+        initialPeriod,
+        timeFormat,
+        saver = TimePickerState.Saver
+    ) {
         TimePickerState(
             initialHour = adjustedHour,
             initialMinute = initialMinute,
             initialPeriod = initialPeriod,
             timeFormat = timeFormat,
         )
+    }
+}
+
+internal fun initialHourForTimeFormat(initialHour: Int, timeFormat: TimeFormat): Int {
+    require(initialHour in 0..23) {
+        "initialHour must be in range [0, 23], but was $initialHour"
+    }
+    return if (timeFormat == TimeFormat.HOUR_12) {
+        val hour = initialHour % 12
+        if (hour == 0) 12 else hour
+    } else {
+        initialHour
     }
 }
 
@@ -146,6 +191,17 @@ class TimePickerState(
     internal val minuteState = PickerState(initialMinute)
     internal val periodState = PickerState(initialPeriod)
 
+    init {
+        require(initialMinute in 0..59) {
+            "initialMinute must be in range [0, 59], but was $initialMinute"
+        }
+        val hourRange = if (timeFormat == TimeFormat.HOUR_12) 1..12 else 0..23
+        val hourRangeLabel = if (timeFormat == TimeFormat.HOUR_12) "1, 12" else "0, 23"
+        require(initialHour in hourRange) {
+            "initialHour must be in range [$hourRangeLabel], but was $initialHour"
+        }
+    }
+
     /**
      * The currently selected hour.
      * For 12-hour format: 1-12, for 24-hour format: 0-23.
@@ -165,4 +221,47 @@ class TimePickerState(
      */
     val selectedPeriod: TimePeriod
         get() = periodState.selectedItem
+
+    /**
+     * The selected hour converted to 24-hour clock time (0-23).
+     */
+    val selectedHourOfDay: Int
+        get() = when (timeFormat) {
+            TimeFormat.HOUR_24 -> selectedHour
+            TimeFormat.HOUR_12 -> when {
+                selectedPeriod == TimePeriod.AM && selectedHour == 12 -> 0
+                selectedPeriod == TimePeriod.PM && selectedHour != 12 -> selectedHour + 12
+                else -> selectedHour
+            }
+        }
+
+    /**
+     * The selected time represented as [LocalTime].
+     */
+    val selectedTime: LocalTime
+        get() = LocalTime(selectedHourOfDay, selectedMinute)
+
+    companion object {
+        /**
+         * Saves and restores [TimePickerState] across configuration changes.
+         */
+        val Saver: Saver<TimePickerState, Any> = listSaver(
+            save = {
+                listOf(
+                    it.selectedHour,
+                    it.selectedMinute,
+                    it.selectedPeriod.name,
+                    it.timeFormat.name
+                )
+            },
+            restore = {
+                TimePickerState(
+                    initialHour = it[0] as Int,
+                    initialMinute = it[1] as Int,
+                    initialPeriod = TimePeriod.valueOf(it[2] as String),
+                    timeFormat = TimeFormat.valueOf(it[3] as String)
+                )
+            }
+        )
+    }
 }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -2,9 +2,12 @@ package com.kez.picker.date
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import com.kez.picker.PickerState
 import com.kez.picker.util.currentDate
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.number
 
 /**
@@ -21,7 +24,7 @@ fun rememberDatePickerState(
     initialMonth: Int = currentDate().month.number,
     initialDay: Int = currentDate().day
 ): DatePickerState {
-    return remember(initialYear, initialMonth, initialDay) {
+    return rememberSaveable(initialYear, initialMonth, initialDay, saver = DatePickerState.Saver) {
         DatePickerState(initialYear, initialMonth, initialDay)
     }
 }
@@ -64,6 +67,12 @@ class DatePickerState(
      */
     val selectedDay: Int
         get() = dayState.selectedItem
+
+    /**
+     * The currently selected date.
+     */
+    val selectedDate: LocalDate
+        get() = LocalDate(selectedYear, selectedMonth, selectedDay.coerceIn(1, maxDay))
 
     /**
      * The currently valid maximum day for the selected year and month.
@@ -110,5 +119,21 @@ class DatePickerState(
 
     private fun isLeapYear(year: Int): Boolean {
         return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+    }
+
+    companion object {
+        /**
+         * Saves and restores [DatePickerState] across configuration changes.
+         */
+        val Saver: Saver<DatePickerState, Any> = listSaver(
+            save = { listOf(it.selectedYear, it.selectedMonth, it.selectedDay) },
+            restore = {
+                DatePickerState(
+                    initialYear = it[0] as Int,
+                    initialMonth = it[1] as Int,
+                    initialDay = it[2] as Int
+                )
+            }
+        )
     }
 }

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -1,9 +1,12 @@
 package com.kez.picker
 
+import androidx.compose.runtime.saveable.SaverScope
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 /**
  * Unit tests for [TimePickerState] class.
@@ -113,6 +116,8 @@ class TimePickerStateTest {
         assertEquals(12, state.selectedHour)
         assertEquals(0, state.selectedMinute)
         assertEquals(TimePeriod.AM, state.selectedPeriod)
+        assertEquals(0, state.selectedHourOfDay)
+        assertEquals(LocalTime(0, 0), state.selectedTime)
     }
 
     @Test
@@ -127,6 +132,21 @@ class TimePickerStateTest {
         assertEquals(12, state.selectedHour)
         assertEquals(0, state.selectedMinute)
         assertEquals(TimePeriod.PM, state.selectedPeriod)
+        assertEquals(12, state.selectedHourOfDay)
+        assertEquals(LocalTime(12, 0), state.selectedTime)
+    }
+
+    @Test
+    fun timePickerState_12HourFormat_pmTime_convertsToLocalTime() {
+        val state = TimePickerState(
+            initialHour = 3,
+            initialMinute = 45,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        assertEquals(15, state.selectedHourOfDay)
+        assertEquals(LocalTime(15, 45), state.selectedTime)
     }
 
     // ==================== Minute Boundary Tests ====================
@@ -153,6 +173,78 @@ class TimePickerStateTest {
         )
 
         assertEquals(59, state.selectedMinute)
+    }
+
+    @Test
+    fun timePickerState_invalidMinute_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            TimePickerState(
+                initialHour = 10,
+                initialMinute = 60,
+                initialPeriod = TimePeriod.AM,
+                timeFormat = TimeFormat.HOUR_24
+            )
+        }
+    }
+
+    @Test
+    fun timePickerState_negativeMinute_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            TimePickerState(
+                initialHour = 10,
+                initialMinute = -1,
+                initialPeriod = TimePeriod.AM,
+                timeFormat = TimeFormat.HOUR_24
+            )
+        }
+    }
+
+    @Test
+    fun timePickerState_invalid24Hour_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            TimePickerState(
+                initialHour = 24,
+                initialMinute = 0,
+                initialPeriod = TimePeriod.AM,
+                timeFormat = TimeFormat.HOUR_24
+            )
+        }
+    }
+
+    @Test
+    fun timePickerState_negative24Hour_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            TimePickerState(
+                initialHour = -1,
+                initialMinute = 0,
+                initialPeriod = TimePeriod.AM,
+                timeFormat = TimeFormat.HOUR_24
+            )
+        }
+    }
+
+    @Test
+    fun timePickerState_invalid12Hour_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            TimePickerState(
+                initialHour = 0,
+                initialMinute = 0,
+                initialPeriod = TimePeriod.AM,
+                timeFormat = TimeFormat.HOUR_12
+            )
+        }
+    }
+
+    @Test
+    fun timePickerState_12HourAboveRange_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            TimePickerState(
+                initialHour = 13,
+                initialMinute = 0,
+                initialPeriod = TimePeriod.AM,
+                timeFormat = TimeFormat.HOUR_12
+            )
+        }
     }
 
     // ==================== State Independence Tests ====================
@@ -199,5 +291,81 @@ class TimePickerStateTest {
 
         assertEquals(TimeFormat.HOUR_24, state24.timeFormat)
         assertEquals(TimeFormat.HOUR_12, state12.timeFormat)
+    }
+
+    @Test
+    fun timePickerState_24HourFormat_selectedTime_isCorrect() {
+        val state = TimePickerState(
+            initialHour = 23,
+            initialMinute = 15,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        assertEquals(23, state.selectedHourOfDay)
+        assertEquals(LocalTime(23, 15), state.selectedTime)
+    }
+
+    @Test
+    fun timePickerState_selectedTime_updatesWhenInternalStateChanges() {
+        val state = TimePickerState(
+            initialHour = 12,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        state.hourState.selectedItem = 11
+        state.minuteState.selectedItem = 30
+        state.periodState.selectedItem = TimePeriod.PM
+
+        assertEquals(23, state.selectedHourOfDay)
+        assertEquals(LocalTime(23, 30), state.selectedTime)
+    }
+
+    @Test
+    fun timePickerState_saver_roundTripsCurrentSelection() {
+        val state = TimePickerState(
+            initialHour = 12,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+        state.hourState.selectedItem = 7
+        state.minuteState.selectedItem = 45
+        state.periodState.selectedItem = TimePeriod.PM
+
+        val restored = state.saveAndRestore()
+
+        assertEquals(7, restored.selectedHour)
+        assertEquals(45, restored.selectedMinute)
+        assertEquals(TimePeriod.PM, restored.selectedPeriod)
+        assertEquals(TimeFormat.HOUR_12, restored.timeFormat)
+        assertEquals(LocalTime(19, 45), restored.selectedTime)
+    }
+
+    @Test
+    fun initialHourForTimeFormat_converts24HourInputFor12HourMode() {
+        assertEquals(12, initialHourForTimeFormat(0, TimeFormat.HOUR_12))
+        assertEquals(12, initialHourForTimeFormat(12, TimeFormat.HOUR_12))
+        assertEquals(1, initialHourForTimeFormat(13, TimeFormat.HOUR_12))
+        assertEquals(11, initialHourForTimeFormat(23, TimeFormat.HOUR_12))
+    }
+
+    @Test
+    fun initialHourForTimeFormat_rejectsOutOfRangeHourOfDay() {
+        assertFailsWith<IllegalArgumentException> {
+            initialHourForTimeFormat(24, TimeFormat.HOUR_12)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            initialHourForTimeFormat(-1, TimeFormat.HOUR_12)
+        }
+    }
+
+    private fun TimePickerState.saveAndRestore(): TimePickerState {
+        val saved = with(TimePickerState.Saver) {
+            SaverScope { true }.save(this@saveAndRestore)
+        }
+        return TimePickerState.Saver.restore(saved!!)!!
     }
 }

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -1,7 +1,10 @@
 package com.kez.picker
 
+import androidx.compose.runtime.saveable.SaverScope
+import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 
 /**
@@ -26,6 +29,7 @@ class YearMonthPickerStateTest {
 
         assertEquals(2024, state.selectedYear)
         assertEquals(6, state.selectedMonth)
+        assertEquals(LocalDate(2024, 6, 1), state.selectedMonthDate)
     }
 
     @Test
@@ -91,6 +95,55 @@ class YearMonthPickerStateTest {
             )
             assertEquals(month, state.selectedMonth, "Month $month should be correctly stored")
         }
+    }
+
+    @Test
+    fun yearMonthPickerState_invalidMonth_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            YearMonthPickerState(
+                initialYear = 2024,
+                initialMonth = 13
+            )
+        }
+    }
+
+    @Test
+    fun yearMonthPickerState_zeroMonth_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            YearMonthPickerState(
+                initialYear = 2024,
+                initialMonth = 0
+            )
+        }
+    }
+
+    @Test
+    fun yearMonthPickerState_selectedMonthDate_updatesWhenInternalStateChanges() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 1
+        )
+
+        state.yearState.selectedItem = 2026
+        state.monthState.selectedItem = 12
+
+        assertEquals(LocalDate(2026, 12, 1), state.selectedMonthDate)
+    }
+
+    @Test
+    fun yearMonthPickerState_saver_roundTripsCurrentSelection() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 1
+        )
+        state.yearState.selectedItem = 2026
+        state.monthState.selectedItem = 12
+
+        val restored = state.saveAndRestore()
+
+        assertEquals(2026, restored.selectedYear)
+        assertEquals(12, restored.selectedMonth)
+        assertEquals(LocalDate(2026, 12, 1), restored.selectedMonthDate)
     }
 
     // ==================== State Independence Tests ====================
@@ -189,5 +242,12 @@ class YearMonthPickerStateTest {
 
         assertEquals(2024, state.selectedYear)
         assertEquals(1, state.selectedMonth)
+    }
+
+    private fun YearMonthPickerState.saveAndRestore(): YearMonthPickerState {
+        val saved = with(YearMonthPickerState.Saver) {
+            SaverScope { true }.save(this@saveAndRestore)
+        }
+        return YearMonthPickerState.Saver.restore(saved!!)!!
     }
 }

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -1,5 +1,7 @@
 package com.kez.picker.date
 
+import androidx.compose.runtime.saveable.SaverScope
+import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -82,6 +84,33 @@ class DatePickerStateTest {
         assertEquals(2025, state.selectedYear)
         assertEquals(6, state.selectedMonth)
         assertEquals(15, state.selectedDay)
+        assertEquals(LocalDate(2025, 6, 15), state.selectedDate)
+    }
+
+    @Test
+    fun testSelectedDate_UpdatesWhenInternalStateChanges() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
+
+        state.yearState.selectedItem = 2026
+        state.monthState.selectedItem = 12
+        state.dayState.selectedItem = 25
+
+        assertEquals(LocalDate(2026, 12, 25), state.selectedDate)
+    }
+
+    @Test
+    fun testSaver_RoundTripsCurrentSelection() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
+        state.yearState.selectedItem = 2026
+        state.monthState.selectedItem = 2
+        state.dayState.selectedItem = 30
+
+        val restored = state.saveAndRestore()
+
+        assertEquals(2026, restored.selectedYear)
+        assertEquals(2, restored.selectedMonth)
+        assertEquals(28, restored.selectedDay)
+        assertEquals(LocalDate(2026, 2, 28), restored.selectedDate)
     }
 
     @Test
@@ -113,5 +142,12 @@ class DatePickerStateTest {
             val state = DatePickerState(initialYear = year, initialMonth = 2, initialDay = 1)
             assertEquals(28, state.maxDay, "Year $year should not be a leap year with 28 days in Feb")
         }
+    }
+
+    private fun DatePickerState.saveAndRestore(): DatePickerState {
+        val saved = with(DatePickerState.Saver) {
+            SaverScope { true }.save(this@saveAndRestore)
+        }
+        return DatePickerState.Saver.restore(saved!!)!!
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ kotlin.daemon.jvmargs=-Xmx4g -Xms1g -XX:ReservedCodeCacheSize=512m
 # Project Information
 GROUP=io.github.kez-lab
 POM_ARTIFACT_ID=compose-date-time-picker
-VERSION_NAME=0.5.0
+VERSION_NAME=0.6.0
 
 POM_NAME=Compose-DateTimePicker
 POM_DESCRIPTION=Compose Multiplatform DateTimePicker library supporting Android, iOS, Desktop and Web

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ compose-components-resources = { module = "org.jetbrains.compose.components:comp
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
+compose-runtime-saveable = { module = "org.jetbrains.compose.runtime:runtime-saveable", version.ref = "compose" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose" }
@@ -51,5 +52,4 @@ room = { id = "androidx.room", version.ref = "room" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfig" }
 vanniktech-maven = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-maven" }
-
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/StringUtils.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/StringUtils.kt
@@ -1,6 +1,7 @@
 package com.kez.picker.sample
 
 import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalTime
 
 /**
  * 시간 형식화를 위한 확장 함수 - 12시간제
@@ -10,6 +11,13 @@ internal fun formatTime12(hour: Int?, minute: Int?, period: TimePeriod?): String
     val m = minute ?: 0
     val p = period ?: TimePeriod.AM
     return "${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')} $p"
+}
+
+internal fun formatTime12(time: LocalTime): String {
+    val period = if (time.hour >= 12) TimePeriod.PM else TimePeriod.AM
+    val hour = time.hour % 12
+    val displayHour = if (hour == 0) 12 else hour
+    return formatTime12(displayHour, time.minute, period)
 }
 
 /**
@@ -40,4 +48,4 @@ internal fun getMonthName(month: Int): String {
         12 -> "12월 (Dec)"
         else -> "알 수 없음"
     }
-} 
+}

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -75,17 +76,11 @@ internal fun BottomSheetSampleScreen(
     )
 
     // Selected date/time text
-    var selectedDateText by remember {
+    var selectedDateText by rememberSaveable {
         mutableStateOf("${currentDate.year}년 ${getMonthName(currentDate.month.number)}")
     }
-    var selectedTimeText by remember {
-        mutableStateOf(
-            formatTime12(
-                timeState.selectedHour,
-                timeState.selectedMinute,
-                timeState.selectedPeriod
-            )
-        )
+    var selectedTimeText by rememberSaveable {
+        mutableStateOf(formatTime12(timeState.selectedTime))
     }
 
     // Bottom sheet state
@@ -269,9 +264,10 @@ internal fun BottomSheetSampleScreen(
 
                     Button(
                         onClick = {
-                            // Update selected date
-                            selectedDateText =
-                                "${yearMonthState.selectedYear}년 ${getMonthName(yearMonthState.selectedMonth)}"
+                            val selectedMonthDate = yearMonthState.selectedMonthDate
+                            selectedDateText = "${selectedMonthDate.year}년 ${
+                                getMonthName(selectedMonthDate.month.number)
+                            }"
                             scope.launch {
                                 dateSheetState.hide()
                                 showDateBottomSheet = false
@@ -337,12 +333,7 @@ internal fun BottomSheetSampleScreen(
 
                     Button(
                         onClick = {
-                            // Update selected time
-                            selectedTimeText = formatTime12(
-                                timeState.selectedHour,
-                                timeState.selectedMinute,
-                                timeState.selectedPeriod
-                            )
+                            selectedTimeText = formatTime12(timeState.selectedTime)
                             scope.launch {
                                 timeSheetState.hide()
                                 showTimeBottomSheet = false

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -114,9 +114,7 @@ fun DatePickerSampleScreen(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                            text = "${state.selectedYear}-${
-                                state.selectedMonth.toString().padStart(2, '0')
-                            }-${state.selectedDay.toString().padStart(2, '0')}",
+                            text = state.selectedDate.toString(),
                             style = MaterialTheme.typography.headlineSmall,
                             color = MaterialTheme.colorScheme.onSecondaryContainer
                         )

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -85,21 +85,9 @@ internal fun TimePickerSampleScreen(
     val selectedTimeText by remember {
         derivedStateOf {
             if (selectedFormat == 0) {
-                val hour12 = timeState12.selectedHour // (1 ~ 12)
-                val minute = timeState12.selectedMinute
-                val isAm = timeState12.selectedPeriod == TimePeriod.AM
-
-                val hour24 = when {
-                    isAm && hour12 == 12 -> 0    // 12:xx AM (midnight) -> 0
-                    !isAm && hour12 != 12 -> hour12 + 12 // 1:xx PM (13) ~ 11:xx PM (23)
-                    else -> hour12               // 1:xx AM (1) ~ 11:xx AM (11), 12:xx PM (12)
-                }
-                val time = LocalTime(hour24, minute)
-                time.format(ktxTimeFormat12)
-
+                timeState12.selectedTime.format(ktxTimeFormat12)
             } else {
-                val time = LocalTime(timeState24.selectedHour, timeState24.selectedMinute)
-                time.format(ktxTimeFormat24)
+                timeState24.selectedTime.format(ktxTimeFormat24)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Add typed state values: TimePickerState.selectedTime, selectedHourOfDay, DatePickerState.selectedDate, YearMonthPickerState.selectedMonthDate
- Make specialized picker states saveable with stable Saver payloads
- Update samples and README docs for the new state API and bump version to 0.6.0
- Add AGENTS.md maintainer workflow guidance for feature branches and review loops

## Verification
- ./gradlew :datetimepicker:check --no-daemon
- ./gradlew :sample:assembleDebug --no-daemon
- ./gradlew :sample:wasmJsBrowserDistribution --no-daemon
- ./gradlew :sample:compileKotlinIosSimulatorArm64 --no-daemon
- ./gradlew printVersion --no-daemon
- git diff --check

## Review loop
- Ran six-agent review for API safety, MPP saveable behavior, tests, Android UX, date/time correctness, and PR hygiene
- Fixed feedback around enum Saver payloads, invalid initial hour handling, save/restore tests, BottomSheet sample usage, README API classification, and versioning