### PR TITLE
Support programmatic picker selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - When public validation rules change, update KDoc plus `README.md` and `README_KO.md` in the same PR, including failure mode and normalization behavior.
 - Do not repurpose legacy `startTime` or `startLocalDate` component parameters for new initialization behavior. Preserve source compatibility, document that they are compatibility no-ops, and prefer explicit `remember*State` overloads for initial values.
 - Treat `remember*State` initial parameters as first-composition defaults. Avoid resetting picker state from changing clock/date expressions during recomposition unless the API explicitly models a reset, and keep internal picker scroll state/effects keyed with state resets.
+- When adding public state mutation APIs, keep logical state and picker scroll position synchronized, and document behavior when custom item lists do not contain the requested value.
+- During programmatic selection sync, do not let intermediate `LazyListState` scroll positions overwrite the requested state value before the picker settles.
 - When higher-level components pass accessibility labels to `Picker`, expose those labels and item content descriptions as public parameters with sensible defaults so Android apps can localize TalkBack output. Update KDoc and both READMEs in the same PR.
 - Keep repository guidance up to date in this `AGENTS.md` when the maintainer gives durable process feedback.
 - Do not include local agent/tooling folders such as `.agents/` or `.claude/` in product PRs unless the change is explicitly about agent workflow assets.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ through Compose `selected` semantics rather than appended as a hardcoded English
 
 For initial values, use either `rememberTimePickerState(initialTime = LocalTime(...))` or the explicit `initialHour`/`initialMinute` parameters. The `startTime` component parameter is retained only for source compatibility and is not used.
 
+To change the selection after state creation, call `state.selectTime(LocalTime(...))` from an event handler or a `LaunchedEffect(externalTime)`. The picker scroll position is synchronized when the current `hourItems`, `minuteItems`, and in 12-hour mode `periodItems`, contain the requested values. If a requested value is missing from a custom list, that child picker normalizes back to its currently centered item.
+
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored selection is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state. In 12-hour mode, `hourItems` uses display-hour values (`1..12`): `initialHour = 13` becomes `state.selectedHour == 1` with `PM`.
 
 ### DatePicker
@@ -254,6 +256,8 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 
 For initial values, use either `rememberDatePickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth`/`initialDay` parameters. Initial years must be in `1000..9999`. The `startLocalDate` component parameter is retained only for source compatibility and is not used.
 
+To change the selection after state creation, call `state.selectDate(LocalDate(...))` from an event handler or a `LaunchedEffect(externalDate)`. The picker scroll position is synchronized when the current year, month, and day item lists contain the requested values. If a requested value is missing from a custom list, that child picker normalizes back to its currently centered item.
+
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
 
 ### YearMonthPicker
