### PR TITLE
test: add accessibility semantics coverage

### DIFF
--- a/.github/workflows/integration-build-test.yml
+++ b/.github/workflows/integration-build-test.yml
@@ -58,6 +58,7 @@ jobs:
             ${{ env.LIBRARY_MODULE }}:clean \
             ${{ env.LIBRARY_MODULE }}:assembleRelease \
             ${{ env.LIBRARY_MODULE }}:testReleaseUnitTest \
+            ${{ env.LIBRARY_MODULE }}:assembleDebugAndroidTest \
             ${{ env.SAMPLE_MODULE }}:assembleDebug \
             --no-daemon
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,12 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
 ./gradlew :datetimepicker:testReleaseUnitTest --no-daemon
 
+# Compile Android instrumented tests
+./gradlew :datetimepicker:assembleDebugAndroidTest --no-daemon
+
+# Run Android instrumented tests on a connected device or emulator
+./gradlew :datetimepicker:connectedDebugAndroidTest --no-daemon
+
 # Run checks (tests + lint)
 ./gradlew :datetimepicker:check --no-daemon
 
@@ -195,12 +201,14 @@ color = lerp(selectedTextStyle.color, textStyle.color, fraction)
 ## Testing Strategy
 
 **Current coverage** (estimated):
-- Unit tests: picker states, date validation, time calculation, and picker index utility behavior
-- Missing: UI interaction tests, screenshot tests, accessibility behavior tests, and sample smoke tests
+- Unit tests: picker states, date validation, time calculation, picker index utility behavior, and accessibility description formatting
+- Android instrumented tests: picker accessibility semantics for selected values, custom labels, state descriptions, and higher-level picker forwarding
+- Missing: broader UI interaction tests, screenshot tests, full TalkBack/readout validation, and sample smoke tests
 
 **When adding tests**:
 - Unit tests → `datetimepicker/src/commonTest/kotlin/`
-- Android UI tests → add `datetimepicker/src/androidInstrumentedTest/kotlin/` when instrumentation coverage is introduced
+- Android UI/instrumented tests → `datetimepicker/src/androidInstrumentedTest/kotlin/`
+- Use `:datetimepicker:assembleDebugAndroidTest` to verify Android test APK compilation/packaging in CI-friendly environments, and `:datetimepicker:connectedDebugAndroidTest` when a device or emulator is available.
 - Follow naming: `<ComponentName>Test.kt` or `<ComponentName>AndroidTest.kt`
 
 ## Code Style

--- a/datetimepicker/build.gradle.kts
+++ b/datetimepicker/build.gradle.kts
@@ -57,6 +57,12 @@ kotlin {
             implementation(libs.androidx.ui.tooling.preview)
         }
 
+        val androidInstrumentedTest by getting {
+            dependencies {
+                implementation(libs.androidx.uitest.junit4)
+            }
+        }
+
         iosMain.dependencies {
 
         }
@@ -71,6 +77,10 @@ kotlin {
             }
         }
     }
