### PR TITLE
ci: run android instrumented tests on managed device

### DIFF
--- a/.github/workflows/integration-build-test.yml
+++ b/.github/workflows/integration-build-test.yml
@@ -19,7 +19,7 @@ jobs:
   linux-builds:
     name: Linux • ${{ matrix.target }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -46,9 +46,19 @@ jobs:
         if: matrix.target == 'android'
         run: |
           sdkmanager "platform-tools" \
+                     "emulator" \
+                     "platforms;android-35" \
                      "platforms;android-36" \
-                     "build-tools;36.0.0"
+                     "build-tools;36.0.0" \
+                     "system-images;android-35;aosp_atd;x86_64"
           yes | sdkmanager --licenses
+
+      - name: Enable KVM permissions
+        if: matrix.target == 'android'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       # Android Build/Unit Test
       - name: Gradle Build • Android
@@ -58,9 +68,29 @@ jobs:
             ${{ env.LIBRARY_MODULE }}:clean \
             ${{ env.LIBRARY_MODULE }}:assembleRelease \
             ${{ env.LIBRARY_MODULE }}:testReleaseUnitTest \
-            ${{ env.LIBRARY_MODULE }}:assembleDebugAndroidTest \
             ${{ env.SAMPLE_MODULE }}:assembleDebug \
             --no-daemon
+
+      # Android Managed Device Instrumented Test
+      - name: Gradle Instrumented Test • Android managed device
+        if: matrix.target == 'android'
+        run: |
+          ./gradlew \
+            ${{ env.LIBRARY_MODULE }}:pixel2Api35DebugAndroidTest \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+            --stacktrace \
+            --no-daemon
+
+      - name: Upload Android instrumented test reports
+        if: matrix.target == 'android' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-instrumented-test-reports
+          path: |
+            datetimepicker/build/reports/androidTests/**
+            datetimepicker/build/outputs/androidTest-results/**
+            datetimepicker/build/outputs/managed_device_android_test_additional_output/**
+          if-no-files-found: ignore
 
       # Web(WASM) Build/Test
       - name: Gradle Build • Web (WASM)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,12 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 # Compile Android instrumented tests
 ./gradlew :datetimepicker:assembleDebugAndroidTest --no-daemon
 
-# Run Android instrumented tests on a connected device or emulator
+# Run Android instrumented tests on the Gradle Managed Device target used by CI
+./gradlew :datetimepicker:pixel2Api35DebugAndroidTest \
+  -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+  --no-daemon
+
+# Run Android instrumented tests on an already connected local device or emulator
 ./gradlew :datetimepicker:connectedDebugAndroidTest --no-daemon
 
 # Run checks (tests + lint)
@@ -210,7 +215,7 @@ color = lerp(selectedTextStyle.color, textStyle.color, fraction)
 **When adding tests**:
 - Unit tests → `datetimepicker/src/commonTest/kotlin/`
 - Android UI/instrumented tests → `datetimepicker/src/androidInstrumentedTest/kotlin/`
-- Use `:datetimepicker:assembleDebugAndroidTest` to verify Android test APK compilation/packaging in CI-friendly environments, and `:datetimepicker:connectedDebugAndroidTest` when a device or emulator is available.
+- Use `:datetimepicker:assembleDebugAndroidTest` to verify Android test APK compilation/packaging. Use `:datetimepicker:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect` for the Gradle Managed Device path used by CI; it requires Android Emulator, the API 35 AOSP ATD x86_64 system image, and local virtualization/KVM. Use `:datetimepicker:connectedDebugAndroidTest` when a local device or emulator is already available. If managed-device prerequisites are unavailable locally, run `assembleDebugAndroidTest` or a managed-device `--dry-run` and rely on CI for the actual emulator run.
 - Follow naming: `<ComponentName>Test.kt` or `<ComponentName>AndroidTest.kt`
 
 ## Code Style
@@ -232,7 +237,7 @@ Follow **Semantic Versioning**: MAJOR.MINOR.PATCH
 ## CI/CD
 
 GitHub Actions workflows:
-- **`integration-build-test.yml`**: Runs multiplatform library checks on pull requests to `main`
+- **`integration-build-test.yml`**: Runs multiplatform library checks on pull requests to `main`; the Android matrix also runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for instrumented tests.
 - **`maven-central-deploy.yml`**: Publishes releases to Maven Central
 
 Build matrix: Ubuntu latest for Android/Desktop/Wasm and macOS 14 for iOS, using JDK 17 (Temurin)

--- a/datetimepicker/build.gradle.kts
+++ b/datetimepicker/build.gradle.kts
@@ -107,6 +107,19 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    testOptions {
+        managedDevices {
+            localDevices {
+                create("pixel2Api35") {
+                    device = "Pixel 2"
+                    apiLevel = 35
+                    systemImageSource = "aosp-atd"
+                    require64Bit = true
+                }
+            }
+        }
+    }
+
     buildFeatures { compose = true }
 }
 


### PR DESCRIPTION
## Summary
- Add a Gradle Managed Device target (`pixel2Api35`) for Android instrumented tests.
- Run `pixel2Api35DebugAndroidTest` in the Android CI matrix with emulator, KVM, and software GPU settings.
- Upload Android instrumented test reports on CI failure and document the managed-device path in AGENTS.md.

## Six-agent review follow-up
- Added explicit `emulator` SDK package installation.
- Added `-Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect` for GitHub Actions managed-device execution.
- Set the managed device to require 64-bit to match the installed x86_64 AOSP ATD image.
- Split managed-device execution into a separate CI step and added report artifact upload.

## Verification
- ./gradlew :datetimepicker:tasks --all --no-daemon | rg "pixel2Api35|Managed"
- ./gradlew :datetimepicker:pixel2Api35DebugAndroidTest --dry-run -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --no-daemon
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:assembleDebugAndroidTest --no-daemon
- git diff --check

## Residual risk
- Local validation used dry-run for managed-device execution; the actual emulator boot/test run is validated by this PR CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with increased build timeout and improved Android SDK setup including emulator and virtualization configuration.
  * Added Android managed device testing infrastructure for automated testing.

* **Documentation**
  * Updated testing documentation with managed device testing procedures, prerequisites, and both CI and local execution guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->