### PR TITLE
feat: add picker accessibility actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ fun BottomSheetPickerExample() {
 
 Accessibility label parameters customize the picker-column prefix used in semantics. `*ItemContentDescription`
 parameters customize the accessibility value text without changing the visual item text. Selection is exposed
-through Compose `selected` semantics rather than appended as a hardcoded English phrase.
+through Compose `selected` semantics rather than appended as a hardcoded English phrase. Pickers also expose
+custom accessibility actions for selecting the previous or next item. Use `previousItemActionLabel` and
+`nextItemActionLabel` to localize those action labels, or pass `null`/blank to omit an action.
 
 ### Programmatic Selection
 
@@ -249,6 +251,8 @@ item.
 | `hourItemContentDescription` | Accessibility description for each hour value. | `it.toString()` |
 | `minuteItemContentDescription` | Accessibility description for each minute value. | `it.toString()` |
 | `periodItemContentDescription` | Accessibility description for each AM/PM value in 12-hour time. | `it.name` |
+| `previousItemActionLabel` | Accessibility action label used by child pickers to select the previous item. Pass `null` or blank to omit it. | `"Select previous item"` |
+| `nextItemActionLabel` | Accessibility action label used by child pickers to select the next item. Pass `null` or blank to omit it. | `"Select next item"` |
 
 **TimePickerState Properties:**
 
@@ -283,6 +287,8 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 | `yearItemContentDescription` | Accessibility description for each year value. | `it.toString()` |
 | `monthItemContentDescription` | Accessibility description for each month value. | `it.toString()` |
 | `dayItemContentDescription` | Accessibility description for each day value. | `it.toString()` |
+| `previousItemActionLabel` | Accessibility action label used by child pickers to select the previous item. Pass `null` or blank to omit it. | `"Select previous item"` |
+| `nextItemActionLabel` | Accessibility action label used by child pickers to select the next item. Pass `null` or blank to omit it. | `"Select next item"` |
 
 **DatePickerState Properties:**
 
@@ -315,6 +321,8 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 | `monthPickerLabel` | Accessibility label for the month picker. Pass `null` to omit the picker label prefix. | `"Month"` |
 | `yearItemContentDescription` | Accessibility description for each year value. | `it.toString()` |
 | `monthItemContentDescription` | Accessibility description for each month value. | `it.toString()` |
+| `previousItemActionLabel` | Accessibility action label used by child pickers to select the previous item. Pass `null` or blank to omit it. | `"Select previous item"` |
+| `nextItemActionLabel` | Accessibility action label used by child pickers to select the next item. Pass `null` or blank to omit it. | `"Select next item"` |
 
 **YearMonthPickerState Properties:**
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -183,7 +183,9 @@ fun BottomSheetPickerExample() {
 
 접근성 label 파라미터는 semantics에 들어가는 picker column prefix를 바꿉니다. `*ItemContentDescription`
 파라미터는 화면에 보이는 텍스트를 바꾸지 않고 접근성 값 설명만 바꿉니다. 선택 상태는 고정된 영어 문구를
-붙이지 않고 Compose `selected` semantics로 전달됩니다.
+붙이지 않고 Compose `selected` semantics로 전달됩니다. Picker는 이전/다음 item을 선택하는 custom
+accessibility action도 제공합니다. `previousItemActionLabel`과 `nextItemActionLabel`로 action label을
+현지화할 수 있고, `null`이나 blank를 전달하면 해당 action을 생략합니다.
 
 ### 프로그래밍 방식 선택
 
@@ -243,6 +245,8 @@ fun ProgrammaticTimePickerExample() {
 | `hourItemContentDescription` | 각 시간 값의 접근성 설명입니다. | `it.toString()` |
 | `minuteItemContentDescription` | 각 분 값의 접근성 설명입니다. | `it.toString()` |
 | `periodItemContentDescription` | 12시간 형식에서 각 오전/오후 값의 접근성 설명입니다. | `it.name` |
+| `previousItemActionLabel` | child picker가 이전 item을 선택할 때 쓰는 접근성 action label입니다. `null` 또는 blank를 전달하면 생략합니다. | `"Select previous item"` |
+| `nextItemActionLabel` | child picker가 다음 item을 선택할 때 쓰는 접근성 action label입니다. `null` 또는 blank를 전달하면 생략합니다. | `"Select next item"` |
 
 **TimePickerState 속성:**
 
@@ -277,6 +281,8 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 | `yearItemContentDescription` | 각 연도 값의 접근성 설명입니다. | `it.toString()` |
 | `monthItemContentDescription` | 각 월 값의 접근성 설명입니다. | `it.toString()` |
 | `dayItemContentDescription` | 각 일 값의 접근성 설명입니다. | `it.toString()` |
+| `previousItemActionLabel` | child picker가 이전 item을 선택할 때 쓰는 접근성 action label입니다. `null` 또는 blank를 전달하면 생략합니다. | `"Select previous item"` |
+| `nextItemActionLabel` | child picker가 다음 item을 선택할 때 쓰는 접근성 action label입니다. `null` 또는 blank를 전달하면 생략합니다. | `"Select next item"` |
 
 **DatePickerState 속성:**
 
@@ -309,6 +315,8 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 | `monthPickerLabel` | 월 picker의 접근성 label입니다. `null`을 전달하면 picker label prefix를 생략합니다. | `"Month"` |
 | `yearItemContentDescription` | 각 연도 값의 접근성 설명입니다. | `it.toString()` |
 | `monthItemContentDescription` | 각 월 값의 접근성 설명입니다. | `it.toString()` |
+| `previousItemActionLabel` | child picker가 이전 item을 선택할 때 쓰는 접근성 action label입니다. `null` 또는 blank를 전달하면 생략합니다. | `"Select previous item"` |
+| `nextItemActionLabel` | child picker가 다음 item을 선택할 때 쓰는 접근성 action label입니다. `null` 또는 blank를 전달하면 생략합니다. | `"Select next item"` |
 
 **YearMonthPickerState 속성:**
 

--- a/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
+++ b/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
@@ -1,6 +1,8 @@
 package com.kez.picker
 
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasContentDescription
@@ -17,8 +19,12 @@ import com.kez.picker.util.TimePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+
+private const val PREVIOUS_VALUE_ACTION_LABEL = "Previous value"
+private const val NEXT_VALUE_ACTION_LABEL = "Next value"
 
 class PickerAccessibilitySemanticsAndroidTest {
 
@@ -77,6 +83,192 @@ class PickerAccessibilitySemanticsAndroidTest {
         composeRule
             .onNode(hasContentDescription("Day: 2 day") and isSelected())
             .assertIsSelected()
+    }
+
+    @Test
+    fun picker_customAccessibilityActionsSelectAdjacentItems() {
+        lateinit var state: PickerState<Int>
+
+        composeRule.setContent {
+            state = rememberPickerState(2)
+
+            Picker(
+                items = listOf(1, 2, 3),
+                state = state,
+                startIndex = 1,
+                visibleItemsCount = 3,
+                isInfinity = false,
+                pickerLabel = "Value",
+                itemContentDescription = { "$it" },
+                previousItemActionLabel = PREVIOUS_VALUE_ACTION_LABEL,
+                nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+            )
+        }
+
+        composeRule
+            .onNode(
+                hasContentDescription("Value: 2") and
+                        hasCustomAccessibilityAction(PREVIOUS_VALUE_ACTION_LABEL) and
+                        hasCustomAccessibilityAction(NEXT_VALUE_ACTION_LABEL)
+            )
+            .assertExists()
+
+        performCustomAccessibilityAction(
+            contentDescription = "Value: 2",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("Value: 3")
+
+        composeRule.runOnIdle {
+            assertEquals(3, state.selectedItem)
+        }
+
+        performCustomAccessibilityAction(
+            contentDescription = "Value: 3",
+            actionLabel = PREVIOUS_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("Value: 2")
+
+        composeRule.runOnIdle {
+            assertEquals(2, state.selectedItem)
+        }
+    }
+
+    @Test
+    fun picker_customAccessibilityActionsRespectBoundedEdges() {
+        composeRule.setContent {
+            val state = rememberPickerState(1)
+
+            Picker(
+                items = listOf(1, 2, 3),
+                state = state,
+                visibleItemsCount = 3,
+                isInfinity = false,
+                pickerLabel = "Value",
+                itemContentDescription = { "$it" },
+                previousItemActionLabel = PREVIOUS_VALUE_ACTION_LABEL,
+                nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+            )
+        }
+
+        assertNoCustomAccessibilityAction("Value: 1", PREVIOUS_VALUE_ACTION_LABEL)
+        assertCustomAccessibilityAction("Value: 1", NEXT_VALUE_ACTION_LABEL)
+
+        performCustomAccessibilityAction(
+            contentDescription = "Value: 1",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("Value: 2")
+
+        performCustomAccessibilityAction(
+            contentDescription = "Value: 2",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("Value: 3")
+
+        assertCustomAccessibilityAction("Value: 3", PREVIOUS_VALUE_ACTION_LABEL)
+        assertNoCustomAccessibilityAction("Value: 3", NEXT_VALUE_ACTION_LABEL)
+    }
+
+    @Test
+    fun picker_customAccessibilityActionsWrapInInfiniteMode() {
+        composeRule.setContent {
+            val state = rememberPickerState(1)
+
+            Picker(
+                items = listOf(1, 2, 3),
+                state = state,
+                visibleItemsCount = 3,
+                isInfinity = true,
+                pickerLabel = "Value",
+                itemContentDescription = { "$it" },
+                previousItemActionLabel = PREVIOUS_VALUE_ACTION_LABEL,
+                nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+            )
+        }
+
+        performCustomAccessibilityAction(
+            contentDescription = "Value: 1",
+            actionLabel = PREVIOUS_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("Value: 3")
+
+        performCustomAccessibilityAction(
+            contentDescription = "Value: 3",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("Value: 1")
+    }
+
+    @Test
+    fun picker_omitsCustomAccessibilityActionsForSingleItemInfinitePicker() {
+        composeRule.setContent {
+            val state = rememberPickerState(1)
+
+            Picker(
+                items = listOf(1),
+                state = state,
+                visibleItemsCount = 3,
+                isInfinity = true,
+                pickerLabel = "Value",
+                itemContentDescription = { "$it" },
+                previousItemActionLabel = PREVIOUS_VALUE_ACTION_LABEL,
+                nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+            )
+        }
+
+        assertNoCustomAccessibilityAction("Value: 1", PREVIOUS_VALUE_ACTION_LABEL)
+        assertNoCustomAccessibilityAction("Value: 1", NEXT_VALUE_ACTION_LABEL)
+    }
+
+    @Test
+    fun picker_exposesCustomAccessibilityActionsWhenDuplicateSelectedValuesAreNotFirst() {
+        composeRule.setContent {
+            val state = rememberPickerState(1)
+
+            Picker(
+                items = listOf(1, 1, 2),
+                state = state,
+                startIndex = 1,
+                visibleItemsCount = 3,
+                isInfinity = false,
+                pickerLabel = "Value",
+                itemContentDescription = { "$it" },
+                previousItemActionLabel = PREVIOUS_VALUE_ACTION_LABEL,
+                nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+            )
+        }
+
+        assertCustomAccessibilityAction("Value: 1", PREVIOUS_VALUE_ACTION_LABEL)
+        assertCustomAccessibilityAction("Value: 1", NEXT_VALUE_ACTION_LABEL)
+    }
+
+    @Test
+    fun picker_customAccessibilityActionsUseValueDescriptionWhenLabelIsOmitted() {
+        composeRule.setContent {
+            val state = rememberPickerState(2)
+
+            Picker(
+                items = listOf(1, 2, 3),
+                state = state,
+                startIndex = 1,
+                visibleItemsCount = 3,
+                isInfinity = false,
+                pickerLabel = null,
+                itemContentDescription = { "$it item" },
+                previousItemActionLabel = PREVIOUS_VALUE_ACTION_LABEL,
+                nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+            )
+        }
+
+        composeRule
+            .onNode(
+                hasContentDescription("2 item") and
+                        hasStateDescription("2 item") and
+                        hasCustomAccessibilityAction(PREVIOUS_VALUE_ACTION_LABEL) and
+                        hasCustomAccessibilityAction(NEXT_VALUE_ACTION_LABEL)
+            )
+            .assertExists()
     }
 
     @Test
@@ -425,6 +617,42 @@ class PickerAccessibilitySemanticsAndroidTest {
     }
 
     @Test
+    fun timePicker_forwardsCustomAccessibilityActionLabelsToChildPickers() {
+        composeRule.setContent {
+            val state = rememberTimePickerState(
+                initialTime = LocalTime(hour = 10, minute = 5),
+                timeFormat = TimeFormat.HOUR_24
+            )
+
+            TimePicker(
+                state = state,
+                hourItems = listOf(10, 11),
+                minuteItems = listOf(5, 10),
+                visibleItemsCount = 3,
+                hourPickerLabel = "시간",
+                minutePickerLabel = "분",
+                hourItemContentDescription = { "${it}시" },
+                minuteItemContentDescription = { "${it}분" },
+                previousItemActionLabel = "이전 항목 선택",
+                nextItemActionLabel = "다음 항목 선택"
+            )
+        }
+
+        composeRule
+            .onNode(
+                hasContentDescription("시간: 10시") and
+                        hasCustomAccessibilityAction("다음 항목 선택")
+            )
+            .assertExists()
+        composeRule
+            .onNode(
+                hasContentDescription("분: 5분") and
+                        hasCustomAccessibilityAction("다음 항목 선택")
+            )
+            .assertExists()
+    }
+
+    @Test
     fun timePicker_forwardsCustomPeriodAccessibilityDescriptionIn12HourMode() {
         composeRule.setContent {
             val state = rememberTimePickerState(
@@ -526,7 +754,51 @@ class PickerAccessibilitySemanticsAndroidTest {
                 .isNotEmpty()
         }
     }
+
+    private fun performCustomAccessibilityAction(
+        contentDescription: String,
+        actionLabel: String
+    ) {
+        val action = composeRule
+            .onNode(
+                hasContentDescription(contentDescription) and
+                        hasCustomAccessibilityAction(actionLabel)
+            )
+            .fetchSemanticsNode()
+            .config[SemanticsActions.CustomActions]
+            .first { it.label == actionLabel }
+
+        composeRule.runOnIdle {
+            assertTrue(action.action())
+        }
+    }
+
+    private fun assertCustomAccessibilityAction(
+        contentDescription: String,
+        actionLabel: String
+    ) {
+        composeRule
+            .onNode(hasContentDescription(contentDescription) and hasCustomAccessibilityAction(actionLabel))
+            .assertExists()
+    }
+
+    private fun assertNoCustomAccessibilityAction(
+        contentDescription: String,
+        actionLabel: String
+    ) {
+        val nodes = composeRule
+            .onAllNodes(hasContentDescription(contentDescription) and hasCustomAccessibilityAction(actionLabel))
+            .fetchSemanticsNodes()
+
+        assertTrue(nodes.isEmpty())
+    }
 }
 
 private fun hasStateDescription(value: String): SemanticsMatcher =
     SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, value)
+
+private fun hasCustomAccessibilityAction(label: String): SemanticsMatcher =
+    SemanticsMatcher("has custom accessibility action '$label'") { node ->
+        node.config.getOrNull(SemanticsActions.CustomActions)
+            ?.any { action -> action.label == label } == true
+    }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -34,11 +34,13 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.CollectionInfo
 import androidx.compose.ui.semantics.CollectionItemInfo
+import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.collectionInfo
 import androidx.compose.ui.semantics.collectionItemInfo
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
@@ -85,6 +87,8 @@ private const val INFINITE_SCROLL_MULTIPLIER = 1000
  * @param isInfinity Whether the picker should loop infinitely.
  * @param pickerLabel Accessibility label for the picker (e.g., "Hour", "Minute", "Year").
  * @param itemContentDescription Accessibility description for each item value.
+ * @param previousItemActionLabel Accessibility action label for selecting the previous item. Pass null or blank to omit the action.
+ * @param nextItemActionLabel Accessibility action label for selecting the next item. Pass null or blank to omit the action.
  * @param content Optional custom content composable for rendering each item.
  */
 @Composable
@@ -107,6 +111,8 @@ fun <T> Picker(
     isInfinity: Boolean = true,
     pickerLabel: String? = null,
     itemContentDescription: (T) -> String = { it.toString() },
+    previousItemActionLabel: String? = PickerDefaults.PreviousItemActionLabel,
+    nextItemActionLabel: String? = PickerDefaults.NextItemActionLabel,
     content: @Composable ((T) -> Unit)? = null
 ) {
     require(items.isNotEmpty()) { "Items list must not be empty" }
@@ -244,17 +250,69 @@ fun <T> Picker(
     }
 
     val normalizedPickerLabel = pickerLabel.asPickerAccessibilityLabelOrNull()
+    val normalizedPreviousItemActionLabel = previousItemActionLabel.asPickerAccessibilityLabelOrNull()
+    val normalizedNextItemActionLabel = nextItemActionLabel.asPickerAccessibilityLabelOrNull()
+    val selectedItemDescription = itemContentDescription(state.selectedItem)
+    val pickerDescription = pickerAccessibilityDescription(normalizedPickerLabel, selectedItemDescription)
+    val hasPickerDescription = pickerDescription.isNotBlank()
+
+    fun adjacentFirstVisibleItemIndex(offset: Int): Int? {
+        if (items.size <= 1) return null
+
+        val maxFirstVisibleIndex = (listScrollCount - visibleItemsCount).coerceAtLeast(0)
+        val targetFirstVisibleIndex = listState.firstVisibleItemIndex + offset
+
+        return if (isInfinity) {
+            when {
+                targetFirstVisibleIndex < 0 -> maxFirstVisibleIndex
+                targetFirstVisibleIndex > maxFirstVisibleIndex -> 0
+                else -> targetFirstVisibleIndex
+            }
+        } else {
+            targetFirstVisibleIndex.takeIf { it in 0..maxFirstVisibleIndex }
+        }
+    }
+
+    fun selectAdjacentItem(offset: Int): Boolean {
+        val targetFirstVisibleIndex = adjacentFirstVisibleItemIndex(offset) ?: return false
+
+        scope.launch {
+            listState.animateScrollToItem(targetFirstVisibleIndex)
+        }
+        return true
+    }
+
+    val accessibilityActions = buildList {
+        if (normalizedPreviousItemActionLabel != null && adjacentFirstVisibleItemIndex(offset = -1) != null) {
+            add(
+                CustomAccessibilityAction(
+                    label = normalizedPreviousItemActionLabel,
+                    action = { selectAdjacentItem(offset = -1) }
+                )
+            )
+        }
+        if (normalizedNextItemActionLabel != null && adjacentFirstVisibleItemIndex(offset = 1) != null) {
+            add(
+                CustomAccessibilityAction(
+                    label = normalizedNextItemActionLabel,
+                    action = { selectAdjacentItem(offset = 1) }
+                )
+            )
+        }
+    }
 
     Box(
         modifier = modifier.semantics {
             // Provide picker-level accessibility information
-            normalizedPickerLabel?.let { label ->
-                val selectedItemDescription = itemContentDescription(state.selectedItem)
-                contentDescription = pickerAccessibilityDescription(label, selectedItemDescription)
+            if (hasPickerDescription) {
+                contentDescription = pickerDescription
                 stateDescription = selectedItemDescription
                 liveRegion = LiveRegionMode.Polite
             }
             collectionInfo = CollectionInfo(rowCount = items.size, columnCount = 1)
+            if (hasPickerDescription && accessibilityActions.isNotEmpty()) {
+                customActions = accessibilityActions
+            }
         }
     ) {
         Box(

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerDefaults.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerDefaults.kt
@@ -47,6 +47,16 @@ object PickerDefaults {
     val SelectedItemBackgroundShape: Shape = RoundedCornerShape(12.dp)
 
     /**
+     * Default accessibility action label for selecting the previous picker item.
+     */
+    const val PreviousItemActionLabel: String = "Select previous item"
+
+    /**
+     * Default accessibility action label for selecting the next picker item.
+     */
+    const val NextItemActionLabel: String = "Select next item"
+
+    /**
      * Default shape for the dividers.
      */
     val DividerShape: Shape = RoundedCornerShape(10.dp)

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -53,6 +53,8 @@ import kotlinx.datetime.LocalDate
  * @param yearItemContentDescription Accessibility description for each year value.
  * @param monthItemContentDescription Accessibility description for each month value.
  * @param dayItemContentDescription Accessibility description for each day value.
+ * @param previousItemActionLabel Accessibility action label used by child pickers to select the previous item. Pass null or blank to omit the action.
+ * @param nextItemActionLabel Accessibility action label used by child pickers to select the next item. Pass null or blank to omit the action.
  * @throws IllegalArgumentException if custom item lists are empty or contain values outside the supported ranges.
  */
 @Composable
@@ -81,7 +83,9 @@ fun DatePicker(
     dayPickerLabel: String? = "Day",
     yearItemContentDescription: (Int) -> String = { it.toString() },
     monthItemContentDescription: (Int) -> String = { it.toString() },
-    dayItemContentDescription: (Int) -> String = { it.toString() }
+    dayItemContentDescription: (Int) -> String = { it.toString() },
+    previousItemActionLabel: String? = PickerDefaults.PreviousItemActionLabel,
+    nextItemActionLabel: String? = PickerDefaults.NextItemActionLabel
 ) {
     validateDatePickerItems(
         state = state,
@@ -132,7 +136,9 @@ fun DatePicker(
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
                     pickerLabel = yearPickerLabel,
-                    itemContentDescription = yearItemContentDescription
+                    itemContentDescription = yearItemContentDescription,
+                    previousItemActionLabel = previousItemActionLabel,
+                    nextItemActionLabel = nextItemActionLabel
                 )
 
                 Picker(
@@ -152,7 +158,9 @@ fun DatePicker(
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
                     pickerLabel = monthPickerLabel,
-                    itemContentDescription = monthItemContentDescription
+                    itemContentDescription = monthItemContentDescription,
+                    previousItemActionLabel = previousItemActionLabel,
+                    nextItemActionLabel = nextItemActionLabel
                 )
 
                 key(maxDay) {
@@ -174,7 +182,9 @@ fun DatePicker(
                         dividerShape = dividerShape,
                         isDividerVisible = isDividerVisible,
                         pickerLabel = dayPickerLabel,
-                        itemContentDescription = dayItemContentDescription
+                        itemContentDescription = dayItemContentDescription,
+                        previousItemActionLabel = previousItemActionLabel,
+                        nextItemActionLabel = nextItemActionLabel
                     )
                 }
             }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -54,6 +54,8 @@ import kotlinx.datetime.number
  * @param monthPickerLabel Accessibility label for the month picker. Pass null to omit the picker label prefix.
  * @param yearItemContentDescription Accessibility description for each year value.
  * @param monthItemContentDescription Accessibility description for each month value.
+ * @param previousItemActionLabel Accessibility action label used by child pickers to select the previous item. Pass null or blank to omit the action.
+ * @param nextItemActionLabel Accessibility action label used by child pickers to select the next item. Pass null or blank to omit the action.
  * @throws IllegalArgumentException if custom item lists are empty or contain values outside the supported ranges.
  */
 @Composable
@@ -80,7 +82,9 @@ fun YearMonthPicker(
     yearPickerLabel: String? = "Year",
     monthPickerLabel: String? = "Month",
     yearItemContentDescription: (Int) -> String = { it.toString() },
-    monthItemContentDescription: (Int) -> String = { it.toString() }
+    monthItemContentDescription: (Int) -> String = { it.toString() },
+    previousItemActionLabel: String? = PickerDefaults.PreviousItemActionLabel,
+    nextItemActionLabel: String? = PickerDefaults.NextItemActionLabel
 ) {
     validateYearMonthPickerItems(
         state = state,
@@ -126,7 +130,9 @@ fun YearMonthPicker(
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
                     pickerLabel = yearPickerLabel,
-                    itemContentDescription = yearItemContentDescription
+                    itemContentDescription = yearItemContentDescription,
+                    previousItemActionLabel = previousItemActionLabel,
+                    nextItemActionLabel = nextItemActionLabel
                 )
                 Picker(
                     state = state.monthState,
@@ -145,7 +151,9 @@ fun YearMonthPicker(
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
                     pickerLabel = monthPickerLabel,
-                    itemContentDescription = monthItemContentDescription
+                    itemContentDescription = monthItemContentDescription,
+                    previousItemActionLabel = previousItemActionLabel,
+                    nextItemActionLabel = nextItemActionLabel
                 )
             }
         }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -61,6 +61,8 @@ import kotlinx.datetime.LocalDateTime
  * @param hourItemContentDescription Accessibility description for each hour value.
  * @param minuteItemContentDescription Accessibility description for each minute value.
  * @param periodItemContentDescription Accessibility description for each AM/PM value in [TimeFormat.HOUR_12].
+ * @param previousItemActionLabel Accessibility action label used by child pickers to select the previous item. Pass null or blank to omit the action.
+ * @param nextItemActionLabel Accessibility action label used by child pickers to select the next item. Pass null or blank to omit the action.
  * @throws IllegalArgumentException if custom item lists are empty where required or contain values outside the supported ranges.
  */
 @Composable
@@ -93,7 +95,9 @@ fun TimePicker(
     periodPickerLabel: String? = "AM/PM",
     hourItemContentDescription: (Int) -> String = { it.toString() },
     minuteItemContentDescription: (Int) -> String = { it.toString() },
-    periodItemContentDescription: (TimePeriod) -> String = { it.name }
+    periodItemContentDescription: (TimePeriod) -> String = { it.name },
+    previousItemActionLabel: String? = PickerDefaults.PreviousItemActionLabel,
+    nextItemActionLabel: String? = PickerDefaults.NextItemActionLabel
 ) {
     validateTimePickerItems(
         state = state,
@@ -145,7 +149,9 @@ fun TimePicker(
                         isDividerVisible = isDividerVisible,
                         isInfinity = false,
                         pickerLabel = periodPickerLabel,
-                        itemContentDescription = periodItemContentDescription
+                        itemContentDescription = periodItemContentDescription,
+                        previousItemActionLabel = previousItemActionLabel,
+                        nextItemActionLabel = nextItemActionLabel
                     )
                     Spacer(modifier = Modifier.width(spacingBetweenPickers))
                 }
@@ -166,7 +172,9 @@ fun TimePicker(
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
                     pickerLabel = hourPickerLabel,
-                    itemContentDescription = hourItemContentDescription
+                    itemContentDescription = hourItemContentDescription,
+                    previousItemActionLabel = previousItemActionLabel,
+                    nextItemActionLabel = nextItemActionLabel
                 )
                 Spacer(modifier = Modifier.width(spacingBetweenPickers))
                 Picker(
@@ -186,7 +194,9 @@ fun TimePicker(
                     dividerShape = dividerShape,
                     isDividerVisible = isDividerVisible,
                     pickerLabel = minutePickerLabel,
-                    itemContentDescription = minuteItemContentDescription
+                    itemContentDescription = minuteItemContentDescription,
+                    previousItemActionLabel = previousItemActionLabel,
+                    nextItemActionLabel = nextItemActionLabel
                 )
             }
         }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -101,7 +101,9 @@ fun DatePickerSampleScreen(
                     dayPickerLabel = "일",
                     yearItemContentDescription = { "${it}년" },
                     monthItemContentDescription = { getMonthContentDescription(it) },
-                    dayItemContentDescription = { "${it}일" }
+                    dayItemContentDescription = { "${it}일" },
+                    previousItemActionLabel = "이전 항목 선택",
+                    nextItemActionLabel = "다음 항목 선택"
                 )
             }
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -198,7 +198,9 @@ internal fun TimePickerSampleScreen(
                     periodPickerLabel = "오전/오후",
                     hourItemContentDescription = { "${it}시" },
                     minuteItemContentDescription = { "${it}분" },
-                    periodItemContentDescription = { it.name }
+                    periodItemContentDescription = { it.name },
+                    previousItemActionLabel = "이전 항목 선택",
+                    nextItemActionLabel = "다음 항목 선택"
                 )
             } else {
                 TimePicker(
@@ -207,7 +209,9 @@ internal fun TimePickerSampleScreen(
                     hourPickerLabel = "시",
                     minutePickerLabel = "분",
                     hourItemContentDescription = { "${it}시" },
-                    minuteItemContentDescription = { "${it}분" }
+                    minuteItemContentDescription = { "${it}분" },
+                    previousItemActionLabel = "이전 항목 선택",
+                    nextItemActionLabel = "다음 항목 선택"
                 )
             }
         }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
@@ -149,7 +149,9 @@ internal fun YearMonthPickerSampleScreen(
                 yearPickerLabel = "연도",
                 monthPickerLabel = "월",
                 yearItemContentDescription = { "${it}년" },
-                monthItemContentDescription = { getMonthContentDescription(it) }
+                monthItemContentDescription = { getMonthContentDescription(it) },
+                previousItemActionLabel = "이전 항목 선택",
+                nextItemActionLabel = "다음 항목 선택"
             )
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- Add previous/next custom accessibility actions to Picker semantics.
- Expose localized action label parameters through Picker, TimePicker, DatePicker, and YearMonthPicker.
- Update Android semantics tests, sample screens, README, and README_KO for the new accessibility behavior.

## Six-agent review follow-up
- Fixed no-op actions for single-item infinite pickers.
- Changed adjacent selection to use the current scroll position instead of value indexOf so duplicate values do not hide actions incorrectly.
- Added localizable action label API and propagated it through high-level pickers.
- Added boundary, infinite-wrap, duplicate-value, no-label, and high-level forwarding test coverage.

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:compileDebugAndroidTestKotlinAndroid --no-daemon
- ./gradlew :datetimepicker:check :datetimepicker:assembleDebugAndroidTest :sample:assembleDebug :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution --no-daemon
- git diff --check
- adb devices (no connected devices; connectedDebugAndroidTest not run)