### PR TITLE
Validate picker item ranges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - After a substantial implementation step, run a six-agent feedback loop when the maintainer asks for autonomous improvement work: collect feedback, fix actionable issues, verify again, then open or update the PR.
 - Merge PRs only after relevant local verification and GitHub Actions checks pass.
 - Keep improving toward Android developer ergonomics first: state APIs, sample usability, documentation clarity, accessibility, and predictable behavior in real app lifecycles.
+- When public picker APIs accept custom item lists, validate value ranges before composing the underlying `Picker`. Prefer normalizing a valid-but-missing current state value through existing picker behavior over crashing during composition.
+- When public validation rules change, update KDoc plus `README.md` and `README_KO.md` in the same PR, including failure mode and normalization behavior.
 - Keep repository guidance up to date in this `AGENTS.md` when the maintainer gives durable process feedback.
 - Do not include local agent/tooling folders such as `.agents/` or `.claude/` in product PRs unless the change is explicitly about agent workflow assets.
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,9 @@ fun BottomSheetPickerExample() {
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberTimePickerState()` |
 | `startTime` | Legacy initial time parameter. Prefer setting initial values in `rememberTimePickerState`. | `currentDateTime()` |
-| `minuteItems` | Minute values available for selection. | `0..59` |
-| `hourItems` | Hour values available for selection. | `0..23` or `1..12` |
+| `minuteItems` | Minute values available for selection. Values must be in `0..59`. | `0..59` |
+| `hourItems` | Hour values available for selection. Values must be in `0..23` for 24-hour time or display-hour `1..12` for 12-hour time. | `0..23` or `1..12` |
+| `periodItems` | AM/PM values available in 12-hour time. Must not be empty when `timeFormat` is `HOUR_12`. | `TimePeriod.entries` |
 | `visibleItemsCount` | Number of items visible in the list. | `3` |
 | `colors` | Colors for text, selected text, dividers, and selected item background. | `PickerDefaults.colors()` |
 | `textStyles` | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
@@ -210,14 +211,16 @@ fun BottomSheetPickerExample() {
 
 `rememberTimePickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
+Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored selection is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state. In 12-hour mode, `hourItems` uses display-hour values (`1..12`): `initialHour = 13` becomes `state.selectedHour == 1` with `PM`.
+
 ### DatePicker
 
 | Parameter           | Description                             | Default                     |
 |:--------------------|:----------------------------------------|:----------------------------|
 | `state`             | The state object to control the picker. | `rememberDatePickerState()` |
 | `startLocalDate`    | Legacy initial date parameter. Prefer setting initial values in `rememberDatePickerState`. | `currentDate()`             |
-| `yearItems`         | List of years available for selection.  | `1000..9999`                |
-| `monthItems`        | List of months available for selection. | `1..12`                     |
+| `yearItems`         | List of years available for selection. Values must be in `1000..9999`. | `1000..9999`                |
+| `monthItems`        | List of months available for selection. Values must be in `1..12`. | `1..12`                     |
 | `visibleItemsCount` | Number of items visible in the list.    | `3`                         |
 | `colors`            | Colors for text, selected text, dividers, and selected item background. | `PickerDefaults.colors()` |
 | `textStyles`        | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
@@ -232,14 +235,16 @@ fun BottomSheetPickerExample() {
 
 `rememberDatePickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
+Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
+
 ### YearMonthPicker
 
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberYearMonthPickerState()` |
 | `startLocalDate` | Legacy initial date parameter. Prefer setting initial values in `rememberYearMonthPickerState`. | `currentDate()` |
-| `yearItems` | List of years available for selection. | `1000..9999` |
-| `monthItems` | List of months available for selection. | `1..12` |
+| `yearItems` | List of years available for selection. Values must be in `1000..9999`. | `1000..9999` |
+| `monthItems` | List of months available for selection. Values must be in `1..12`. | `1..12` |
 | `visibleItemsCount` | Number of items visible in the list. | `3` |
 | `colors` | Colors for text, selected text, dividers, and selected item background. | `PickerDefaults.colors()` |
 | `textStyles` | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
@@ -251,6 +256,8 @@ fun BottomSheetPickerExample() {
 - `selectedMonthDate`: The selected year/month represented as the first day of that month.
 
 `rememberYearMonthPickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
+
+Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
 
 ## License
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -188,8 +188,9 @@ fun BottomSheetPickerExample() {
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberTimePickerState()` |
 | `startTime` | 레거시 초기 시간 파라미터입니다. 초기값은 `rememberTimePickerState`에서 설정하는 방식을 권장합니다. | `currentDateTime()` |
-| `minuteItems` | 선택 가능한 분 목록입니다. | `0..59` |
-| `hourItems` | 선택 가능한 시간 목록입니다. | `0..23` 또는 `1..12` |
+| `minuteItems` | 선택 가능한 분 목록입니다. 값은 `0..59` 범위여야 합니다. | `0..59` |
+| `hourItems` | 선택 가능한 시간 목록입니다. 24시간 형식에서는 `0..23`, 12시간 형식에서는 표시 시간 기준 `1..12` 범위여야 합니다. | `0..23` 또는 `1..12` |
+| `periodItems` | 12시간 형식에서 선택 가능한 오전/오후 목록입니다. `timeFormat`이 `HOUR_12`일 때 비어 있으면 안 됩니다. | `TimePeriod.entries` |
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 | `colors` | 텍스트, 선택 텍스트, 구분선, 선택 영역 배경 색상입니다. | `PickerDefaults.colors()` |
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
@@ -205,14 +206,16 @@ fun BottomSheetPickerExample() {
 
 `rememberTimePickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
+custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 선택값이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다. 12시간 형식의 `hourItems`는 표시 시간 기준(`1..12`)입니다. 예를 들어 `initialHour = 13`은 `state.selectedHour == 1`, `PM`으로 변환됩니다.
+
 ### DatePicker
 
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberDatePickerState()` |
 | `startLocalDate` | 레거시 초기 날짜 파라미터입니다. 초기값은 `rememberDatePickerState`에서 설정하는 방식을 권장합니다. | `currentDate()` |
-| `yearItems` | 선택 가능한 연도 목록입니다. | `1000..9999` |
-| `monthItems` | 선택 가능한 월 목록입니다. | `1..12` |
+| `yearItems` | 선택 가능한 연도 목록입니다. 값은 `1000..9999` 범위여야 합니다. | `1000..9999` |
+| `monthItems` | 선택 가능한 월 목록입니다. 값은 `1..12` 범위여야 합니다. | `1..12` |
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 | `colors` | 텍스트, 선택 텍스트, 구분선, 선택 영역 배경 색상입니다. | `PickerDefaults.colors()` |
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
@@ -227,14 +230,16 @@ fun BottomSheetPickerExample() {
 
 `rememberDatePickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
+custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
+
 ### YearMonthPicker
 
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberYearMonthPickerState()` |
 | `startLocalDate` | 레거시 초기 날짜 파라미터입니다. 초기값은 `rememberYearMonthPickerState`에서 설정하는 방식을 권장합니다. | `currentDate()` |
-| `yearItems` | 선택 가능한 연도 목록입니다. | `1000..9999` |
-| `monthItems` | 선택 가능한 월 목록입니다. | `1..12` |
+| `yearItems` | 선택 가능한 연도 목록입니다. 값은 `1000..9999` 범위여야 합니다. | `1000..9999` |
+| `monthItems` | 선택 가능한 월 목록입니다. 값은 `1..12` 범위여야 합니다. | `1..12` |
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 | `colors` | 텍스트, 선택 텍스트, 구분선, 선택 영역 배경 색상입니다. | `PickerDefaults.colors()` |
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
@@ -246,6 +251,8 @@ fun BottomSheetPickerExample() {
 - `selectedMonthDate`: 선택된 연/월을 해당 월의 1일 `LocalDate`로 제공합니다.
 
 `rememberYearMonthPickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
+
+custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
 
 ## 라이선스
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -70,8 +70,9 @@ fun rememberYearMonthPickerState(
  * Manages the state of the year and month pickers.
  * Internal picker states are not directly accessible to prevent inconsistent state modifications.
  *
- * @param initialYear The initial year to be selected.
+ * @param initialYear The initial year to be selected. Must be in 1000..9999.
  * @param initialMonth The initial month to be selected.
+ * @throws IllegalArgumentException if [initialYear] or [initialMonth] is outside the supported range.
  */
 @Stable
 class YearMonthPickerState(
@@ -82,6 +83,9 @@ class YearMonthPickerState(
     internal val monthState = PickerState(initialMonth)
 
     init {
+        require(initialYear in 1000..9999) {
+            "initialYear must be in range [1000, 9999], but was $initialYear"
+        }
         require(initialMonth in 1..12) {
             "initialMonth must be in range [1, 12], but was $initialMonth"
         }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -32,8 +32,8 @@ import kotlinx.datetime.LocalDate
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
  * @param startLocalDate Legacy initial date parameter. Prefer setting initial values in [state].
- * @param yearItems The list of year values to display.
- * @param monthItems The list of month values to display.
+ * @param yearItems The list of year values to display. Must contain values in 1000..9999.
+ * @param monthItems The list of month values to display. Must contain values in 1..12.
  * @param visibleItemsCount The number of items visible at once.
  * @param colors The colors used by the picker. See [PickerDefaults.colors].
  * @param textStyles The text styles used by the picker. See [PickerDefaults.textStyles].
@@ -46,6 +46,7 @@ import kotlinx.datetime.LocalDate
  * @param dividerShape The shape of the dividers.
  * @param spacingBetweenPickers The spacing between the pickers.
  * @param isDividerVisible Whether the divider should be visible.
+ * @throws IllegalArgumentException if custom item lists are empty or contain values outside the supported ranges.
  */
 @Composable
 fun DatePicker(
@@ -68,6 +69,12 @@ fun DatePicker(
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
     isDividerVisible: Boolean = true
 ) {
+    validateDatePickerItems(
+        state = state,
+        yearItems = yearItems,
+        monthItems = monthItems
+    )
+
     // Validate state whenever year or month changes to ensure day is within range
     LaunchedEffect(state.selectedYear, state.selectedMonth) {
         state.validate()
@@ -160,6 +167,31 @@ fun DatePicker(
 
 private fun <T> List<T>.startIndexOf(item: T): Int =
     indexOf(item).takeIf { it >= 0 } ?: 0
+
+internal fun validateDatePickerItems(
+    state: DatePickerState,
+    yearItems: List<Int>,
+    monthItems: List<Int>
+) {
+    val yearRange = 1000..9999
+    val monthRange = 1..12
+    val invalidYears = yearItems.invalidValuesFor(yearRange)
+    val invalidMonths = monthItems.invalidValuesFor(monthRange)
+
+    require(yearItems.isNotEmpty()) { "DatePicker yearItems must not be empty." }
+    require(monthItems.isNotEmpty()) { "DatePicker monthItems must not be empty." }
+    require(invalidYears.isEmpty()) {
+        "DatePicker yearItems must contain only values in range [1000, 9999]. " +
+                "Invalid values: $invalidYears"
+    }
+    require(invalidMonths.isEmpty()) {
+        "DatePicker monthItems must contain only values in range [1, 12]. " +
+                "Invalid values: $invalidMonths"
+    }
+}
+
+private fun List<Int>.invalidValuesFor(range: IntRange): List<Int> =
+    filterNot { it in range }.distinct()
 
 @Preview(name = "Default", group = "DatePicker", showBackground = true)
 @Composable

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -36,9 +36,10 @@ fun rememberDatePickerState(
  * Automatically adjusts the selected day if it exceeds the maximum valid day for the new year/month.
  * Internal picker states are not directly accessible to prevent inconsistent state modifications.
  *
- * @param initialYear The initial year to be selected.
+ * @param initialYear The initial year to be selected. Must be in 1000..9999.
  * @param initialMonth The initial month to be selected.
  * @param initialDay The initial day to be selected.
+ * @throws IllegalArgumentException if [initialYear], [initialMonth], or [initialDay] is outside the supported range.
  */
 @Stable
 class DatePickerState(
@@ -82,6 +83,9 @@ class DatePickerState(
         get() = daysInMonth(selectedYear, selectedMonth)
 
     init {
+        require(initialYear in 1000..9999) {
+            "initialYear must be in range [1000, 9999], but was $initialYear"
+        }
         require(initialMonth in 1..12) {
             "initialMonth must be in range [1, 12], but was $initialMonth"
         }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -35,8 +35,8 @@ import kotlinx.datetime.number
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
  * @param startLocalDate Legacy initial date parameter. Prefer setting initial values in [state].
- * @param yearItems The list of year values to display.
- * @param monthItems The list of month values to display.
+ * @param yearItems The list of year values to display. Must contain values in 1000..9999.
+ * @param monthItems The list of month values to display. Must contain values in 1..12.
  * @param visibleItemsCount The number of items visible at once.
  * @param colors The colors used by the picker. See [PickerDefaults.colors].
  * @param textStyles The text styles used by the picker. See [PickerDefaults.textStyles].
@@ -49,6 +49,7 @@ import kotlinx.datetime.number
  * @param dividerShape The shape of the dividers.
  * @param spacingBetweenPickers The spacing between the pickers.
  * @param isDividerVisible Whether the divider should be visible.
+ * @throws IllegalArgumentException if custom item lists are empty or contain values outside the supported ranges.
  */
 @Composable
 fun YearMonthPicker(
@@ -71,6 +72,12 @@ fun YearMonthPicker(
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
     isDividerVisible: Boolean = true
 ) {
+    validateYearMonthPickerItems(
+        state = state,
+        yearItems = yearItems,
+        monthItems = monthItems
+    )
+
     Box(modifier = modifier) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -135,6 +142,31 @@ fun YearMonthPicker(
 
 private fun <T> List<T>.startIndexOf(item: T): Int =
     indexOf(item).takeIf { it >= 0 } ?: 0
+
+internal fun validateYearMonthPickerItems(
+    state: YearMonthPickerState,
+    yearItems: List<Int>,
+    monthItems: List<Int>
+) {
+    val yearRange = 1000..9999
+    val monthRange = 1..12
+    val invalidYears = yearItems.invalidValuesFor(yearRange)
+    val invalidMonths = monthItems.invalidValuesFor(monthRange)
+
+    require(yearItems.isNotEmpty()) { "YearMonthPicker yearItems must not be empty." }
+    require(monthItems.isNotEmpty()) { "YearMonthPicker monthItems must not be empty." }
+    require(invalidYears.isEmpty()) {
+        "YearMonthPicker yearItems must contain only values in range [1000, 9999]. " +
+                "Invalid values: $invalidYears"
+    }
+    require(invalidMonths.isEmpty()) {
+        "YearMonthPicker monthItems must contain only values in range [1, 12]. " +
+                "Invalid values: $invalidMonths"
+    }
+}
+
+private fun List<Int>.invalidValuesFor(range: IntRange): List<Int> =
+    filterNot { it in range }.distinct()
 
 @Preview(name = "Default", group = "YearMonthPicker - Basic", showBackground = true)
 @Composable

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -39,9 +39,9 @@ import kotlinx.datetime.LocalDateTime
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
  * @param startTime Legacy initial time parameter. Prefer setting initial values in [state].
- * @param minuteItems The list of minute values to display.
- * @param hourItems The list of hour values to display.
- * @param periodItems The list of period values to display.
+ * @param minuteItems The list of minute values to display. Must contain values in 0..59.
+ * @param hourItems The list of hour values to display. Must contain display-hour values in 1..12 for [TimeFormat.HOUR_12] or 0..23 for [TimeFormat.HOUR_24].
+ * @param periodItems The list of period values to display in [TimeFormat.HOUR_12]. Must not be empty when the picker uses 12-hour time.
  * @param visibleItemsCount The number of items visible at once.
  * @param colors The colors used by the picker. See [PickerDefaults.colors].
  * @param textStyles The text styles used by the picker. See [PickerDefaults.textStyles].
@@ -54,6 +54,7 @@ import kotlinx.datetime.LocalDateTime
  * @param dividerShape The shape of the dividers.
  * @param spacingBetweenPickers The spacing between the pickers.
  * @param isDividerVisible Whether the divider should be visible.
+ * @throws IllegalArgumentException if custom item lists are empty where required or contain values outside the supported ranges.
  */
 @Composable
 fun TimePicker(
@@ -80,6 +81,13 @@ fun TimePicker(
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
     isDividerVisible: Boolean = true
 ) {
+    validateTimePickerItems(
+        state = state,
+        minuteItems = minuteItems,
+        hourItems = hourItems,
+        periodItems = periodItems
+    )
+
     Box(modifier = modifier) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -170,6 +178,39 @@ fun TimePicker(
 
 private fun <T> List<T>.startIndexOf(item: T): Int =
     indexOf(item).takeIf { it >= 0 } ?: 0
+
+internal fun validateTimePickerItems(
+    state: TimePickerState,
+    minuteItems: List<Int>,
+    hourItems: List<Int>,
+    periodItems: List<TimePeriod>
+) {
+    val minuteRange = 0..59
+    val invalidMinutes = minuteItems.invalidValuesFor(minuteRange)
+    require(minuteItems.isNotEmpty()) { "TimePicker minuteItems must not be empty." }
+    require(invalidMinutes.isEmpty()) {
+        "TimePicker minuteItems must contain only values in range [0, 59]. " +
+                "Invalid values: $invalidMinutes"
+    }
+
+    val hourRange = if (state.timeFormat == TimeFormat.HOUR_12) 1..12 else 0..23
+    val hourRangeLabel = if (state.timeFormat == TimeFormat.HOUR_12) "1, 12" else "0, 23"
+    val invalidHours = hourItems.invalidValuesFor(hourRange)
+    require(hourItems.isNotEmpty()) { "TimePicker hourItems must not be empty." }
+    require(invalidHours.isEmpty()) {
+        "TimePicker hourItems must contain only values in range [$hourRangeLabel] " +
+                "for timeFormat=${state.timeFormat}. Invalid values: $invalidHours"
+    }
+
+    if (state.timeFormat == TimeFormat.HOUR_12) {
+        require(periodItems.isNotEmpty()) {
+            "TimePicker periodItems must not be empty for timeFormat=${TimeFormat.HOUR_12}."
+        }
+    }
+}
+
+private fun List<Int>.invalidValuesFor(range: IntRange): List<Int> =
+    filterNot { it in range }.distinct()
 
 @Preview(name = "24-Hour Format", group = "TimePicker - Formats", showBackground = true)
 @Composable

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -1,12 +1,14 @@
 package com.kez.picker
 
 import androidx.compose.runtime.saveable.SaverScope
+import com.kez.picker.time.validateTimePickerItems
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
 import kotlinx.datetime.LocalTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /**
  * Unit tests for [TimePickerState] class.
@@ -245,6 +247,236 @@ class TimePickerStateTest {
                 timeFormat = TimeFormat.HOUR_12
             )
         }
+    }
+
+    @Test
+    fun validateTimePickerItems_allowsCurrentSelection() {
+        val state = TimePickerState(
+            initialHour = 14,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        validateTimePickerItems(
+            state = state,
+            minuteItems = listOf(0, 15, 30, 45),
+            hourItems = (9..18).toList(),
+            periodItems = emptyList()
+        )
+    }
+
+    @Test
+    fun validateTimePickerItems_allows12HourCurrentSelection() {
+        val state = TimePickerState(
+            initialHour = 11,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        validateTimePickerItems(
+            state = state,
+            minuteItems = listOf(0, 15, 30, 45),
+            hourItems = listOf(9, 10, 11, 12),
+            periodItems = TimePeriod.entries
+        )
+    }
+
+    @Test
+    fun validateTimePickerItems_allowsMinuteItemsMissingCurrentSelection() {
+        val state = TimePickerState(
+            initialHour = 14,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        validateTimePickerItems(
+            state = state,
+            minuteItems = listOf(0, 15, 45),
+            hourItems = (9..18).toList(),
+            periodItems = emptyList()
+        )
+    }
+
+    @Test
+    fun validateTimePickerItems_allowsHourItemsMissingCurrentSelection() {
+        val state = TimePickerState(
+            initialHour = 14,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        validateTimePickerItems(
+            state = state,
+            minuteItems = listOf(0, 15, 30, 45),
+            hourItems = listOf(9, 10, 11, 12, 13),
+            periodItems = emptyList()
+        )
+    }
+
+    @Test
+    fun validateTimePickerItems_allowsBoundaryValues() {
+        val state24 = TimePickerState(
+            initialHour = 23,
+            initialMinute = 59,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+        val state12 = TimePickerState(
+            initialHour = 12,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        validateTimePickerItems(
+            state = state24,
+            minuteItems = listOf(0, 59),
+            hourItems = listOf(0, 23),
+            periodItems = emptyList()
+        )
+        validateTimePickerItems(
+            state = state12,
+            minuteItems = listOf(0, 59),
+            hourItems = listOf(1, 12),
+            periodItems = TimePeriod.entries
+        )
+    }
+
+    @Test
+    fun validateTimePickerItems_throwsWhenMinuteItemsContainInvalidValue() {
+        val state = TimePickerState(
+            initialHour = 14,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            validateTimePickerItems(
+                state = state,
+                minuteItems = listOf(-1, 0, 30, 60),
+                hourItems = (9..18).toList(),
+                periodItems = emptyList()
+            )
+        }
+
+        assertTrue(exception.message.orEmpty().contains("Invalid values: [-1, 60]"))
+    }
+
+    @Test
+    fun validateTimePickerItems_throwsWhenHourItemsContainInvalid12HourValue() {
+        val state = TimePickerState(
+            initialHour = 11,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            validateTimePickerItems(
+                state = state,
+                minuteItems = (0..59).toList(),
+                hourItems = listOf(0, 1, 2, 11),
+                periodItems = TimePeriod.entries
+            )
+        }
+    }
+
+    @Test
+    fun validateTimePickerItems_throwsWhenHourItemsContainInvalid24HourValue() {
+        val state = TimePickerState(
+            initialHour = 14,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            validateTimePickerItems(
+                state = state,
+                minuteItems = (0..59).toList(),
+                hourItems = listOf(-1, 0, 14, 24),
+                periodItems = emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun validateTimePickerItems_throwsWhenMinuteItemsAreEmpty() {
+        val state = TimePickerState(
+            initialHour = 14,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            validateTimePickerItems(
+                state = state,
+                minuteItems = emptyList(),
+                hourItems = (9..18).toList(),
+                periodItems = emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun validateTimePickerItems_throwsWhenHourItemsAreEmpty() {
+        val state = TimePickerState(
+            initialHour = 14,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            validateTimePickerItems(
+                state = state,
+                minuteItems = (0..59).toList(),
+                hourItems = emptyList(),
+                periodItems = emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun validateTimePickerItems_throwsWhen12HourPeriodItemsAreEmpty() {
+        val state = TimePickerState(
+            initialHour = 11,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            validateTimePickerItems(
+                state = state,
+                minuteItems = (0..59).toList(),
+                hourItems = (1..12).toList(),
+                periodItems = emptyList()
+            )
+        }
+    }
+
+    @Test
+    fun validateTimePickerItems_allowsPeriodItemsMissingCurrentSelection() {
+        val state = TimePickerState(
+            initialHour = 11,
+            initialMinute = 30,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        validateTimePickerItems(
+            state = state,
+            minuteItems = (0..59).toList(),
+            hourItems = (1..12).toList(),
+            periodItems = listOf(TimePeriod.AM)
+        )
     }
 
     // ==================== State Independence Tests ====================

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -1,6 +1,7 @@
 package com.kez.picker
 
 import androidx.compose.runtime.saveable.SaverScope
+import com.kez.picker.date.validateYearMonthPickerItems
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -75,6 +76,46 @@ class YearMonthPickerStateTest {
     }
 
     @Test
+    fun yearMonthPickerState_minimumYear_isCorrect() {
+        val state = YearMonthPickerState(
+            initialYear = 1000,
+            initialMonth = 1
+        )
+
+        assertEquals(1000, state.selectedYear)
+    }
+
+    @Test
+    fun yearMonthPickerState_maximumYear_isCorrect() {
+        val state = YearMonthPickerState(
+            initialYear = 9999,
+            initialMonth = 12
+        )
+
+        assertEquals(9999, state.selectedYear)
+    }
+
+    @Test
+    fun yearMonthPickerState_yearBelowRange_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            YearMonthPickerState(
+                initialYear = 999,
+                initialMonth = 1
+            )
+        }
+    }
+
+    @Test
+    fun yearMonthPickerState_yearAboveRange_throws() {
+        assertFailsWith<IllegalArgumentException> {
+            YearMonthPickerState(
+                initialYear = 10000,
+                initialMonth = 1
+            )
+        }
+    }
+
+    @Test
     fun yearMonthPickerState_currentYear_isCorrect() {
         val state = YearMonthPickerState(
             initialYear = 2025,
@@ -144,6 +185,94 @@ class YearMonthPickerStateTest {
         assertEquals(2026, restored.selectedYear)
         assertEquals(12, restored.selectedMonth)
         assertEquals(LocalDate(2026, 12, 1), restored.selectedMonthDate)
+    }
+
+    @Test
+    fun validateYearMonthPickerItems_allowsCurrentSelection() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 6
+        )
+
+        validateYearMonthPickerItems(
+            state = state,
+            yearItems = (2020..2030).toList(),
+            monthItems = listOf(3, 6, 9, 12)
+        )
+    }
+
+    @Test
+    fun validateYearMonthPickerItems_allowsYearItemsMissingCurrentSelection() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 6
+        )
+
+        validateYearMonthPickerItems(
+            state = state,
+            yearItems = (2025..2030).toList(),
+            monthItems = listOf(3, 6, 9, 12)
+        )
+    }
+
+    @Test
+    fun validateYearMonthPickerItems_throwsWhenMonthItemsContainInvalidValue() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 6
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            validateYearMonthPickerItems(
+                state = state,
+                yearItems = (2020..2030).toList(),
+                monthItems = listOf(0, 6, 13)
+            )
+        }
+    }
+
+    @Test
+    fun validateYearMonthPickerItems_allowsMonthItemsMissingCurrentSelection() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 6
+        )
+
+        validateYearMonthPickerItems(
+            state = state,
+            yearItems = (2020..2030).toList(),
+            monthItems = listOf(3, 9, 12)
+        )
+    }
+
+    @Test
+    fun validateYearMonthPickerItems_allowsBoundaryValues() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 6
+        )
+
+        validateYearMonthPickerItems(
+            state = state,
+            yearItems = listOf(1000, 9999),
+            monthItems = listOf(1, 12)
+        )
+    }
+
+    @Test
+    fun validateYearMonthPickerItems_throwsWhenYearItemsContainInvalidValue() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 6
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            validateYearMonthPickerItems(
+                state = state,
+                yearItems = listOf(999, 2024, 10000),
+                monthItems = listOf(3, 6, 9, 12)
+            )
+        }
     }
 
     // ==================== State Independence Tests ====================

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -72,6 +72,16 @@ class DatePickerStateTest {
     }
 
     @Test
+    fun testInitialYear_Throws_WhenOutOfRange() {
+        assertFailsWith<IllegalArgumentException> {
+            DatePickerState(initialYear = 999, initialMonth = 1, initialDay = 1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            DatePickerState(initialYear = 10000, initialMonth = 1, initialDay = 1)
+        }
+    }
+
+    @Test
     fun testInitialDay_Throws_WhenLessThanOne() {
         assertFailsWith<IllegalArgumentException> {
             DatePickerState(initialYear = 2024, initialMonth = 1, initialDay = 0)
@@ -111,6 +121,76 @@ class DatePickerStateTest {
         assertEquals(2, restored.selectedMonth)
         assertEquals(28, restored.selectedDay)
         assertEquals(LocalDate(2026, 2, 28), restored.selectedDate)
+    }
+
+    @Test
+    fun testValidateDatePickerItems_AllowsCurrentSelection() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 6, initialDay = 15)
+
+        validateDatePickerItems(
+            state = state,
+            yearItems = (2020..2030).toList(),
+            monthItems = listOf(3, 6, 9, 12)
+        )
+    }
+
+    @Test
+    fun testValidateDatePickerItems_AllowsYearItemsMissingCurrentSelection() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 6, initialDay = 15)
+
+        validateDatePickerItems(
+            state = state,
+            yearItems = (2026..2030).toList(),
+            monthItems = listOf(3, 6, 9, 12)
+        )
+    }
+
+    @Test
+    fun testValidateDatePickerItems_ThrowsWhenMonthItemsContainInvalidValue() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 6, initialDay = 15)
+
+        assertFailsWith<IllegalArgumentException> {
+            validateDatePickerItems(
+                state = state,
+                yearItems = (2020..2030).toList(),
+                monthItems = listOf(6, 13)
+            )
+        }
+    }
+
+    @Test
+    fun testValidateDatePickerItems_AllowsMonthItemsMissingCurrentSelection() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 6, initialDay = 15)
+
+        validateDatePickerItems(
+            state = state,
+            yearItems = (2020..2030).toList(),
+            monthItems = listOf(3, 9, 12)
+        )
+    }
+
+    @Test
+    fun testValidateDatePickerItems_AllowsBoundaryValues() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 6, initialDay = 15)
+
+        validateDatePickerItems(
+            state = state,
+            yearItems = listOf(1000, 9999),
+            monthItems = listOf(1, 12)
+        )
+    }
+
+    @Test
+    fun testValidateDatePickerItems_ThrowsWhenYearItemsContainInvalidValue() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 6, initialDay = 15)
+
+        assertFailsWith<IllegalArgumentException> {
+            validateDatePickerItems(
+                state = state,
+                yearItems = listOf(999, 2025, 10000),
+                monthItems = listOf(3, 6, 9, 12)
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- validate custom picker item values before composing TimePicker, DatePicker, and YearMonthPicker
- add year range validation to date state objects so typed LocalDate values stay safe
- document custom item constraints and normalization behavior in README, README_KO, KDoc, and AGENTS.md
- expand common tests for validator boundaries and state year validation

## Review loop
- Ran six sub-agent reviews for this step.
- Addressed findings around 12-hour display-hour wording, year validation, missing-state normalization, docs, and boundary coverage.
- Left version unchanged because this PR is not a release cut; bump before Maven Central publish if this ships after 0.6.0.

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- ./gradlew :datetimepicker:check :sample:assembleDebug --no-daemon
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced validation for date/time picker components with stricter constraints on custom item lists; invalid values now throw exceptions during composition.
  * Improved state normalization when custom selections don't match provided item lists.

* **Documentation**
  * Updated API documentation with explicit value range requirements and error behavior for all picker components.
  * Added maintenance guidelines for validation and documentation consistency.

* **Tests**
  * Added comprehensive test coverage for validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->