### PR TITLE
Show programmatic selection in samples

### DIFF
--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -1,6 +1,9 @@
 package com.kez.picker.sample.ui.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,9 +14,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -34,6 +39,7 @@ import com.kez.picker.sample.getMonthContentDescription
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
+import kotlinx.datetime.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,10 +69,12 @@ fun DatePickerSampleScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             val state = rememberDatePickerState()
+            val demoDate = LocalDate(2026, 5, 20)
 
             Box(
                 modifier = Modifier
@@ -95,6 +103,32 @@ fun DatePickerSampleScreen(
                     monthItemContentDescription = { getMonthContentDescription(it) },
                     dayItemContentDescription = { "${it}일" }
                 )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Button(
+                    onClick = { state.selectDate(demoDate) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = FeatherIcons.Calendar,
+                        contentDescription = null
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Set 2026-05-20")
+                }
+
+                OutlinedButton(
+                    onClick = { state.selectDate(LocalDate(2024, 2, 29)) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Set 2024-02-29")
+                }
             }
 
             Spacer(modifier = Modifier.height(32.dp))

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -1,6 +1,8 @@
 package com.kez.picker.sample.ui.screen
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,7 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -17,6 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
@@ -62,6 +67,7 @@ internal fun TimePickerSampleScreen(
     val timeState24 = rememberTimePickerState(
         initialTime = currentTime
     )
+    val demoTime = LocalTime(hour = 9, minute = 30)
 
     val ktxTimeFormat12 = LocalTime.Format {
         amPmHour(padding = Padding.ZERO)
@@ -100,7 +106,11 @@ internal fun TimePickerSampleScreen(
         }
     ) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(it).padding(16.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Card(
@@ -129,6 +139,38 @@ internal fun TimePickerSampleScreen(
                         fontWeight = FontWeight.Medium,
                         color = MaterialTheme.colorScheme.onSurface
                     )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Button(
+                    onClick = {
+                        val now = currentDateTime().time
+                        timeState12.selectTime(now)
+                        timeState24.selectTime(now)
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = FeatherIcons.Clock,
+                        contentDescription = null
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Set now")
+                }
+                OutlinedButton(
+                    onClick = {
+                        timeState12.selectTime(demoTime)
+                        timeState24.selectTime(demoTime)
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Set 09:30")
                 }
             }
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
@@ -1,6 +1,8 @@
 package com.kez.picker.sample.ui.screen
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,7 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -17,6 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -74,7 +79,11 @@ internal fun YearMonthPickerSampleScreen(
         }
     ) {
         Column(
-            modifier = Modifier.fillMaxSize().padding(it).padding(16.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(it)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // Selected result display card
@@ -104,6 +113,31 @@ internal fun YearMonthPickerSampleScreen(
                         fontWeight = FontWeight.Medium,
                         color = MaterialTheme.colorScheme.onSurface
                     )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Button(
+                    onClick = { state.selectDate(currentDate()) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = FeatherIcons.Calendar,
+                        contentDescription = null
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("This month")
+                }
+                OutlinedButton(
+                    onClick = { state.selectYearMonth(year = 2026, month = 12) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Set Dec 2026")
                 }
             }
 


### PR DESCRIPTION
## Summary
- add sample actions that call selectDate, selectTime, and selectYearMonth from button handlers
- make sample screens scrollable so the added actions fit better on small Android screens
- use explicit action labels such as Set 2026-05-20, Set 09:30, and Set Dec 2026

## Android developer impact
- consumers can see the new programmatic state APIs in executable sample screens instead of only reading README prose
- actions demonstrate event-handler usage without recomposition-driven resets

## Validation
- ./gradlew :sample:assembleDebug :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check

## Review loop
- ran 6-agent review for sample UX, mobile layout, KMP compatibility, repo hygiene, API usage, and docs/sample consistency
- fixed feedback around stale current time/month values, ambiguous labels, small-screen button overflow, and non-scrollable sample screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sample picker screens now feature vertical scrolling for improved content navigation
  * Added quick-select demo buttons across date, time, and year-month picker samples with preset values for streamlined testing and evaluation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->