+}
+
+dependencies {
+    debugImplementation(libs.androidx.uitest.testManifest)
 }
 
 android {

--- a/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
+++ b/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
@@ -1,0 +1,224 @@
+package com.kez.picker
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.isSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import com.kez.picker.date.DatePicker
+import com.kez.picker.date.YearMonthPicker
+import com.kez.picker.date.rememberDatePickerState
+import com.kez.picker.time.TimePicker
+import com.kez.picker.util.TimeFormat
+import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalTime
+import org.junit.Rule
+import org.junit.Test
+
+class PickerAccessibilitySemanticsAndroidTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun picker_exposesPickerLabelSelectedValueAndSelectedItemSemantics() {
+        composeRule.setContent {
+            val state = rememberPickerState(10)
+
+            Picker(
+                items = listOf(9, 10, 11),
+                state = state,
+                startIndex = 1,
+                isInfinity = false,
+                pickerLabel = "Hour",
+                itemContentDescription = { "$it" }
+            )
+        }
+
+        composeRule
+            .onNode(hasContentDescription("Hour: 10") and hasStateDescription("10"))
+            .assertExists()
+
+        composeRule
+            .onNode(hasContentDescription("Hour: 10") and isSelected())
+            .assertExists()
+    }
+
+    @Test
+    fun picker_updatesAccessibilitySemanticsWhenSelectionChangesByClick() {
+        composeRule.setContent {
+            val state = rememberPickerState(1)
+
+            Picker(
+                items = listOf(1, 2, 3),
+                state = state,
+                visibleItemsCount = 3,
+                isInfinity = false,
+                pickerLabel = "Day",
+                itemContentDescription = { "$it day" }
+            )
+        }
+
+        composeRule
+            .onNode(hasContentDescription("Day: 2 day"))
+            .performClick()
+
+        composeRule.waitForIdle()
+
+        composeRule
+            .onNode(hasContentDescription("Day: 2 day") and hasStateDescription("2 day"))
+            .assertExists()
+
+        composeRule
+            .onNode(hasContentDescription("Day: 2 day") and isSelected())
+            .assertIsSelected()
+    }
+
+    @Test
+    fun picker_omitsBlankLabelFromItemContentDescription() {
+        composeRule.setContent {
+            val state = rememberPickerState(2)
+
+            Picker(
+                items = listOf(1, 2, 3),
+                state = state,
+                startIndex = 1,
+                isInfinity = false,
+                pickerLabel = "   ",
+                itemContentDescription = { "$it item" }
+            )
+        }
+
+        composeRule
+            .onNode(hasContentDescription("2 item") and isSelected())
+            .assertExists()
+    }
+
+    @Test
+    fun timePicker_forwardsCustomHourAndMinuteAccessibilityDescriptions() {
+        composeRule.setContent {
+            val state = rememberTimePickerState(
+                initialTime = LocalTime(hour = 10, minute = 5),
+                timeFormat = TimeFormat.HOUR_24
+            )
+
+            TimePicker(
+                state = state,
+                hourItems = listOf(10, 11),
+                minuteItems = listOf(5, 10),
+                visibleItemsCount = 3,
+                hourPickerLabel = "시간",
+                minutePickerLabel = "분",
+                hourItemContentDescription = { "${it}시" },
+                minuteItemContentDescription = { "${it}분" }
+            )
+        }
+
+        composeRule
+            .onNode(hasContentDescription("시간: 10시") and hasStateDescription("10시"))
+            .assertExists()
+
+        composeRule
+            .onNode(hasContentDescription("분: 5분") and hasStateDescription("5분"))
+            .assertExists()
+    }
+
+    @Test
+    fun timePicker_forwardsCustomPeriodAccessibilityDescriptionIn12HourMode() {
+        composeRule.setContent {
+            val state = rememberTimePickerState(
+                initialTime = LocalTime(hour = 22, minute = 5),
+                timeFormat = TimeFormat.HOUR_12
+            )
+
+            TimePicker(
+                state = state,
+                hourItems = listOf(10, 11),
+                minuteItems = listOf(5, 10),
+                periodItems = listOf(TimePeriod.AM, TimePeriod.PM),
+                visibleItemsCount = 3,
+                periodPickerLabel = "오전/오후",
+                periodItemContentDescription = {
+                    when (it) {
+                        TimePeriod.AM -> "오전"
+                        TimePeriod.PM -> "오후"
+                    }
+                }
+            )
+        }
+
+        composeRule
+            .onNode(hasContentDescription("오전/오후: 오후") and hasStateDescription("오후"))
+            .assertExists()
+    }
+
+    @Test
+    fun datePicker_forwardsCustomAccessibilityDescriptionsToChildPickers() {
+        composeRule.setContent {
+            val state = rememberDatePickerState(
+                initialYear = 2026,
+                initialMonth = 5,
+                initialDay = 20
+            )
+
+            DatePicker(
+                state = state,
+                yearItems = listOf(2026),
+                monthItems = listOf(5),
+                visibleItemsCount = 3,
+                yearPickerLabel = "연도",
+                monthPickerLabel = "월",
+                dayPickerLabel = "일",
+                yearItemContentDescription = { "${it}년" },
+                monthItemContentDescription = { "${it}월" },
+                dayItemContentDescription = { "${it}일" }
+            )
+        }
+
+        composeRule
+            .onNode(hasContentDescription("연도: 2026년") and hasStateDescription("2026년"))
+            .assertExists()
+
+        composeRule
+            .onNode(hasContentDescription("월: 5월") and hasStateDescription("5월"))
+            .assertExists()
+
+        composeRule
+            .onNode(hasContentDescription("일: 20일") and hasStateDescription("20일"))
+            .assertExists()
+    }
+
+    @Test
+    fun yearMonthPicker_forwardsCustomAccessibilityDescriptionsToChildPickers() {
+        composeRule.setContent {
+            val state = rememberYearMonthPickerState(
+                initialYear = 2026,
+                initialMonth = 5
+            )
+
+            YearMonthPicker(
+                state = state,
+                yearItems = listOf(2026),
+                monthItems = listOf(5),
+                visibleItemsCount = 3,
+                yearPickerLabel = "연도",
+                monthPickerLabel = "월",
+                yearItemContentDescription = { "${it}년" },
+                monthItemContentDescription = { "${it}월" }
+            )
+        }
+
+        composeRule
+            .onNode(hasContentDescription("연도: 2026년") and hasStateDescription("2026년"))
+            .assertExists()
+
+        composeRule
+            .onNode(hasContentDescription("월: 5월") and hasStateDescription("5월"))
+            .assertExists()
+    }
+}
+
+private fun hasStateDescription(value: String): SemanticsMatcher =
+    SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, value)


### PR DESCRIPTION
## Summary
- add Android instrumented Compose semantics tests for Picker accessibility labels, selected state, state descriptions, and click-driven state updates
- cover TimePicker 24-hour labels, 12-hour AM/PM labels, DatePicker labels, and YearMonthPicker labels
- wire Android instrumented test dependencies and add `assembleDebugAndroidTest` to the Android CI job so test APK compilation/packaging is gated
- update AGENTS.md with the new Android instrumented test commands and current coverage status

## Validation
- ./gradlew :datetimepicker:compileDebugAndroidTestKotlinAndroid :datetimepicker:assembleDebugAndroidTest --no-daemon
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:check :sample:assembleDebug --no-daemon
- git diff --check
- adb devices

## Residual risk
- No Android device or emulator was connected locally, so `:datetimepicker:connectedDebugAndroidTest` was not executed. This PR gates test APK compilation/packaging in CI, not runtime device execution.
- Semantics assertions improve regression coverage but do not replace manual TalkBack readout checks for duplicate or awkward announcements.

## Excluded
- Local tooling folders `.agents/` and `.claude/` are not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added accessibility semantics tests for picker components to verify correct accessibility properties, state descriptions, and custom label forwarding.

* **Documentation**
  * Updated testing guidelines with instrumented test procedures and expanded test coverage documentation.

* **Chores**
  * Enhanced CI/CD pipeline and build configuration for improved testing workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->