@@ -281,6 +285,8 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 `rememberYearMonthPickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
 For initial values, use either `rememberYearMonthPickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth` parameters. Initial years must be in `1000..9999`. The `startLocalDate` component parameter is retained only for source compatibility and is not used.
+
+To change the selection after state creation, call `state.selectYearMonth(year, month)` or `state.selectDate(LocalDate(...))` from an event handler or a `LaunchedEffect(externalDate)`. The picker scroll position is synchronized when the current year and month item lists contain the requested values. If a requested value is missing from a custom list, that child picker normalizes back to its currently centered item.
 
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -217,6 +217,8 @@ fun BottomSheetPickerExample() {
 
 초기값은 `rememberTimePickerState(initialTime = LocalTime(...))` 또는 `initialHour`/`initialMinute` 파라미터로 설정합니다. 컴포넌트의 `startTime` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
 
+State 생성 이후 선택값을 바꾸려면 이벤트 핸들러나 `LaunchedEffect(externalTime)`에서 `state.selectTime(LocalTime(...))`을 호출합니다. 현재 `hourItems`, `minuteItems`, 그리고 12시간 형식에서는 `periodItems`에 요청한 값이 포함되어 있으면 Picker의 스크롤 위치가 동기화됩니다. custom list에 요청한 값이 없다면 해당 child Picker는 현재 가운데에 보이는 item으로 정상화됩니다.
+
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 선택값이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다. 12시간 형식의 `hourItems`는 표시 시간 기준(`1..12`)입니다. 예를 들어 `initialHour = 13`은 `state.selectedHour == 1`, `PM`으로 변환됩니다.
 
 ### DatePicker
@@ -249,6 +251,8 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 
 초기값은 `rememberDatePickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth`/`initialDay` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
 
+State 생성 이후 선택값을 바꾸려면 이벤트 핸들러나 `LaunchedEffect(externalDate)`에서 `state.selectDate(LocalDate(...))`를 호출합니다. 현재 연도, 월, 일 item list에 요청한 값이 포함되어 있으면 Picker의 스크롤 위치가 동기화됩니다. custom list에 요청한 값이 없다면 해당 child Picker는 현재 가운데에 보이는 item으로 정상화됩니다.
+
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
 
 ### YearMonthPicker
@@ -276,6 +280,8 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 `rememberYearMonthPickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
 초기값은 `rememberYearMonthPickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
+
+State 생성 이후 선택값을 바꾸려면 이벤트 핸들러나 `LaunchedEffect(externalDate)`에서 `state.selectYearMonth(year, month)` 또는 `state.selectDate(LocalDate(...))`를 호출합니다. 현재 연도와 월 item list에 요청한 값이 포함되어 있으면 Picker의 스크롤 위치가 동기화됩니다. custom list에 요청한 값이 없다면 해당 child Picker는 현재 가운데에 보이는 item으로 정상화됩니다.
 
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
 

--- a/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
+++ b/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
@@ -8,11 +8,13 @@ import androidx.compose.ui.test.isSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import com.kez.picker.date.DatePicker
+import com.kez.picker.date.DatePickerState
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.date.rememberDatePickerState
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import org.junit.Rule
 import org.junit.Test
@@ -74,6 +76,111 @@ class PickerAccessibilitySemanticsAndroidTest {
         composeRule
             .onNode(hasContentDescription("Day: 2 day") and isSelected())
             .assertIsSelected()
+    }
+
+    @Test
+    fun picker_updatesAccessibilitySemanticsWhenSelectionChangesProgrammatically() {
+        lateinit var state: PickerState<Int>
+
+        composeRule.setContent {
+            state = rememberPickerState(1)
+
+            Picker(
+                items = (1..30).toList(),
+                state = state,
+                visibleItemsCount = 3,
+                isInfinity = false,
+                pickerLabel = "Value",
+                itemContentDescription = { "$it" }
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectItem(30)
+        }
+
+        waitUntilSelectedItem("Value: 30")
+
+        composeRule
+            .onNode(hasContentDescription("Value: 30") and hasStateDescription("30"))
+            .assertExists()
+
+        composeRule
+            .onNode(hasContentDescription("Value: 30") and isSelected())
+            .assertIsSelected()
+    }
+
+    @Test
+    fun timePicker_updatesChildPickerSemanticsWhenSelectionChangesProgrammatically() {
+        lateinit var state: TimePickerState
+
+        composeRule.setContent {
+            state = rememberTimePickerState(
+                initialTime = LocalTime(hour = 1, minute = 0),
+                timeFormat = TimeFormat.HOUR_12
+            )
+
+            TimePicker(
+                state = state,
+                hourItems = listOf(1, 2, 3),
+                minuteItems = listOf(0, 30),
+                periodItems = listOf(TimePeriod.AM, TimePeriod.PM),
+                visibleItemsCount = 3,
+                hourPickerLabel = "시간",
+                minutePickerLabel = "분",
+                periodPickerLabel = "오전/오후",
+                hourItemContentDescription = { "${it}시" },
+                minuteItemContentDescription = { "${it}분" },
+                periodItemContentDescription = {
+                    when (it) {
+                        TimePeriod.AM -> "오전"
+                        TimePeriod.PM -> "오후"
+                    }
+                }
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectTime(LocalTime(hour = 14, minute = 30))
+        }
+
+        waitUntilSelectedItem("시간: 2시")
+        waitUntilSelectedItem("분: 30분")
+        waitUntilSelectedItem("오전/오후: 오후")
+    }
+
+    @Test
+    fun datePicker_updatesChildPickerSemanticsWhenSelectionChangesProgrammatically() {
+        lateinit var state: DatePickerState
+
+        composeRule.setContent {
+            state = rememberDatePickerState(
+                initialYear = 2026,
+                initialMonth = 1,
+                initialDay = 1
+            )
+
+            DatePicker(
+                state = state,
+                yearItems = listOf(2026, 2027),
+                monthItems = listOf(1, 5),
+                visibleItemsCount = 3,
+                yearPickerLabel = "연도",
+                monthPickerLabel = "월",
+                dayPickerLabel = "일",
+                yearItemContentDescription = { "${it}년" },
+                monthItemContentDescription = { "${it}월" },
+                dayItemContentDescription = { "${it}일" }
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectDate(LocalDate(2027, 5, 20))
+        }
+
+        waitUntilSelectedItem("연도: 2027년")
+        waitUntilSelectedItem("월: 5월")
+        waitUntilSelectedItem("일: 20일")
     }
 
     @Test
@@ -217,6 +324,15 @@ class PickerAccessibilitySemanticsAndroidTest {
         composeRule
             .onNode(hasContentDescription("월: 5월") and hasStateDescription("5월"))
             .assertExists()
+    }
+
+    private fun waitUntilSelectedItem(contentDescription: String) {
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule
+                .onAllNodes(hasContentDescription(contentDescription) and isSelected())
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
     }
 }
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -183,7 +183,64 @@ fun <T> Picker(
         snapshotFlow { listState.firstVisibleItemIndex }
             .mapNotNull { index -> getItem(index + visibleItemsMiddle) }
             .distinctUntilChanged()
-            .collect { item -> state.selectedItem = item }
+            .collect { item -> state.updateSelectedItemFromScroll(item) }
+    }
+
+    LaunchedEffect(
+        listState,
+        items,
+        visibleItemsMiddle,
+        visibleItemsCount,
+        isInfinity,
+        listScrollCount,
+        state.selectionRequestVersion
+    ) {
+        val selectionRequest = state.activeSelectionRequest ?: return@LaunchedEffect
+        val requestedItem = selectionRequest.item
+
+        val currentCenterIndex = listState.firstVisibleItemIndex + visibleItemsMiddle
+        val currentCenteredItem = getItem(currentCenterIndex)
+        if (currentCenteredItem == requestedItem) {
+            currentCenteredItem?.let {
+                state.completeSelectionRequest(selectionRequest.version, it)
+            } ?: state.clearSelectionRequest(selectionRequest.version)
+            return@LaunchedEffect
+        }
+
+        val selectedItemIndex = items.indexOf(requestedItem)
+        if (selectedItemIndex < 0) {
+            currentCenteredItem?.let {
+                state.completeSelectionRequest(selectionRequest.version, it)
+            } ?: state.clearSelectionRequest(selectionRequest.version)
+            return@LaunchedEffect
+        }
+
+        val maxFirstVisibleIndex = (listScrollCount - visibleItemsCount).coerceAtLeast(0)
+        val targetFirstVisibleIndex = if (isInfinity) {
+            val itemCount = items.size
+            val currentCycleStart = currentCenterIndex - currentCenterIndex.mod(itemCount)
+            val targetFirstVisibleIndex = listOf(
+                currentCycleStart - itemCount + selectedItemIndex,
+                currentCycleStart + selectedItemIndex,
+                currentCycleStart + itemCount + selectedItemIndex
+            )
+                .map { targetCenterIndex -> targetCenterIndex - visibleItemsMiddle }
+                .filter { it in 0..maxFirstVisibleIndex }
+                .minByOrNull { abs((it + visibleItemsMiddle) - currentCenterIndex) }
+
+            targetFirstVisibleIndex
+                ?: (listScrollMiddle - listScrollMiddle % itemCount - visibleItemsMiddle + selectedItemIndex)
+        } else {
+            selectedItemIndex
+        }.coerceIn(0, maxFirstVisibleIndex)
+
+        if (targetFirstVisibleIndex != listState.firstVisibleItemIndex) {
+            listState.scrollToItem(targetFirstVisibleIndex)
+        }
+        val settledCenteredItem = getItem(listState.firstVisibleItemIndex + visibleItemsMiddle)
+        settledCenteredItem?.let {
+            state.completeSelectionRequest(selectionRequest.version, it)
+        } ?: state.clearSelectionRequest(selectionRequest.version)
     }
 
     val normalizedPickerLabel = pickerLabel.asPickerAccessibilityLabelOrNull()

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -30,8 +30,8 @@ fun <T> rememberPickerState(initialItem: T) = remember { PickerState(initialItem
 /**
  * State holder for the picker component.
  *
- * The [selectedItem] property is read-only from external code.
- * Item selection is managed internally by the [Picker] component through scrolling.
+ * The [selectedItem] property is read-only from external code. Use [selectItem] to change the
+ * selection programmatically, or let [Picker] update it when the user scrolls.
  *
  * @param initialItem The initial selected item.
  */
@@ -45,7 +45,50 @@ class PickerState<T>(
      */
     var selectedItem: T by mutableStateOf(initialItem)
         internal set
+
+    internal var selectionRequestVersion: Int by mutableStateOf(0)
+        private set
+
+    internal var activeSelectionRequest: PickerSelectionRequest<T>? by mutableStateOf(null)
+        private set
+
+    /**
+     * Programmatically selects [item].
+     *
+     * When this state is used by [Picker], the picker scroll position is synchronized to the selected item
+     * if that item exists in the current item list. If [item] is not present in the current list, [Picker]
+     * normalizes the state back to the currently centered item.
+     */
+    fun selectItem(item: T) {
+        selectedItem = item
+        selectionRequestVersion += 1
+        activeSelectionRequest = PickerSelectionRequest(selectionRequestVersion, item)
+    }
+
+    internal fun updateSelectedItemFromScroll(item: T) {
+        if (activeSelectionRequest == null) {
+            selectedItem = item
+        }
+    }
+
+    internal fun completeSelectionRequest(requestVersion: Int, settledItem: T) {
+        if (activeSelectionRequest?.version == requestVersion) {
+            selectedItem = settledItem
+            activeSelectionRequest = null
+        }
+    }
+
+    internal fun clearSelectionRequest(requestVersion: Int) {
+        if (activeSelectionRequest?.version == requestVersion) {
+            activeSelectionRequest = null
+        }
+    }
 }
+
+internal data class PickerSelectionRequest<T>(
+    val version: Int,
+    val item: T
+)
 
 /**
  * Creates and remembers a [YearMonthPickerState].
@@ -128,6 +171,37 @@ class YearMonthPickerState(
      */
     val selectedMonthDate: LocalDate
         get() = LocalDate(selectedYear, selectedMonth, 1)
+
+    /**
+     * Programmatically selects [year] and [month].
+     *
+     * The child pickers scroll to the requested values when the current item lists contain them. If a
+     * requested value is not present in a custom item list, that child picker normalizes back to its
+     * currently centered item.
+     *
+     * @throws IllegalArgumentException if [year] or [month] is outside the supported range.
+     */
+    fun selectYearMonth(year: Int, month: Int) {
+        require(year in 1000..9999) {
+            "year must be in range [1000, 9999], but was $year"
+        }
+        require(month in 1..12) {
+            "month must be in range [1, 12], but was $month"
+        }
+        yearState.selectItem(year)
+        monthState.selectItem(month)
+    }
+
+    /**
+     * Programmatically selects the year and month from [date].
+     *
+     * The day value is ignored because [com.kez.picker.date.YearMonthPicker] only selects year and month.
+     *
+     * @throws IllegalArgumentException if [date]'s year is outside the supported range.
+     */
+    fun selectDate(date: LocalDate) {
+        selectYearMonth(date.year, date.month.number)
+    }
 
     companion object {
         /**
@@ -304,6 +378,20 @@ class TimePickerState(
      */
     val selectedTime: LocalTime
         get() = LocalTime(selectedHourOfDay, selectedMinute)
+
+    /**
+     * Programmatically selects [time].
+     *
+     * The hour is converted to the current [timeFormat]. In 12-hour mode, the AM/PM period is derived from
+     * [time]. In 24-hour mode, [selectedPeriod] is still updated for consistency but is not displayed by
+     * [com.kez.picker.time.TimePicker]. The child pickers scroll to the requested values when the current
+     * item lists contain them; otherwise that child picker normalizes back to its currently centered item.
+     */
+    fun selectTime(time: LocalTime) {
+        hourState.selectItem(initialHourForTimeFormat(time.hour, timeFormat))
+        minuteState.selectItem(time.minute)
+        periodState.selectItem(if (time.hour >= 12) TimePeriod.PM else TimePeriod.AM)
+    }
 
     companion object {
         /**

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -97,6 +97,24 @@ class DatePickerState(
         get() = LocalDate(selectedYear, selectedMonth, selectedDay.coerceIn(1, maxDay))
 
     /**
+     * Programmatically selects [date].
+     *
+     * The child pickers scroll to the requested values when the current item lists contain them. If a
+     * requested value is not present in a custom item list, that child picker normalizes back to its
+     * currently centered item.
+     *
+     * @throws IllegalArgumentException if [date]'s year is outside the supported range.
+     */
+    fun selectDate(date: LocalDate) {
+        require(date.year in 1000..9999) {
+            "date.year must be in range [1000, 9999], but was ${date.year}"
+        }
+        yearState.selectItem(date.year)
+        monthState.selectItem(date.month.number)
+        dayState.selectItem(date.day)
+    }
+
+    /**
      * The currently valid maximum day for the selected year and month.
      * Calculated dynamically based on the selected year and month.
      */

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerStateTest.kt
@@ -27,6 +27,25 @@ class PickerStateTest {
     }
 
     @Test
+    fun pickerState_selectItem_updatesSelectedItem() {
+        val state = PickerState("Initial")
+
+        state.selectItem("Updated")
+
+        assertEquals("Updated", state.selectedItem)
+    }
+
+    @Test
+    fun pickerState_selectItem_recordsProgrammaticSelectionRequest() {
+        val state = PickerState("Initial")
+
+        state.selectItem("Updated")
+
+        assertEquals(1, state.selectionRequestVersion)
+        assertEquals("Updated", state.activeSelectionRequest?.item)
+    }
+
+    @Test
     fun pickerState_nullableInitialValue_isCorrect() {
         val state = PickerState<String?>(null)
         assertEquals(null, state.selectedItem)

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -539,6 +539,56 @@ class TimePickerStateTest {
     }
 
     @Test
+    fun timePickerState_selectTime_updates24HourSelection() {
+        val state = TimePickerState(
+            initialHour = 8,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        state.selectTime(LocalTime(21, 45))
+
+        assertEquals(21, state.selectedHour)
+        assertEquals(45, state.selectedMinute)
+        assertEquals(TimePeriod.PM, state.selectedPeriod)
+        assertEquals(LocalTime(21, 45), state.selectedTime)
+        assertEquals(1, state.hourState.selectionRequestVersion)
+        assertEquals(1, state.minuteState.selectionRequestVersion)
+        assertEquals(1, state.periodState.selectionRequestVersion)
+    }
+
+    @Test
+    fun timePickerState_selectTime_updates12HourSelection() {
+        val state = TimePickerState(
+            initialHour = 8,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        state.selectTime(LocalTime(0, 30))
+
+        assertEquals(12, state.selectedHour)
+        assertEquals(30, state.selectedMinute)
+        assertEquals(TimePeriod.AM, state.selectedPeriod)
+        assertEquals(LocalTime(0, 30), state.selectedTime)
+        assertEquals(1, state.hourState.selectionRequestVersion)
+        assertEquals(1, state.minuteState.selectionRequestVersion)
+        assertEquals(1, state.periodState.selectionRequestVersion)
+
+        state.selectTime(LocalTime(13, 5))
+
+        assertEquals(1, state.selectedHour)
+        assertEquals(5, state.selectedMinute)
+        assertEquals(TimePeriod.PM, state.selectedPeriod)
+        assertEquals(LocalTime(13, 5), state.selectedTime)
+        assertEquals(2, state.hourState.selectionRequestVersion)
+        assertEquals(2, state.minuteState.selectionRequestVersion)
+        assertEquals(2, state.periodState.selectionRequestVersion)
+    }
+
+    @Test
     fun timePickerState_selectedTime_updatesWhenInternalStateChanges() {
         val state = TimePickerState(
             initialHour = 12,

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -172,6 +172,53 @@ class YearMonthPickerStateTest {
     }
 
     @Test
+    fun yearMonthPickerState_selectYearMonth_updatesSelection() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 1
+        )
+
+        state.selectYearMonth(year = 2026, month = 12)
+
+        assertEquals(2026, state.selectedYear)
+        assertEquals(12, state.selectedMonth)
+        assertEquals(LocalDate(2026, 12, 1), state.selectedMonthDate)
+        assertEquals(1, state.yearState.selectionRequestVersion)
+        assertEquals(1, state.monthState.selectionRequestVersion)
+    }
+
+    @Test
+    fun yearMonthPickerState_selectDate_updatesYearAndMonth() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 1
+        )
+
+        state.selectDate(LocalDate(2026, 5, 20))
+
+        assertEquals(2026, state.selectedYear)
+        assertEquals(5, state.selectedMonth)
+        assertEquals(LocalDate(2026, 5, 1), state.selectedMonthDate)
+        assertEquals(1, state.yearState.selectionRequestVersion)
+        assertEquals(1, state.monthState.selectionRequestVersion)
+    }
+
+    @Test
+    fun yearMonthPickerState_selectYearMonth_rejectsInvalidValues() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 1
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            state.selectYearMonth(year = 999, month = 1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            state.selectYearMonth(year = 2024, month = 13)
+        }
+    }
+
+    @Test
     fun yearMonthPickerState_saver_roundTripsCurrentSelection() {
         val state = YearMonthPickerState(
             initialYear = 2024,

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -109,6 +109,33 @@ class DatePickerStateTest {
     }
 
     @Test
+    fun datePickerState_selectDate_updatesSelection() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
+
+        state.selectDate(LocalDate(2026, 5, 20))
+
+        assertEquals(2026, state.selectedYear)
+        assertEquals(5, state.selectedMonth)
+        assertEquals(20, state.selectedDay)
+        assertEquals(LocalDate(2026, 5, 20), state.selectedDate)
+        assertEquals(1, state.yearState.selectionRequestVersion)
+        assertEquals(1, state.monthState.selectionRequestVersion)
+        assertEquals(1, state.dayState.selectionRequestVersion)
+    }
+
+    @Test
+    fun datePickerState_selectDate_throwsWhenYearOutOfRange() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            state.selectDate(LocalDate(999, 1, 1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            state.selectDate(LocalDate(10000, 1, 1))
+        }
+    }
+
+    @Test
     fun testSaver_RoundTripsCurrentSelection() {
         val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
         state.yearState.selectedItem = 2026


### PR DESCRIPTION
## Summary
- add public state mutation APIs for Picker, TimePicker, DatePicker, and YearMonthPicker
- synchronize picker scroll position when selection changes programmatically, while preventing transient scroll feedback from overwriting the requested value
- document custom-list normalization behavior and add unit/instrumented coverage for programmatic selection

## Android developer impact
- apps can now drive picker state from external events such as buttons, form resets, or LaunchedEffect-backed model changes
- custom item lists have documented behavior: missing requested values normalize back to the currently centered item

## Validation
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:compileDebugAndroidTestKotlinAndroid --no-daemon
- ./gradlew :datetimepicker:check :datetimepicker:assembleDebugAndroidTest :sample:assembleDebug --no-daemon
- git diff --check

## Review loop
- ran 6-agent review for API ergonomics, scroll sync correctness, KMP compatibility, docs, tests, and PR hygiene
- fixed Must-fix feedback around transient scroll feedback, centerable infinite scroll targeting, and stronger selected-item UI tests