### PR TITLE
feat: add initial value state overloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - Keep improving toward Android developer ergonomics first: state APIs, sample usability, documentation clarity, accessibility, and predictable behavior in real app lifecycles.
 - When public picker APIs accept custom item lists, validate value ranges before composing the underlying `Picker`. Prefer normalizing a valid-but-missing current state value through existing picker behavior over crashing during composition.
 - When public validation rules change, update KDoc plus `README.md` and `README_KO.md` in the same PR, including failure mode and normalization behavior.
+- Do not repurpose legacy `startTime` or `startLocalDate` component parameters for new initialization behavior. Preserve source compatibility, document that they are compatibility no-ops, and prefer explicit `remember*State` overloads for initial values.
+- Treat `remember*State` initial parameters as first-composition defaults. Avoid resetting picker state from changing clock/date expressions during recomposition unless the API explicitly models a reset, and keep internal picker scroll state/effects keyed with state resets.
 - Keep repository guidance up to date in this `AGENTS.md` when the maintainer gives durable process feedback.
 - Do not include local agent/tooling folders such as `.agents/` or `.claude/` in product PRs unless the change is explicitly about agent workflow assets.
 

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ Use `TimePicker` for time selection. It supports both 12-hour and 24-hour format
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.time.TimePicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 
 @Composable
 fun TimePicker24hExample() {
+    val initialTime = remember { currentDateTime().time }
     val state = rememberTimePickerState(
-        initialHour = currentHour(),
-        initialMinute = currentMinute(),
+        initialTime = initialTime,
         timeFormat = TimeFormat.HOUR_24
     )
 
@@ -75,18 +75,18 @@ fun TimePicker24hExample() {
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.time.TimePicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 
 @Composable
 fun TimePicker12hExample() {
     // Handling of 12-hour format conversion is now done internally by the state
+    val initialTime = remember { currentDateTime().time }
     val state = rememberTimePickerState(
-        initialHour = currentHour(),
-        initialMinute = currentMinute(),
+        initialTime = initialTime,
         timeFormat = TimeFormat.HOUR_12
     )
 
@@ -105,17 +105,16 @@ adjusts the day when the selected month changes (e.g., Feb 30 → Feb 28).
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.date.DatePicker
 import com.kez.picker.date.rememberDatePickerState
 import com.kez.picker.util.currentDate
-import com.kez.picker.util.currentMonth
 
 @Composable
 fun DatePickerExample() {
+    val initialDate = remember { currentDate() }
     val state = rememberDatePickerState(
-        initialYear = currentDate().year,
-        initialMonth = currentMonth(),
-        initialDay = currentDate().day
+        initialDate = initialDate
     )
 
     DatePicker(
@@ -132,16 +131,16 @@ Use `YearMonthPicker` for selecting a specific month in a year.
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.util.currentDate
-import com.kez.picker.util.currentMonth
 
 @Composable
 fun YearMonthPickerExample() {
+    val initialDate = remember { currentDate() }
     val state = rememberYearMonthPickerState(
-        initialYear = currentDate().year,
-        initialMonth = currentMonth()
+        initialDate = initialDate
     )
 
     YearMonthPicker(
@@ -192,7 +191,7 @@ fun BottomSheetPickerExample() {
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberTimePickerState()` |
-| `startTime` | Legacy initial time parameter. Prefer setting initial values in `rememberTimePickerState`. | `currentDateTime()` |
+| `startTime` | Legacy compatibility parameter. It does not initialize or update `state`, even when `state` is omitted; use `rememberTimePickerState(initialTime = ...)` or explicit initial values instead. | `currentDateTime()` |
 | `minuteItems` | Minute values available for selection. Values must be in `0..59`. | `0..59` |
 | `hourItems` | Hour values available for selection. Values must be in `0..23` for 24-hour time or display-hour `1..12` for 12-hour time. | `0..23` or `1..12` |
 | `periodItems` | AM/PM values available in 12-hour time. Must not be empty when `timeFormat` is `HOUR_12`. | `TimePeriod.entries` |
@@ -211,6 +210,8 @@ fun BottomSheetPickerExample() {
 
 `rememberTimePickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
+For initial values, use either `rememberTimePickerState(initialTime = LocalTime(...))` or the explicit `initialHour`/`initialMinute` parameters. The `startTime` component parameter is retained only for source compatibility and is not used.
+
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored selection is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state. In 12-hour mode, `hourItems` uses display-hour values (`1..12`): `initialHour = 13` becomes `state.selectedHour == 1` with `PM`.
 
 ### DatePicker
@@ -218,7 +219,7 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 | Parameter           | Description                             | Default                     |
 |:--------------------|:----------------------------------------|:----------------------------|
 | `state`             | The state object to control the picker. | `rememberDatePickerState()` |
-| `startLocalDate`    | Legacy initial date parameter. Prefer setting initial values in `rememberDatePickerState`. | `currentDate()`             |
+| `startLocalDate`    | Legacy compatibility parameter. It does not initialize or update `state`, even when `state` is omitted; use `rememberDatePickerState(initialDate = ...)` or explicit initial values instead. | `currentDate()`             |
 | `yearItems`         | List of years available for selection. Values must be in `1000..9999`. | `1000..9999`                |
 | `monthItems`        | List of months available for selection. Values must be in `1..12`. | `1..12`                     |
 | `visibleItemsCount` | Number of items visible in the list.    | `3`                         |
@@ -235,6 +236,8 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 
 `rememberDatePickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
+For initial values, use either `rememberDatePickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth`/`initialDay` parameters. Initial years must be in `1000..9999`. The `startLocalDate` component parameter is retained only for source compatibility and is not used.
+
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
 
 ### YearMonthPicker
@@ -242,7 +245,7 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberYearMonthPickerState()` |
-| `startLocalDate` | Legacy initial date parameter. Prefer setting initial values in `rememberYearMonthPickerState`. | `currentDate()` |
+| `startLocalDate` | Legacy compatibility parameter. It does not initialize or update `state`, even when `state` is omitted; use `rememberYearMonthPickerState(initialDate = ...)` or explicit initial values instead. | `currentDate()` |
 | `yearItems` | List of years available for selection. Values must be in `1000..9999`. | `1000..9999` |
 | `monthItems` | List of months available for selection. Values must be in `1..12`. | `1..12` |
 | `visibleItemsCount` | Number of items visible in the list. | `3` |
@@ -256,6 +259,8 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 - `selectedMonthDate`: The selected year/month represented as the first day of that month.
 
 `rememberYearMonthPickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
+
+For initial values, use either `rememberYearMonthPickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth` parameters. Initial years must be in `1000..9999`. The `startLocalDate` component parameter is retained only for source compatibility and is not used.
 
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -47,17 +47,17 @@ dependencies {
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.time.TimePicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 
 @Composable
 fun TimePicker24hExample() {
+    val initialTime = remember { currentDateTime().time }
     val state = rememberTimePickerState(
-        initialHour = currentHour(),
-        initialMinute = currentMinute(),
+        initialTime = initialTime,
         timeFormat = TimeFormat.HOUR_24
     )
 
@@ -73,18 +73,18 @@ fun TimePicker24hExample() {
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.time.TimePicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 
 @Composable
 fun TimePicker12hExample() {
     // 12시간 형식 변환은 이제 state 내부에서 처리됩니다.
+    val initialTime = remember { currentDateTime().time }
     val state = rememberTimePickerState(
-        initialHour = currentHour(),
-        initialMinute = currentMinute(),
+        initialTime = initialTime,
         timeFormat = TimeFormat.HOUR_12
     )
 
@@ -102,17 +102,16 @@ fun TimePicker12hExample() {
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.date.DatePicker
 import com.kez.picker.date.rememberDatePickerState
 import com.kez.picker.util.currentDate
-import com.kez.picker.util.currentMonth
 
 @Composable
 fun DatePickerExample() {
+    val initialDate = remember { currentDate() }
     val state = rememberDatePickerState(
-        initialYear = currentDate().year,
-        initialMonth = currentMonth(),
-        initialDay = currentDate().day
+        initialDate = initialDate
     )
 
     DatePicker(state = state)
@@ -127,16 +126,16 @@ fun DatePickerExample() {
 
 ```kotlin
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.util.currentDate
-import com.kez.picker.util.currentMonth
 
 @Composable
 fun YearMonthPickerExample() {
+    val initialDate = remember { currentDate() }
     val state = rememberYearMonthPickerState(
-        initialYear = currentDate().year,
-        initialMonth = currentMonth()
+        initialDate = initialDate
     )
 
     YearMonthPicker(
@@ -187,7 +186,7 @@ fun BottomSheetPickerExample() {
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberTimePickerState()` |
-| `startTime` | 레거시 초기 시간 파라미터입니다. 초기값은 `rememberTimePickerState`에서 설정하는 방식을 권장합니다. | `currentDateTime()` |
+| `startTime` | 레거시 호환성 파라미터입니다. `state`를 생략해도 `state`를 초기화하거나 갱신하지 않으므로 `rememberTimePickerState(initialTime = ...)` 또는 명시적인 초기값 파라미터를 사용하세요. | `currentDateTime()` |
 | `minuteItems` | 선택 가능한 분 목록입니다. 값은 `0..59` 범위여야 합니다. | `0..59` |
 | `hourItems` | 선택 가능한 시간 목록입니다. 24시간 형식에서는 `0..23`, 12시간 형식에서는 표시 시간 기준 `1..12` 범위여야 합니다. | `0..23` 또는 `1..12` |
 | `periodItems` | 12시간 형식에서 선택 가능한 오전/오후 목록입니다. `timeFormat`이 `HOUR_12`일 때 비어 있으면 안 됩니다. | `TimePeriod.entries` |
@@ -206,6 +205,8 @@ fun BottomSheetPickerExample() {
 
 `rememberTimePickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
+초기값은 `rememberTimePickerState(initialTime = LocalTime(...))` 또는 `initialHour`/`initialMinute` 파라미터로 설정합니다. 컴포넌트의 `startTime` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
+
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 선택값이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다. 12시간 형식의 `hourItems`는 표시 시간 기준(`1..12`)입니다. 예를 들어 `initialHour = 13`은 `state.selectedHour == 1`, `PM`으로 변환됩니다.
 
 ### DatePicker
@@ -213,7 +214,7 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberDatePickerState()` |
-| `startLocalDate` | 레거시 초기 날짜 파라미터입니다. 초기값은 `rememberDatePickerState`에서 설정하는 방식을 권장합니다. | `currentDate()` |
+| `startLocalDate` | 레거시 호환성 파라미터입니다. `state`를 생략해도 `state`를 초기화하거나 갱신하지 않으므로 `rememberDatePickerState(initialDate = ...)` 또는 명시적인 초기값 파라미터를 사용하세요. | `currentDate()` |
 | `yearItems` | 선택 가능한 연도 목록입니다. 값은 `1000..9999` 범위여야 합니다. | `1000..9999` |
 | `monthItems` | 선택 가능한 월 목록입니다. 값은 `1..12` 범위여야 합니다. | `1..12` |
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
@@ -230,6 +231,8 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 
 `rememberDatePickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
+초기값은 `rememberDatePickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth`/`initialDay` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
+
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
 
 ### YearMonthPicker
@@ -237,7 +240,7 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberYearMonthPickerState()` |
-| `startLocalDate` | 레거시 초기 날짜 파라미터입니다. 초기값은 `rememberYearMonthPickerState`에서 설정하는 방식을 권장합니다. | `currentDate()` |
+| `startLocalDate` | 레거시 호환성 파라미터입니다. `state`를 생략해도 `state`를 초기화하거나 갱신하지 않으므로 `rememberYearMonthPickerState(initialDate = ...)` 또는 명시적인 초기값 파라미터를 사용하세요. | `currentDate()` |
 | `yearItems` | 선택 가능한 연도 목록입니다. 값은 `1000..9999` 범위여야 합니다. | `1000..9999` |
 | `monthItems` | 선택 가능한 월 목록입니다. 값은 `1..12` 범위여야 합니다. | `1..12` |
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
@@ -251,6 +254,8 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 - `selectedMonthDate`: 선택된 연/월을 해당 월의 1일 `LocalDate`로 제공합니다.
 
 `rememberYearMonthPickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
+
+초기값은 `rememberYearMonthPickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
 
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
@@ -115,7 +116,7 @@ fun <T> Picker(
     }
 
     val density = LocalDensity.current
-    val visibleItemsMiddle = remember { visibleItemsCount / 2 }
+    val visibleItemsMiddle = remember(visibleItemsCount) { visibleItemsCount / 2 }
     val scope = rememberCoroutineScope()
 
     val adjustedItems = if (!isInfinity) {
@@ -150,7 +151,9 @@ fun <T> Picker(
         }
     }
 
-    val listState = rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
+    val listState = key(state, listStartIndex, listScrollCount) {
+        rememberLazyListState(initialFirstVisibleItemIndex = listStartIndex)
+    }
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
 
     val textStyle = textStyles.textStyle
@@ -174,7 +177,7 @@ fun <T> Picker(
                 itemPadding.calculateBottomPadding()
     }
 
-    LaunchedEffect(listState) {
+    LaunchedEffect(listState, adjustedItems, visibleItemsMiddle, state) {
         snapshotFlow { listState.firstVisibleItemIndex }
             .mapNotNull { index -> getItem(index + visibleItemsMiddle) }
             .distinctUntilChanged()

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -49,6 +49,7 @@ class PickerState<T>(
 
 /**
  * Creates and remembers a [YearMonthPickerState].
+ * Initial year and month are read when the state is first created.
  *
  * @param initialYear The initial year to be selected. Defaults to the current year.
  * @param initialMonth The initial month to be selected. Defaults to the current month.
@@ -59,9 +60,28 @@ fun rememberYearMonthPickerState(
     initialYear: Int = currentDate().year,
     initialMonth: Int = currentDate().month.number
 ): YearMonthPickerState {
-    return rememberSaveable(initialYear, initialMonth, saver = YearMonthPickerState.Saver) {
-        YearMonthPickerState(initialYear, initialMonth)
+    val rememberedInitialYear = remember { initialYear }
+    val rememberedInitialMonth = remember { initialMonth }
+    return rememberSaveable(saver = YearMonthPickerState.Saver) {
+        YearMonthPickerState(rememberedInitialYear, rememberedInitialMonth)
     }
+}
+
+/**
+ * Creates and remembers a [YearMonthPickerState] from a [LocalDate].
+ *
+ * The day value is ignored because [com.kez.picker.date.YearMonthPicker] only selects year and month.
+ *
+ * @param initialDate The initial date whose year and month should be selected.
+ * @return A [YearMonthPickerState] initialized with the year and month from [initialDate].
+ * @throws IllegalArgumentException if [initialDate]'s year is outside the supported 1000..9999 range.
+ */
+@Composable
+fun rememberYearMonthPickerState(initialDate: LocalDate): YearMonthPickerState {
+    return rememberYearMonthPickerState(
+        initialYear = initialDate.year,
+        initialMonth = initialDate.month.number
+    )
 }
 
 /**
@@ -127,6 +147,7 @@ class YearMonthPickerState(
 
 /**
  * Creates and remembers a [TimePickerState].
+ * Initial time values are read when the state is first created.
  *
  * @param initialHour The initial hour to be selected. Defaults to the current hour.
  * If [timeFormat] is [TimeFormat.HOUR_12], this value is automatically adjusted to the 12-hour format (1-12).
@@ -142,23 +163,47 @@ fun rememberTimePickerState(
     initialPeriod: TimePeriod = if (initialHour >= 12) TimePeriod.PM else TimePeriod.AM,
     timeFormat: TimeFormat = TimeFormat.HOUR_24
 ): TimePickerState {
-    val adjustedHour = remember(initialHour, timeFormat) {
-        initialHourForTimeFormat(initialHour, timeFormat)
+    val rememberedInitialHour = remember { initialHour }
+    val rememberedInitialMinute = remember { initialMinute }
+    val rememberedInitialPeriod = remember { initialPeriod }
+    val adjustedHour = remember(rememberedInitialHour, timeFormat) {
+        initialHourForTimeFormat(rememberedInitialHour, timeFormat)
     }
+    val saver = remember(timeFormat) { timePickerStateSaver(timeFormat) }
     return rememberSaveable(
-        adjustedHour,
-        initialMinute,
-        initialPeriod,
         timeFormat,
-        saver = TimePickerState.Saver
+        saver = saver
     ) {
         TimePickerState(
             initialHour = adjustedHour,
-            initialMinute = initialMinute,
-            initialPeriod = initialPeriod,
+            initialMinute = rememberedInitialMinute,
+            initialPeriod = rememberedInitialPeriod,
             timeFormat = timeFormat,
         )
     }
+}
+
+/**
+ * Creates and remembers a [TimePickerState] from a [LocalTime].
+ *
+ * When [timeFormat] is [TimeFormat.HOUR_12], the hour is converted to the display-hour range (1-12)
+ * and the AM/PM period is derived from [initialTime].
+ *
+ * @param initialTime The initial time to be selected.
+ * @param timeFormat The time format (12-hour or 24-hour). Defaults to [TimeFormat.HOUR_24].
+ * @return A [TimePickerState] initialized from [initialTime].
+ */
+@Composable
+fun rememberTimePickerState(
+    initialTime: LocalTime,
+    timeFormat: TimeFormat = TimeFormat.HOUR_24
+): TimePickerState {
+    return rememberTimePickerState(
+        initialHour = initialTime.hour,
+        initialMinute = initialTime.minute,
+        initialPeriod = if (initialTime.hour >= 12) TimePeriod.PM else TimePeriod.AM,
+        timeFormat = timeFormat
+    )
 }
 
 internal fun initialHourForTimeFormat(initialHour: Int, timeFormat: TimeFormat): Int {
@@ -171,6 +216,21 @@ internal fun initialHourForTimeFormat(initialHour: Int, timeFormat: TimeFormat):
     } else {
         initialHour
     }
+}
+
+private fun timePickerStateSaver(timeFormat: TimeFormat): Saver<TimePickerState, Any> {
+    return listSaver(
+        save = { listOf(it.selectedHourOfDay, it.selectedMinute) },
+        restore = {
+            val restoredHourOfDay = it[0] as Int
+            TimePickerState(
+                initialHour = initialHourForTimeFormat(restoredHourOfDay, timeFormat),
+                initialMinute = it[1] as Int,
+                initialPeriod = if (restoredHourOfDay >= 12) TimePeriod.PM else TimePeriod.AM,
+                timeFormat = timeFormat
+            )
+        }
+    )
 }
 
 /**

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -31,7 +31,8 @@ import kotlinx.datetime.LocalDate
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
- * @param startLocalDate Legacy initial date parameter. Prefer setting initial values in [state].
+ * @param startLocalDate Legacy compatibility parameter. It does not initialize or update [state],
+ * even when [state] is omitted; prefer [rememberDatePickerState] with initial values.
  * @param yearItems The list of year values to display. Must contain values in 1000..9999.
  * @param monthItems The list of month values to display. Must contain values in 1..12.
  * @param visibleItemsCount The number of items visible at once.
@@ -53,6 +54,7 @@ fun DatePicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
     state: DatePickerState = rememberDatePickerState(),
+    @Suppress("UNUSED_PARAMETER")
     startLocalDate: LocalDate = currentDate(),
     yearItems: List<Int> = YEAR_RANGE,
     monthItems: List<Int> = MONTH_RANGE,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -2,6 +2,7 @@ package com.kez.picker.date
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -12,6 +13,7 @@ import kotlinx.datetime.number
 
 /**
  * Creates and remembers a [DatePickerState].
+ * Initial date values are read when the state is first created.
  *
  * @param initialYear The initial year to be selected. Defaults to the current year.
  * @param initialMonth The initial month to be selected. Defaults to the current month.
@@ -24,9 +26,28 @@ fun rememberDatePickerState(
     initialMonth: Int = currentDate().month.number,
     initialDay: Int = currentDate().day
 ): DatePickerState {
-    return rememberSaveable(initialYear, initialMonth, initialDay, saver = DatePickerState.Saver) {
-        DatePickerState(initialYear, initialMonth, initialDay)
+    val rememberedInitialYear = remember { initialYear }
+    val rememberedInitialMonth = remember { initialMonth }
+    val rememberedInitialDay = remember { initialDay }
+    return rememberSaveable(saver = DatePickerState.Saver) {
+        DatePickerState(rememberedInitialYear, rememberedInitialMonth, rememberedInitialDay)
     }
+}
+
+/**
+ * Creates and remembers a [DatePickerState] from a [LocalDate].
+ *
+ * @param initialDate The initial date to be selected.
+ * @return A [DatePickerState] initialized with the year, month, and day from [initialDate].
+ * @throws IllegalArgumentException if [initialDate]'s year is outside the supported 1000..9999 range.
+ */
+@Composable
+fun rememberDatePickerState(initialDate: LocalDate): DatePickerState {
+    return rememberDatePickerState(
+        initialYear = initialDate.year,
+        initialMonth = initialDate.month.number,
+        initialDay = initialDate.day
+    )
 }
 
 /**

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -34,7 +34,8 @@ import kotlinx.datetime.number
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
- * @param startLocalDate Legacy initial date parameter. Prefer setting initial values in [state].
+ * @param startLocalDate Legacy compatibility parameter. It does not initialize or update [state],
+ * even when [state] is omitted; prefer [rememberYearMonthPickerState] with initial values.
  * @param yearItems The list of year values to display. Must contain values in 1000..9999.
  * @param monthItems The list of month values to display. Must contain values in 1..12.
  * @param visibleItemsCount The number of items visible at once.
@@ -56,6 +57,7 @@ fun YearMonthPicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
     state: YearMonthPickerState = rememberYearMonthPickerState(),
+    @Suppress("UNUSED_PARAMETER")
     startLocalDate: LocalDate = currentDate(),
     yearItems: List<Int> = YEAR_RANGE,
     monthItems: List<Int> = MONTH_RANGE,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -38,7 +38,8 @@ import kotlinx.datetime.LocalDateTime
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
- * @param startTime Legacy initial time parameter. Prefer setting initial values in [state].
+ * @param startTime Legacy compatibility parameter. It does not initialize or update [state],
+ * even when [state] is omitted; prefer [rememberTimePickerState] with initial values.
  * @param minuteItems The list of minute values to display. Must contain values in 0..59.
  * @param hourItems The list of hour values to display. Must contain display-hour values in 1..12 for [TimeFormat.HOUR_12] or 0..23 for [TimeFormat.HOUR_24].
  * @param periodItems The list of period values to display in [TimeFormat.HOUR_12]. Must not be empty when the picker uses 12-hour time.
@@ -61,6 +62,7 @@ fun TimePicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
     state: TimePickerState = rememberTimePickerState(),
+    @Suppress("UNUSED_PARAMETER")
     startTime: LocalDateTime = currentDateTime(),
     minuteItems: List<Int> = MINUTE_RANGE,
     hourItems: List<Int> = when (state.timeFormat) {

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
@@ -38,28 +38,21 @@ import com.kez.picker.sample.formatTime12
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.TimePeriod
-import com.kez.picker.util.currentDate
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
-import kotlinx.datetime.number
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun BackgroundStylePickerScreen(
     onBackPressed: () -> Unit = {},
 ) {
+    val now = remember { currentDateTime() }
     val yearMonthState = rememberYearMonthPickerState(
-        initialYear = currentDate().year,
-        initialMonth = currentDate().month.number
+        initialDate = now.date
     )
-    val currentHour = currentHour()
     val timeState = rememberTimePickerState(
-        initialHour = currentHour,
-        initialMinute = currentMinute(),
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        initialTime = now.time,
         timeFormat = TimeFormat.HOUR_12
     )
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
@@ -45,10 +45,8 @@ import com.kez.picker.sample.formatTime12
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDate
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
@@ -61,17 +59,13 @@ import kotlinx.datetime.number
 internal fun BottomSheetSampleScreen(
     onBackPressed: () -> Unit = {},
 ) {
-    val currentDate = currentDate()
+    val currentDate = remember { currentDate() }
+    val currentTime = remember { currentDateTime().time }
     val yearMonthState = rememberYearMonthPickerState(
-        initialYear = currentDate.year,
-        initialMonth = currentDate.month.number
+        initialDate = currentDate
     )
-    val currentHour = currentHour()
-    val currentMinute = currentMinute()
     val timeState = rememberTimePickerState(
-        initialHour = currentHour,
-        initialMinute = currentMinute,
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        initialTime = currentTime,
         timeFormat = TimeFormat.HOUR_12
     )
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
@@ -57,10 +57,7 @@ import com.kez.picker.sample.formatTime12
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.TimePeriod
-import com.kez.picker.util.currentDate
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
@@ -72,18 +69,15 @@ import kotlinx.datetime.number
 internal fun IntegratedPickerScreen(
     onBackPressed: () -> Unit = {},
 ) {
-    val currentDate = currentDate()
-    val currentHour = currentHour()
-    val currentMinute = currentMinute()
+    val now = remember { currentDateTime() }
+    val currentDate = now.date
+    val currentTime = now.time
 
     val yearMonthState = rememberYearMonthPickerState(
-        initialYear = currentDate.year,
-        initialMonth = currentDate.month.number
+        initialDate = currentDate
     )
     val timeState = rememberTimePickerState(
-        initialHour = currentHour,
-        initialMinute = currentMinute,
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        initialTime = currentTime,
         timeFormat = TimeFormat.HOUR_12
     )
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -38,8 +38,7 @@ import com.kez.picker.rememberTimePickerState
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
-import com.kez.picker.util.currentHour
-import com.kez.picker.util.currentMinute
+import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Clock
@@ -54,18 +53,14 @@ internal fun TimePickerSampleScreen(
     onBackPressed: () -> Unit = {},
 ) {
     var selectedFormat by remember { mutableIntStateOf(0) }
-    val currentHour = currentHour()
-    val currentMinute = currentMinute()
+    val currentTime = remember { currentDateTime().time }
 
     val timeState12 = rememberTimePickerState(
-        initialHour = currentHour,
-        initialMinute = currentMinute,
-        initialPeriod = if (currentHour >= 12) TimePeriod.PM else TimePeriod.AM,
+        initialTime = currentTime,
         timeFormat = TimeFormat.HOUR_12
     )
     val timeState24 = rememberTimePickerState(
-        initialHour = currentHour,
-        initialMinute = currentMinute
+        initialTime = currentTime
     )
 
     val ktxTimeFormat12 = LocalTime.Format {

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
@@ -37,17 +37,15 @@ import com.kez.picker.util.currentDate
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
-import kotlinx.datetime.number
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun YearMonthPickerSampleScreen(
     onBackPressed: () -> Unit = {},
 ) {
-    val currentDate = currentDate()
+    val currentDate = remember { currentDate() }
     val state = rememberYearMonthPickerState(
-        initialYear = currentDate.year,
-        initialMonth = currentDate.month.number
+        initialDate = currentDate
     )
 
     // Calculate selected date text


### PR DESCRIPTION
## What changed
- Added `rememberTimePickerState(initialTime = LocalTime(...))`, `rememberDatePickerState(initialDate = LocalDate(...))`, and `rememberYearMonthPickerState(initialDate = LocalDate(...))` overloads.
- Kept legacy `startTime` / `startLocalDate` component parameters source-compatible, but documented them as compatibility no-ops.
- Treated state factory initial values as first-composition defaults so changing clock/date expressions during recomposition does not reset user selections.
- Updated `Picker` scroll state/effect keys so picker scroll state follows state resets and item-list changes more predictably.
- Updated README, README_KO, sample screens, and AGENTS guidance to point Android users toward explicit state initialization.

## Review feedback addressed
- Documented `initialDate` year range failure (`1000..9999`) in KDoc and README docs.
- Replaced sample manual AM/PM calculation with `initialTime` overload usage.
- Captured sample current date/time once with `remember { ... }` to avoid recomposition-time clock drift.
- Used a time-format-aware saveable restore path so the current `timeFormat` parameter wins after restoration.
- Excluded local `.agents/` and `.claude/` tooling folders from the product PR.

## Validation
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon`
- `./gradlew :datetimepicker:check :sample:assembleDebug --no-daemon`
- `git diff --check`
