### PR TITLE
feat: expose picker accessibility descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - When public validation rules change, update KDoc plus `README.md` and `README_KO.md` in the same PR, including failure mode and normalization behavior.
 - Do not repurpose legacy `startTime` or `startLocalDate` component parameters for new initialization behavior. Preserve source compatibility, document that they are compatibility no-ops, and prefer explicit `remember*State` overloads for initial values.
 - Treat `remember*State` initial parameters as first-composition defaults. Avoid resetting picker state from changing clock/date expressions during recomposition unless the API explicitly models a reset, and keep internal picker scroll state/effects keyed with state resets.
+- When higher-level components pass accessibility labels to `Picker`, expose those labels and item content descriptions as public parameters with sensible defaults so Android apps can localize TalkBack output. Update KDoc and both READMEs in the same PR.
 - Keep repository guidance up to date in this `AGENTS.md` when the maintainer gives durable process feedback.
 - Do not include local agent/tooling folders such as `.agents/` or `.claude/` in product PRs unless the change is explicitly about agent workflow assets.
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ fun BottomSheetPickerExample() {
 
 ## API Reference
 
+Accessibility label parameters customize the picker-column prefix used in semantics. `*ItemContentDescription`
+parameters customize the accessibility value text without changing the visual item text. Selection is exposed
+through Compose `selected` semantics rather than appended as a hardcoded English phrase.
+
 ### TimePicker
 
 | Parameter | Description | Default |
@@ -199,6 +203,12 @@ fun BottomSheetPickerExample() {
 | `colors` | Colors for text, selected text, dividers, and selected item background. | `PickerDefaults.colors()` |
 | `textStyles` | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
 | `isDividerVisible` | Whether selection dividers are visible. | `true` |
+| `hourPickerLabel` | Accessibility label for the hour picker. Pass `null` to omit the picker label prefix. | `"Hour"` |
+| `minutePickerLabel` | Accessibility label for the minute picker. Pass `null` to omit the picker label prefix. | `"Minute"` |
+| `periodPickerLabel` | Accessibility label for the AM/PM picker in 12-hour time. Pass `null` to omit the picker label prefix. | `"AM/PM"` |
+| `hourItemContentDescription` | Accessibility description for each hour value. | `it.toString()` |
+| `minuteItemContentDescription` | Accessibility description for each minute value. | `it.toString()` |
+| `periodItemContentDescription` | Accessibility description for each AM/PM value in 12-hour time. | `it.name` |
 
 **TimePickerState Properties:**
 
@@ -225,6 +235,12 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 | `visibleItemsCount` | Number of items visible in the list.    | `3`                         |
 | `colors`            | Colors for text, selected text, dividers, and selected item background. | `PickerDefaults.colors()` |
 | `textStyles`        | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
+| `yearPickerLabel`   | Accessibility label for the year picker. Pass `null` to omit the picker label prefix. | `"Year"` |
+| `monthPickerLabel`  | Accessibility label for the month picker. Pass `null` to omit the picker label prefix. | `"Month"` |
+| `dayPickerLabel`    | Accessibility label for the day picker. Pass `null` to omit the picker label prefix. | `"Day"` |
+| `yearItemContentDescription` | Accessibility description for each year value. | `it.toString()` |
+| `monthItemContentDescription` | Accessibility description for each month value. | `it.toString()` |
+| `dayItemContentDescription` | Accessibility description for each day value. | `it.toString()` |
 
 **DatePickerState Properties:**
 
@@ -251,6 +267,10 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 | `visibleItemsCount` | Number of items visible in the list. | `3` |
 | `colors` | Colors for text, selected text, dividers, and selected item background. | `PickerDefaults.colors()` |
 | `textStyles` | Text styles for selected and unselected items. | `PickerDefaults.textStyles()` |
+| `yearPickerLabel` | Accessibility label for the year picker. Pass `null` to omit the picker label prefix. | `"Year"` |
+| `monthPickerLabel` | Accessibility label for the month picker. Pass `null` to omit the picker label prefix. | `"Month"` |
+| `yearItemContentDescription` | Accessibility description for each year value. | `it.toString()` |
+| `monthItemContentDescription` | Accessibility description for each month value. | `it.toString()` |
 
 **YearMonthPickerState Properties:**
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -181,6 +181,10 @@ fun BottomSheetPickerExample() {
 
 ## API 레퍼런스
 
+접근성 label 파라미터는 semantics에 들어가는 picker column prefix를 바꿉니다. `*ItemContentDescription`
+파라미터는 화면에 보이는 텍스트를 바꾸지 않고 접근성 값 설명만 바꿉니다. 선택 상태는 고정된 영어 문구를
+붙이지 않고 Compose `selected` semantics로 전달됩니다.
+
 ### TimePicker
 
 | 파라미터 | 설명 | 기본값 |
@@ -194,6 +198,12 @@ fun BottomSheetPickerExample() {
 | `colors` | 텍스트, 선택 텍스트, 구분선, 선택 영역 배경 색상입니다. | `PickerDefaults.colors()` |
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
 | `isDividerVisible` | 선택 영역 구분선 표시 여부입니다. | `true` |
+| `hourPickerLabel` | 시간 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Hour"` |
+| `minutePickerLabel` | 분 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Minute"` |
+| `periodPickerLabel` | 12시간 형식에서 오전/오후 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"AM/PM"` |
+| `hourItemContentDescription` | 각 시간 값의 접근성 설명입니다. | `it.toString()` |
+| `minuteItemContentDescription` | 각 분 값의 접근성 설명입니다. | `it.toString()` |
+| `periodItemContentDescription` | 12시간 형식에서 각 오전/오후 값의 접근성 설명입니다. | `it.name` |
 
 **TimePickerState 속성:**
 
@@ -220,6 +230,12 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 | `colors` | 텍스트, 선택 텍스트, 구분선, 선택 영역 배경 색상입니다. | `PickerDefaults.colors()` |
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
+| `yearPickerLabel` | 연도 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Year"` |
+| `monthPickerLabel` | 월 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Month"` |
+| `dayPickerLabel` | 일 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Day"` |
+| `yearItemContentDescription` | 각 연도 값의 접근성 설명입니다. | `it.toString()` |
+| `monthItemContentDescription` | 각 월 값의 접근성 설명입니다. | `it.toString()` |
+| `dayItemContentDescription` | 각 일 값의 접근성 설명입니다. | `it.toString()` |
 
 **DatePickerState 속성:**
 
@@ -246,6 +262,10 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 | `visibleItemsCount` | 리스트에 표시될 아이템의 개수입니다. | `3` |
 | `colors` | 텍스트, 선택 텍스트, 구분선, 선택 영역 배경 색상입니다. | `PickerDefaults.colors()` |
 | `textStyles` | 선택/비선택 아이템의 텍스트 스타일입니다. | `PickerDefaults.textStyles()` |
+| `yearPickerLabel` | 연도 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Year"` |
+| `monthPickerLabel` | 월 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Month"` |
+| `yearItemContentDescription` | 각 연도 값의 접근성 설명입니다. | `it.toString()` |
+| `monthItemContentDescription` | 각 월 값의 접근성 설명입니다. | `it.toString()` |
 
 **YearMonthPickerState 속성:**
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -84,6 +84,7 @@ private const val INFINITE_SCROLL_MULTIPLIER = 1000
  * @param isDividerVisible Whether the divider should be visible.
  * @param isInfinity Whether the picker should loop infinitely.
  * @param pickerLabel Accessibility label for the picker (e.g., "Hour", "Minute", "Year").
+ * @param itemContentDescription Accessibility description for each item value.
  * @param content Optional custom content composable for rendering each item.
  */
 @Composable
@@ -105,6 +106,7 @@ fun <T> Picker(
     isDividerVisible: Boolean = true,
     isInfinity: Boolean = true,
     pickerLabel: String? = null,
+    itemContentDescription: (T) -> String = { it.toString() },
     content: @Composable ((T) -> Unit)? = null
 ) {
     require(items.isNotEmpty()) { "Items list must not be empty" }
@@ -184,12 +186,15 @@ fun <T> Picker(
             .collect { item -> state.selectedItem = item }
     }
 
+    val normalizedPickerLabel = pickerLabel.asAccessibilityLabelOrNull()
+
     Box(
         modifier = modifier.semantics {
             // Provide picker-level accessibility information
-            pickerLabel?.let { label ->
-                contentDescription = "$label picker, currently selected: ${state.selectedItem}"
-                stateDescription = "Selected: ${state.selectedItem}"
+            normalizedPickerLabel?.let { label ->
+                val selectedItemDescription = itemContentDescription(state.selectedItem)
+                contentDescription = accessibilityDescription(label, selectedItemDescription)
+                stateDescription = selectedItemDescription
                 liveRegion = LiveRegionMode.Polite
             }
             collectionInfo = CollectionInfo(rowCount = items.size, columnCount = 1)
@@ -263,7 +268,8 @@ fun <T> Picker(
 
                 val item = getItem(index)
                 val isSelected = item == state.selectedItem
-                val itemDescription = item?.toString() ?: ""
+                val itemText = item?.toString() ?: ""
+                val itemDescription = item?.let(itemContentDescription) ?: ""
                 val itemIndex = if (isInfinity) {
                     index % items.size
                 } else {
@@ -278,11 +284,8 @@ fun <T> Picker(
                             if (item != null) {
                                 role = Role.Button
                                 // Enhanced content description with picker context
-                                contentDescription = if (pickerLabel != null) {
-                                    "$pickerLabel: $itemDescription${if (isSelected) ", selected" else ""}"
-                                } else {
-                                    "$itemDescription${if (isSelected) ", selected" else ""}"
-                                }
+                                contentDescription =
+                                    accessibilityDescription(normalizedPickerLabel, itemDescription)
                                 selected = isSelected
                                 collectionItemInfo = CollectionItemInfo(
                                     rowIndex = itemIndex,
@@ -317,7 +320,7 @@ fun <T> Picker(
                             content(item)
                         } else {
                             Text(
-                                text = itemDescription,
+                                text = itemText,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
                                 style = textStyle.copy(
@@ -339,6 +342,17 @@ fun <T> Picker(
                 }
             }
         }
+    }
+}
+
+private fun String?.asAccessibilityLabelOrNull(): String? =
+    this?.trim()?.takeIf { it.isNotEmpty() }
+
+private fun accessibilityDescription(label: String?, value: String): String {
+    return when {
+        label != null && value.isNotBlank() -> "$label: $value"
+        label != null -> label
+        else -> value
     }
 }
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -47,6 +47,12 @@ import kotlinx.datetime.LocalDate
  * @param dividerShape The shape of the dividers.
  * @param spacingBetweenPickers The spacing between the pickers.
  * @param isDividerVisible Whether the divider should be visible.
+ * @param yearPickerLabel Accessibility label for the year picker. Pass null to omit the picker label prefix.
+ * @param monthPickerLabel Accessibility label for the month picker. Pass null to omit the picker label prefix.
+ * @param dayPickerLabel Accessibility label for the day picker. Pass null to omit the picker label prefix.
+ * @param yearItemContentDescription Accessibility description for each year value.
+ * @param monthItemContentDescription Accessibility description for each month value.
+ * @param dayItemContentDescription Accessibility description for each day value.
  * @throws IllegalArgumentException if custom item lists are empty or contain values outside the supported ranges.
  */
 @Composable
@@ -69,7 +75,13 @@ fun DatePicker(
     dividerThickness: Dp = PickerDefaults.DividerThickness,
     dividerShape: Shape = PickerDefaults.DividerShape,
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
-    isDividerVisible: Boolean = true
+    isDividerVisible: Boolean = true,
+    yearPickerLabel: String? = "Year",
+    monthPickerLabel: String? = "Month",
+    dayPickerLabel: String? = "Day",
+    yearItemContentDescription: (Int) -> String = { it.toString() },
+    monthItemContentDescription: (Int) -> String = { it.toString() },
+    dayItemContentDescription: (Int) -> String = { it.toString() }
 ) {
     validateDatePickerItems(
         state = state,
@@ -119,7 +131,8 @@ fun DatePicker(
                     dividerThickness = dividerThickness,
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
-                    pickerLabel = "Year"
+                    pickerLabel = yearPickerLabel,
+                    itemContentDescription = yearItemContentDescription
                 )
 
                 Picker(
@@ -138,7 +151,8 @@ fun DatePicker(
                     dividerThickness = dividerThickness,
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
-                    pickerLabel = "Month"
+                    pickerLabel = monthPickerLabel,
+                    itemContentDescription = monthItemContentDescription
                 )
 
                 key(maxDay) {
@@ -159,7 +173,8 @@ fun DatePicker(
                         dividerThickness = dividerThickness,
                         dividerShape = dividerShape,
                         isDividerVisible = isDividerVisible,
-                        pickerLabel = "Day"
+                        pickerLabel = dayPickerLabel,
+                        itemContentDescription = dayItemContentDescription
                     )
                 }
             }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -50,6 +50,10 @@ import kotlinx.datetime.number
  * @param dividerShape The shape of the dividers.
  * @param spacingBetweenPickers The spacing between the pickers.
  * @param isDividerVisible Whether the divider should be visible.
+ * @param yearPickerLabel Accessibility label for the year picker. Pass null to omit the picker label prefix.
+ * @param monthPickerLabel Accessibility label for the month picker. Pass null to omit the picker label prefix.
+ * @param yearItemContentDescription Accessibility description for each year value.
+ * @param monthItemContentDescription Accessibility description for each month value.
  * @throws IllegalArgumentException if custom item lists are empty or contain values outside the supported ranges.
  */
 @Composable
@@ -72,7 +76,11 @@ fun YearMonthPicker(
     dividerThickness: Dp = PickerDefaults.DividerThickness,
     dividerShape: Shape = PickerDefaults.DividerShape,
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
-    isDividerVisible: Boolean = true
+    isDividerVisible: Boolean = true,
+    yearPickerLabel: String? = "Year",
+    monthPickerLabel: String? = "Month",
+    yearItemContentDescription: (Int) -> String = { it.toString() },
+    monthItemContentDescription: (Int) -> String = { it.toString() }
 ) {
     validateYearMonthPickerItems(
         state = state,
@@ -117,7 +125,8 @@ fun YearMonthPicker(
                     dividerThickness = dividerThickness,
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
-                    pickerLabel = "Year"
+                    pickerLabel = yearPickerLabel,
+                    itemContentDescription = yearItemContentDescription
                 )
                 Picker(
                     state = state.monthState,
@@ -135,7 +144,8 @@ fun YearMonthPicker(
                     dividerThickness = dividerThickness,
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
-                    pickerLabel = "Month"
+                    pickerLabel = monthPickerLabel,
+                    itemContentDescription = monthItemContentDescription
                 )
             }
         }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -55,6 +55,12 @@ import kotlinx.datetime.LocalDateTime
  * @param dividerShape The shape of the dividers.
  * @param spacingBetweenPickers The spacing between the pickers.
  * @param isDividerVisible Whether the divider should be visible.
+ * @param hourPickerLabel Accessibility label for the hour picker. Pass null to omit the picker label prefix.
+ * @param minutePickerLabel Accessibility label for the minute picker. Pass null to omit the picker label prefix.
+ * @param periodPickerLabel Accessibility label for the AM/PM picker in [TimeFormat.HOUR_12]. Pass null to omit the picker label prefix.
+ * @param hourItemContentDescription Accessibility description for each hour value.
+ * @param minuteItemContentDescription Accessibility description for each minute value.
+ * @param periodItemContentDescription Accessibility description for each AM/PM value in [TimeFormat.HOUR_12].
  * @throws IllegalArgumentException if custom item lists are empty where required or contain values outside the supported ranges.
  */
 @Composable
@@ -81,7 +87,13 @@ fun TimePicker(
     dividerThickness: Dp = PickerDefaults.DividerThickness,
     dividerShape: Shape = PickerDefaults.DividerShape,
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
-    isDividerVisible: Boolean = true
+    isDividerVisible: Boolean = true,
+    hourPickerLabel: String? = "Hour",
+    minutePickerLabel: String? = "Minute",
+    periodPickerLabel: String? = "AM/PM",
+    hourItemContentDescription: (Int) -> String = { it.toString() },
+    minuteItemContentDescription: (Int) -> String = { it.toString() },
+    periodItemContentDescription: (TimePeriod) -> String = { it.name }
 ) {
     validateTimePickerItems(
         state = state,
@@ -132,7 +144,8 @@ fun TimePicker(
                         dividerShape = dividerShape,
                         isDividerVisible = isDividerVisible,
                         isInfinity = false,
-                        pickerLabel = "Period"
+                        pickerLabel = periodPickerLabel,
+                        itemContentDescription = periodItemContentDescription
                     )
                     Spacer(modifier = Modifier.width(spacingBetweenPickers))
                 }
@@ -152,7 +165,8 @@ fun TimePicker(
                     dividerThickness = dividerThickness,
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
-                    pickerLabel = "Hour"
+                    pickerLabel = hourPickerLabel,
+                    itemContentDescription = hourItemContentDescription
                 )
                 Spacer(modifier = Modifier.width(spacingBetweenPickers))
                 Picker(
@@ -171,7 +185,8 @@ fun TimePicker(
                     dividerThickness = dividerThickness,
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
-                    pickerLabel = "Minute"
+                    pickerLabel = minutePickerLabel,
+                    itemContentDescription = minuteItemContentDescription
                 )
             }
         }


### PR DESCRIPTION
## What changed
- Exposed picker accessibility labels on `TimePicker`, `DatePicker`, and `YearMonthPicker` with source-compatible default values.
- Added item accessibility description formatters so apps can localize value output without changing visible item text.
- Removed hardcoded English accessibility phrases from `Picker` semantics and now rely on label/value descriptions plus Compose `selected` semantics.
- Updated README, README_KO, and AGENTS maintainer guidance for accessibility label/value description API changes.

## Review feedback addressed
- `periodPickerLabel` now defaults to `"AM/PM"` and is documented as 12-hour-mode only.
- `null` labels omit only the label prefix, not all item/collection semantics.
- Empty labels are normalized like omitted labels.
- Item value descriptions can be localized through `*ItemContentDescription` lambdas.
- Local `.agents/` and `.claude/` folders remain untracked and excluded.

## Validation
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon`
- `./gradlew :datetimepicker:check :sample:assembleDebug --no-daemon`
- `git diff --check`

## Residual risk
- Semantics behavior is compile-verified and statically reviewed, but this repository still lacks Compose UI/accessibility semantics tests. That should be the next accessibility hardening step.
