### PR TITLE
docs: show localized accessibility labels in sample

### DIFF
--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/StringUtils.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/StringUtils.kt
@@ -49,3 +49,10 @@ internal fun getMonthName(month: Int): String {
         else -> "알 수 없음"
     }
 }
+
+internal fun getMonthContentDescription(month: Int): String {
+    return when (month) {
+        in 1..12 -> "${month}월"
+        else -> "알 수 없음"
+    }
+}

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import com.kez.picker.PickerDefaults
 import com.kez.picker.date.DatePicker
 import com.kez.picker.date.rememberDatePickerState
+import com.kez.picker.sample.getMonthContentDescription
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
@@ -86,7 +87,13 @@ fun DatePickerSampleScreen(
                     colors = PickerDefaults.colors(
                         selectedTextColor = MaterialTheme.colorScheme.primary,
                         dividerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f)
-                    )
+                    ),
+                    yearPickerLabel = "연도",
+                    monthPickerLabel = "월",
+                    dayPickerLabel = "일",
+                    yearItemContentDescription = { "${it}년" },
+                    monthItemContentDescription = { getMonthContentDescription(it) },
+                    dayItemContentDescription = { "${it}일" }
                 )
             }
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -150,12 +150,22 @@ internal fun TimePickerSampleScreen(
             Spacer(modifier = Modifier.height(32.dp))
             if (selectedFormat == 0) {
                 TimePicker(
-                    state = timeState12
+                    state = timeState12,
+                    hourPickerLabel = "시",
+                    minutePickerLabel = "분",
+                    periodPickerLabel = "오전/오후",
+                    hourItemContentDescription = { "${it}시" },
+                    minuteItemContentDescription = { "${it}분" },
+                    periodItemContentDescription = { it.name }
                 )
             } else {
                 TimePicker(
                     state = timeState24,
-                    visibleItemsCount = 5
+                    visibleItemsCount = 5,
+                    hourPickerLabel = "시",
+                    minutePickerLabel = "분",
+                    hourItemContentDescription = { "${it}시" },
+                    minuteItemContentDescription = { "${it}분" }
                 )
             }
         }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberYearMonthPickerState
+import com.kez.picker.sample.getMonthContentDescription
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.util.currentDate
 import compose.icons.FeatherIcons
@@ -110,7 +111,11 @@ internal fun YearMonthPickerSampleScreen(
 
             YearMonthPicker(
                 modifier = Modifier.padding(horizontal = 12.dp),
-                state = state
+                state = state,
+                yearPickerLabel = "연도",
+                monthPickerLabel = "월",
+                yearItemContentDescription = { "${it}년" },
+                monthItemContentDescription = { getMonthContentDescription(it) }
             )
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- apply localized picker labels and content descriptions in the sample TimePicker, DatePicker, and YearMonthPicker screens
- split display month text from accessibility month text so TalkBack does not read mixed display strings like `5월 (May)`
- keep the change sample-only so the public library API remains unchanged

## Validation
- ./gradlew :sample:assembleDebug :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution --no-daemon
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check

## Residual risk
- No physical Android TalkBack run was performed; wording was reviewed statically and through six-agent feedback.

## Excluded
- Local tooling folders `.agents/` and `.claude/` are not included.