### PR TITLE
docs: add programmatic selection examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,46 @@ Accessibility label parameters customize the picker-column prefix used in semant
 parameters customize the accessibility value text without changing the visual item text. Selection is exposed
 through Compose `selected` semantics rather than appended as a hardcoded English phrase.
 
+### Programmatic Selection
+
+Create picker state with `remember*State`, pass it to the picker, then call the public selection method
+from an event handler or a `LaunchedEffect(externalValue)`. Do not recreate the state just to reset the
+selection.
+
+| State | Method |
+| :--- | :--- |
+| `PickerState<T>` | `selectItem(item)` |
+| `TimePickerState` | `selectTime(LocalTime(...))` |
+| `DatePickerState` | `selectDate(LocalDate(...))` |
+| `YearMonthPickerState` | `selectYearMonth(year, month)` or `selectDate(LocalDate(...))` |
+
+```kotlin
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.kez.picker.rememberTimePickerState
+import com.kez.picker.time.TimePicker
+import kotlinx.datetime.LocalTime
+
+@Composable
+fun ProgrammaticTimePickerExample() {
+    val state = rememberTimePickerState(initialTime = LocalTime(8, 0))
+
+    Column {
+        Button(onClick = { state.selectTime(LocalTime(9, 30)) }) {
+            Text("Set 09:30")
+        }
+
+        TimePicker(state = state)
+    }
+}
+```
+
+The picker scroll position is synchronized when the current item lists contain the requested values. If a
+requested value is missing from a custom list, that child picker normalizes back to its currently centered
+item.
+
 ### TimePicker
 
 | Parameter | Description | Default |
@@ -222,7 +262,7 @@ through Compose `selected` semantics rather than appended as a hardcoded English
 
 For initial values, use either `rememberTimePickerState(initialTime = LocalTime(...))` or the explicit `initialHour`/`initialMinute` parameters. The `startTime` component parameter is retained only for source compatibility and is not used.
 
-To change the selection after state creation, call `state.selectTime(LocalTime(...))` from an event handler or a `LaunchedEffect(externalTime)`. The picker scroll position is synchronized when the current `hourItems`, `minuteItems`, and in 12-hour mode `periodItems`, contain the requested values. If a requested value is missing from a custom list, that child picker normalizes back to its currently centered item.
+To change the selection after state creation, call `state.selectTime(LocalTime(...))`.
 
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored selection is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state. In 12-hour mode, `hourItems` uses display-hour values (`1..12`): `initialHour = 13` becomes `state.selectedHour == 1` with `PM`.
 
@@ -256,7 +296,7 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 
 For initial values, use either `rememberDatePickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth`/`initialDay` parameters. Initial years must be in `1000..9999`. The `startLocalDate` component parameter is retained only for source compatibility and is not used.
 
-To change the selection after state creation, call `state.selectDate(LocalDate(...))` from an event handler or a `LaunchedEffect(externalDate)`. The picker scroll position is synchronized when the current year, month, and day item lists contain the requested values. If a requested value is missing from a custom list, that child picker normalizes back to its currently centered item.
+To change the selection after state creation, call `state.selectDate(LocalDate(...))`.
 
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
 
@@ -286,7 +326,7 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 
 For initial values, use either `rememberYearMonthPickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth` parameters. Initial years must be in `1000..9999`. The `startLocalDate` component parameter is retained only for source compatibility and is not used.
 
