### PR TITLE
test: cover picker accessibility descriptions

### DIFF
--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -186,14 +186,14 @@ fun <T> Picker(
             .collect { item -> state.selectedItem = item }
     }
 
-    val normalizedPickerLabel = pickerLabel.asAccessibilityLabelOrNull()
+    val normalizedPickerLabel = pickerLabel.asPickerAccessibilityLabelOrNull()
 
     Box(
         modifier = modifier.semantics {
             // Provide picker-level accessibility information
             normalizedPickerLabel?.let { label ->
                 val selectedItemDescription = itemContentDescription(state.selectedItem)
-                contentDescription = accessibilityDescription(label, selectedItemDescription)
+                contentDescription = pickerAccessibilityDescription(label, selectedItemDescription)
                 stateDescription = selectedItemDescription
                 liveRegion = LiveRegionMode.Polite
             }
@@ -285,7 +285,7 @@ fun <T> Picker(
                                 role = Role.Button
                                 // Enhanced content description with picker context
                                 contentDescription =
-                                    accessibilityDescription(normalizedPickerLabel, itemDescription)
+                                    pickerAccessibilityDescription(normalizedPickerLabel, itemDescription)
                                 selected = isSelected
                                 collectionItemInfo = CollectionItemInfo(
                                     rowIndex = itemIndex,
@@ -345,13 +345,14 @@ fun <T> Picker(
     }
 }
 
-private fun String?.asAccessibilityLabelOrNull(): String? =
+private fun String?.asPickerAccessibilityLabelOrNull(): String? =
     this?.trim()?.takeIf { it.isNotEmpty() }
 
-private fun accessibilityDescription(label: String?, value: String): String {
+internal fun pickerAccessibilityDescription(label: String?, value: String): String {
+    val normalizedLabel = label.asPickerAccessibilityLabelOrNull()
     return when {
-        label != null && value.isNotBlank() -> "$label: $value"
-        label != null -> label
+        normalizedLabel != null && value.isNotBlank() -> "$normalizedLabel: $value"
+        normalizedLabel != null -> normalizedLabel
         else -> value
     }
 }

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerUtilsTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerUtilsTest.kt
@@ -152,4 +152,32 @@ class PickerUtilsTest {
             assertEquals(expected, result, 0.001f, "For input $input, expected $expected but got $result")
         }
     }
+
+    // ==================== Accessibility Description Tests ====================
+
+    @Test
+    fun pickerAccessibilityDescription_combinesNormalizedLabelAndValue() {
+        assertEquals("Hour: 10", pickerAccessibilityDescription("Hour", "10"))
+        assertEquals("Hour: 10", pickerAccessibilityDescription(" Hour ", "10"))
+        assertEquals("시: 10시", pickerAccessibilityDescription("시", "10시"))
+    }
+
+    @Test
+    fun pickerAccessibilityDescription_omitsBlankOrMissingLabel() {
+        assertEquals("10", pickerAccessibilityDescription(null, "10"))
+        assertEquals("10", pickerAccessibilityDescription("", "10"))
+        assertEquals("10", pickerAccessibilityDescription("   ", "10"))
+    }
+
+    @Test
+    fun pickerAccessibilityDescription_usesLabelWhenValueIsBlank() {
+        assertEquals("Hour", pickerAccessibilityDescription("Hour", ""))
+        assertEquals("Hour", pickerAccessibilityDescription("Hour", "   "))
+    }
+
+    @Test
+    fun pickerAccessibilityDescription_preservesValueWhitespaceWhenLabelIsMissing() {
+        assertEquals("", pickerAccessibilityDescription(null, ""))
+        assertEquals("   ", pickerAccessibilityDescription(null, "   "))
+    }
 }


### PR DESCRIPTION
## Summary
- add unit coverage for picker accessibility description formatting
- keep the normalization helper private and expose only the internal description helper needed by common tests
- document the edge cases around blank labels and blank values through tests

## Scope note
This PR does not add Compose semantics or TalkBack instrumentation coverage. It only locks the pure string policy used by the accessibility semantics added in the previous PR.

## Validation
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- ./gradlew :datetimepicker:check :sample:assembleDebug --no-daemon
- git diff --check

## Excluded
- local tooling folders such as .agents/ and .claude/