-To change the selection after state creation, call `state.selectYearMonth(year, month)` or `state.selectDate(LocalDate(...))` from an event handler or a `LaunchedEffect(externalDate)`. The picker scroll position is synchronized when the current year and month item lists contain the requested values. If a requested value is missing from a custom list, that child picker normalizes back to its currently centered item.
+To change the selection after state creation, call `state.selectYearMonth(year, month)` or `state.selectDate(LocalDate(...))`.
 
 Invalid custom item values throw `IllegalArgumentException` during composition. If the current or restored year/month is valid but not present in a custom list, the picker starts from the first item in that list and normalizes the state.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -185,6 +185,45 @@ fun BottomSheetPickerExample() {
 파라미터는 화면에 보이는 텍스트를 바꾸지 않고 접근성 값 설명만 바꿉니다. 선택 상태는 고정된 영어 문구를
 붙이지 않고 Compose `selected` semantics로 전달됩니다.
 
+### 프로그래밍 방식 선택
+
+`remember*State`로 picker state를 만들고 picker에 전달한 뒤, 이벤트 핸들러나
+`LaunchedEffect(externalValue)`에서 공개 선택 메서드를 호출하세요. 선택값을 다시 맞추기 위해
+state를 새로 만들 필요는 없습니다.
+
+| State | Method |
+| :--- | :--- |
+| `PickerState<T>` | `selectItem(item)` |
+| `TimePickerState` | `selectTime(LocalTime(...))` |
+| `DatePickerState` | `selectDate(LocalDate(...))` |
+| `YearMonthPickerState` | `selectYearMonth(year, month)` 또는 `selectDate(LocalDate(...))` |
+
+```kotlin
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.kez.picker.rememberTimePickerState
+import com.kez.picker.time.TimePicker
+import kotlinx.datetime.LocalTime
+
+@Composable
+fun ProgrammaticTimePickerExample() {
+    val state = rememberTimePickerState(initialTime = LocalTime(8, 0))
+
+    Column {
+        Button(onClick = { state.selectTime(LocalTime(9, 30)) }) {
+            Text("Set 09:30")
+        }
+
+        TimePicker(state = state)
+    }
+}
+```
+
+요청한 값이 현재 item list에 포함되어 있으면 picker 스크롤 위치가 동기화됩니다. custom list에
+요청한 값이 없다면 해당 child picker는 현재 가운데에 보이는 item으로 정상화됩니다.
+
 ### TimePicker
 
 | 파라미터 | 설명 | 기본값 |
@@ -217,7 +256,7 @@ fun BottomSheetPickerExample() {
 
 초기값은 `rememberTimePickerState(initialTime = LocalTime(...))` 또는 `initialHour`/`initialMinute` 파라미터로 설정합니다. 컴포넌트의 `startTime` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
 
-State 생성 이후 선택값을 바꾸려면 이벤트 핸들러나 `LaunchedEffect(externalTime)`에서 `state.selectTime(LocalTime(...))`을 호출합니다. 현재 `hourItems`, `minuteItems`, 그리고 12시간 형식에서는 `periodItems`에 요청한 값이 포함되어 있으면 Picker의 스크롤 위치가 동기화됩니다. custom list에 요청한 값이 없다면 해당 child Picker는 현재 가운데에 보이는 item으로 정상화됩니다.
+상태 생성 이후 선택값을 바꾸려면 `state.selectTime(LocalTime(...))`을 호출합니다.
 
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 선택값이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다. 12시간 형식의 `hourItems`는 표시 시간 기준(`1..12`)입니다. 예를 들어 `initialHour = 13`은 `state.selectedHour == 1`, `PM`으로 변환됩니다.
 
@@ -251,7 +290,7 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 
 초기값은 `rememberDatePickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth`/`initialDay` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
 
-State 생성 이후 선택값을 바꾸려면 이벤트 핸들러나 `LaunchedEffect(externalDate)`에서 `state.selectDate(LocalDate(...))`를 호출합니다. 현재 연도, 월, 일 item list에 요청한 값이 포함되어 있으면 Picker의 스크롤 위치가 동기화됩니다. custom list에 요청한 값이 없다면 해당 child Picker는 현재 가운데에 보이는 item으로 정상화됩니다.
+상태 생성 이후 선택값을 바꾸려면 `state.selectDate(LocalDate(...))`를 호출합니다.
 
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
 
@@ -281,7 +320,8 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 
 초기값은 `rememberYearMonthPickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
 
-State 생성 이후 선택값을 바꾸려면 이벤트 핸들러나 `LaunchedEffect(externalDate)`에서 `state.selectYearMonth(year, month)` 또는 `state.selectDate(LocalDate(...))`를 호출합니다. 현재 연도와 월 item list에 요청한 값이 포함되어 있으면 Picker의 스크롤 위치가 동기화됩니다. custom list에 요청한 값이 없다면 해당 child Picker는 현재 가운데에 보이는 item으로 정상화됩니다.
+상태 생성 이후 선택값을 바꾸려면 `state.selectYearMonth(year, month)` 또는
+`state.selectDate(LocalDate(...))`를 호출합니다.
 
 custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumentException`이 발생합니다. 현재 또는 복원된 연도/월이 유효하지만 custom 목록에 없다면 picker는 해당 목록의 첫 번째 값에서 시작하고 state를 정상화합니다.
 


### PR DESCRIPTION
## Summary
- Add a shared Programmatic Selection section to English and Korean README files.
- Document selectItem/selectTime/selectDate/selectYearMonth in one method table.
- Replace repeated component-specific guidance with concise links to the public selection methods.

## Six-agent review follow-up
- Consolidated repeated snippets into one common section.
- Added a complete @Composable example with imports.
- Included generic PickerState.selectItem documentation.
- Kept README and README_KO wording aligned.

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check