### PR TITLE
Add Kotlin ABI validation gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+datetimepicker/api/**/*.api whitespace=-blank-at-eof

--- a/.github/workflows/integration-build-test.yml
+++ b/.github/workflows/integration-build-test.yml
@@ -15,6 +15,38 @@ env:
   LIBRARY_MODULE: ":datetimepicker"
   SAMPLE_MODULE: ":sample"
 jobs:
+  abi-check:
+    name: macOS • Kotlin ABI Check
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: gradle/actions/wrapper-validation@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android build tools
+        run: |
+          sdkmanager "platform-tools" \
+                     "platforms;android-36" \
+                     "build-tools;36.0.0"
+          yes | sdkmanager --licenses
+
+      - name: Gradle Check • Kotlin ABI
+        run: |
+          ./gradlew \
+            ${{ env.LIBRARY_MODULE }}:checkLegacyAbi \
+            --no-daemon
 
   linux-builds:
     name: Linux • ${{ matrix.target }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - When adding public state mutation APIs, keep logical state and picker scroll position synchronized, and document behavior when custom item lists do not contain the requested value.
 - During programmatic selection sync, do not let intermediate `LazyListState` scroll positions overwrite the requested state value before the picker settles.
 - When higher-level components pass accessibility labels to `Picker`, expose those labels and item content descriptions as public parameters with sensible defaults so Android apps can localize TalkBack output. Update KDoc and both READMEs in the same PR.
+- Kotlin 2.2.21 ABI validation uses `checkLegacyAbi`/`updateLegacyAbi` in this repo. Re-check task names and dump format after Kotlin upgrades.
+- Treat `datetimepicker/api/` as committed release-gate data. Public API changes must include reviewed ABI dump updates, and reviewers should separate intended picker/state API changes from preview/generated resource churn.
 - Keep repository guidance up to date in this `AGENTS.md` when the maintainer gives durable process feedback.
 - Do not include local agent/tooling folders such as `.agents/` or `.claude/` in product PRs unless the change is explicitly about agent workflow assets.
 
@@ -136,6 +138,13 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 
 # Run checks (tests + lint)
 ./gradlew :datetimepicker:check --no-daemon
+
+# Check public Kotlin ABI against the committed reference dump.
+# Run this explicitly; do not assume :datetimepicker:check covers the ABI gate.
+./gradlew :datetimepicker:checkLegacyAbi --no-daemon
+
+# Update the Kotlin ABI reference dump after an intentional public API change
+./gradlew :datetimepicker:updateLegacyAbi --no-daemon
 
 # Verify sample app compilation
 ./gradlew :sample:compileKotlinDesktop --no-daemon
@@ -216,6 +225,7 @@ color = lerp(selectedTextStyle.color, textStyle.color, fraction)
 - Unit tests → `datetimepicker/src/commonTest/kotlin/`
 - Android UI/instrumented tests → `datetimepicker/src/androidInstrumentedTest/kotlin/`
 - Use `:datetimepicker:assembleDebugAndroidTest` to verify Android test APK compilation/packaging. Use `:datetimepicker:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect` for the Gradle Managed Device path used by CI; it requires Android Emulator, the API 35 AOSP ATD x86_64 system image, and local virtualization/KVM. Use `:datetimepicker:connectedDebugAndroidTest` when a local device or emulator is already available. If managed-device prerequisites are unavailable locally, run `assembleDebugAndroidTest` or a managed-device `--dry-run` and rely on CI for the actual emulator run.
+- Public Kotlin API/ABI changes → run `:datetimepicker:checkLegacyAbi`. If the API change is intentional and SemVer-appropriate, run `:datetimepicker:updateLegacyAbi`, commit the updated `datetimepicker/api/` dumps, and review preview/generated resource changes separately from supported picker/state API changes.
 - Follow naming: `<ComponentName>Test.kt` or `<ComponentName>AndroidTest.kt`
 
 ## Code Style
@@ -237,7 +247,7 @@ Follow **Semantic Versioning**: MAJOR.MINOR.PATCH
 ## CI/CD
 
 GitHub Actions workflows:
-- **`integration-build-test.yml`**: Runs multiplatform library checks on pull requests to `main`; the Android matrix also runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for instrumented tests.
+- **`integration-build-test.yml`**: Runs multiplatform library checks on pull requests to `main`; the dedicated macOS ABI job runs `checkLegacyAbi`, and the Android matrix runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for instrumented tests.
 - **`maven-central-deploy.yml`**: Publishes releases to Maven Central
 
 Build matrix: Ubuntu latest for Android/Desktop/Wasm and macOS 14 for iOS, using JDK 17 (Temurin)

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -1,0 +1,225 @@
+public final class com/kez/picker/PickerColors {
+	public static final field $stable I
+	public synthetic fun <init> (JJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-0d7_KjU ()J
+	public final fun component2-0d7_KjU ()J
+	public final fun component3-0d7_KjU ()J
+	public final fun component4-0d7_KjU ()J
+	public final fun copy-jRlVdoo (JJJJ)Lcom/kez/picker/PickerColors;
+	public static synthetic fun copy-jRlVdoo$default (Lcom/kez/picker/PickerColors;JJJJILjava/lang/Object;)Lcom/kez/picker/PickerColors;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDividerColor-0d7_KjU ()J
+	public final fun getSelectedItemBackgroundColor-0d7_KjU ()J
+	public final fun getSelectedTextColor-0d7_KjU ()J
+	public final fun getTextColor-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/PickerDefaults {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/PickerDefaults;
+	public static final field NextItemActionLabel Ljava/lang/String;
+	public static final field PreviousItemActionLabel Ljava/lang/String;
+	public static final field VisibleItemsCount I
+	public final fun colors-ro_MJ88 (JJJJLandroidx/compose/runtime/Composer;II)Lcom/kez/picker/PickerColors;
+	public final fun fadingEdgeGradient ()Landroidx/compose/ui/graphics/Brush;
+	public final fun getDividerShape ()Landroidx/compose/ui/graphics/Shape;
+	public final fun getDividerThickness-D9Ej5fM ()F
+	public final fun getItemPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public final fun getSelectedItemBackgroundShape ()Landroidx/compose/ui/graphics/Shape;
+	public final fun getSpacingBetweenPickers-D9Ej5fM ()F
+	public final fun textStyles (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/PickerTextStyles;
+}
+
+public final class com/kez/picker/PickerKt {
+	public static final fun Picker-RZLgG4U (Ljava/util/List;Lcom/kez/picker/PickerState;Landroidx/compose/ui/Modifier;IILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;ZZLjava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun Picker5VisibleItemsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerBoundedPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerCustomColorsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerLongTextPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerManyItemsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerNoDividerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerSelectedBackgroundPreview (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/PickerState {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getSelectedItem ()Ljava/lang/Object;
+	public final fun selectItem (Ljava/lang/Object;)V
+}
+
+public final class com/kez/picker/PickerStateKt {
+	public static final fun rememberPickerState (Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Lcom/kez/picker/PickerState;
+	public static final fun rememberTimePickerState (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/util/TimeFormat;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/TimePickerState;
+	public static final fun rememberTimePickerState (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/TimePickerState;
+	public static final fun rememberYearMonthPickerState (IILandroidx/compose/runtime/Composer;II)Lcom/kez/picker/YearMonthPickerState;
+	public static final fun rememberYearMonthPickerState (Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;I)Lcom/kez/picker/YearMonthPickerState;
+}
+
+public final class com/kez/picker/PickerTextStyles {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
+	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
+	public final fun component2 ()Landroidx/compose/ui/text/TextStyle;
+	public final fun copy (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)Lcom/kez/picker/PickerTextStyles;
+	public static synthetic fun copy$default (Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;ILjava/lang/Object;)Lcom/kez/picker/PickerTextStyles;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSelectedTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public final fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/TimePickerState {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/TimePickerState$Companion;
+	public fun <init> (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/util/TimeFormat;)V
+	public final fun getSelectedHour ()I
+	public final fun getSelectedHourOfDay ()I
+	public final fun getSelectedMinute ()I
+	public final fun getSelectedPeriod ()Lcom/kez/picker/util/TimePeriod;
+	public final fun getSelectedTime ()Lkotlinx/datetime/LocalTime;
+	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
+	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
+}
+
+public final class com/kez/picker/TimePickerState$Companion {
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+}
+
+public final class com/kez/picker/YearMonthPickerState {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/YearMonthPickerState$Companion;
+	public fun <init> (II)V
+	public final fun getSelectedMonth ()I
+	public final fun getSelectedMonthDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getSelectedYear ()I
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+	public final fun selectYearMonth (II)V
+}
+
+public final class com/kez/picker/YearMonthPickerState$Companion {
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+}
+
+public final class com/kez/picker/date/DatePickerKt {
+	public static final fun DatePicker-D2qtrsM (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/DatePickerState;Lkotlinx/datetime/LocalDate;Ljava/util/List;Ljava/util/List;ILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;FZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun DatePickerPreview (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/date/DatePickerState {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/date/DatePickerState$Companion;
+	public fun <init> (III)V
+	public final fun getMaxDay ()I
+	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getSelectedDay ()I
+	public final fun getSelectedMonth ()I
+	public final fun getSelectedYear ()I
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+}
+
+public final class com/kez/picker/date/DatePickerState$Companion {
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+}
+
+public final class com/kez/picker/date/DatePickerStateKt {
+	public static final fun rememberDatePickerState (IIILandroidx/compose/runtime/Composer;II)Lcom/kez/picker/date/DatePickerState;
+	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;I)Lcom/kez/picker/date/DatePickerState;
+}
+
+public final class com/kez/picker/date/YearMonthPickerKt {
+	public static final fun YearMonthPicker-7WfaJQo (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/YearMonthPickerState;Lkotlinx/datetime/LocalDate;Ljava/util/List;Ljava/util/List;ILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;FZLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun YearMonthPickerCustomColorsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun YearMonthPickerLargeTextPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun YearMonthPickerNoDividerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun YearMonthPickerPreview (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/resources/ActualResourceCollectorsKt {
+	public static final fun getAllDrawableResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllFontResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllPluralStringResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringArrayResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+}
+
+public final class com/kez/picker/resources/Res {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res;
+	public final fun getUri (Ljava/lang/String;)Ljava/lang/String;
+	public final fun readBytes (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kez/picker/resources/Res$array {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$array;
+}
+
+public final class com/kez/picker/resources/Res$drawable {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$drawable;
+}
+
+public final class com/kez/picker/resources/Res$font {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$font;
+}
+
+public final class com/kez/picker/resources/Res$plurals {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$plurals;
+}
+
+public final class com/kez/picker/resources/Res$string {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$string;
+}
+
+public final class com/kez/picker/time/TimePickerKt {
+	public static final fun TimePicker-5tL9tX4 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/TimePickerState;Lkotlinx/datetime/LocalDateTime;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;FZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun TimePickerCustomColorsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerLargeTextPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerNoDividerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerPreview12Hour (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerPreview24Hour (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/util/TimeCalculationKt {
+	public static final fun calculateTime (IILcom/kez/picker/util/TimeFormat;Lcom/kez/picker/util/TimePeriod;)Lkotlinx/datetime/LocalDateTime;
+	public static synthetic fun calculateTime$default (IILcom/kez/picker/util/TimeFormat;Lcom/kez/picker/util/TimePeriod;ILjava/lang/Object;)Lkotlinx/datetime/LocalDateTime;
+}
+
+public final class com/kez/picker/util/TimeFormat : java/lang/Enum {
+	public static final field HOUR_12 Lcom/kez/picker/util/TimeFormat;
+	public static final field HOUR_24 Lcom/kez/picker/util/TimeFormat;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kez/picker/util/TimeFormat;
+	public static fun values ()[Lcom/kez/picker/util/TimeFormat;
+}
+
+public final class com/kez/picker/util/TimePeriod : java/lang/Enum {
+	public static final field AM Lcom/kez/picker/util/TimePeriod;
+	public static final field PM Lcom/kez/picker/util/TimePeriod;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kez/picker/util/TimePeriod;
+	public static fun values ()[Lcom/kez/picker/util/TimePeriod;
+}
+
+public final class com/kez/picker/util/TimeUtilKt {
+	public static final fun currentDate ()Lkotlinx/datetime/LocalDate;
+	public static final fun currentDateTime ()Lkotlinx/datetime/LocalDateTime;
+	public static final fun currentHour ()I
+	public static final fun currentMinute ()I
+	public static final fun currentMonth ()I
+	public static final fun currentYear ()I
+	public static final fun getHOUR12_RANGE ()Ljava/util/List;
+	public static final fun getHOUR24_RANGE ()Ljava/util/List;
+	public static final fun getMINUTE_RANGE ()Ljava/util/List;
+	public static final fun getMONTH_RANGE ()Ljava/util/List;
+	public static final fun getYEAR_RANGE ()Ljava/util/List;
+}
+

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -1,0 +1,264 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <Compose-DateTimePicker:datetimepicker>
+final enum class com.kez.picker.util/TimeFormat : kotlin/Enum<com.kez.picker.util/TimeFormat> { // com.kez.picker.util/TimeFormat|null[0]
+    enum entry HOUR_12 // com.kez.picker.util/TimeFormat.HOUR_12|null[0]
+    enum entry HOUR_24 // com.kez.picker.util/TimeFormat.HOUR_24|null[0]
+
+    final val entries // com.kez.picker.util/TimeFormat.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kez.picker.util/TimeFormat> // com.kez.picker.util/TimeFormat.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.kez.picker.util/TimeFormat // com.kez.picker.util/TimeFormat.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kez.picker.util/TimeFormat> // com.kez.picker.util/TimeFormat.values|values#static(){}[0]
+}
+
+final enum class com.kez.picker.util/TimePeriod : kotlin/Enum<com.kez.picker.util/TimePeriod> { // com.kez.picker.util/TimePeriod|null[0]
+    enum entry AM // com.kez.picker.util/TimePeriod.AM|null[0]
+    enum entry PM // com.kez.picker.util/TimePeriod.PM|null[0]
+
+    final val entries // com.kez.picker.util/TimePeriod.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.kez.picker.util/TimePeriod> // com.kez.picker.util/TimePeriod.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.kez.picker.util/TimePeriod // com.kez.picker.util/TimePeriod.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.kez.picker.util/TimePeriod> // com.kez.picker.util/TimePeriod.values|values#static(){}[0]
+}
+
+final class <#A: kotlin/Any?> com.kez.picker/PickerState { // com.kez.picker/PickerState|null[0]
+    constructor <init>(#A) // com.kez.picker/PickerState.<init>|<init>(1:0){}[0]
+
+    final var selectedItem // com.kez.picker/PickerState.selectedItem|{}selectedItem[0]
+        final fun <get-selectedItem>(): #A // com.kez.picker/PickerState.selectedItem.<get-selectedItem>|<get-selectedItem>(){}[0]
+
+    final fun selectItem(#A) // com.kez.picker/PickerState.selectItem|selectItem(1:0){}[0]
+}
+
+final class com.kez.picker.date/DatePickerState { // com.kez.picker.date/DatePickerState|null[0]
+    constructor <init>(kotlin/Int, kotlin/Int, kotlin/Int) // com.kez.picker.date/DatePickerState.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+
+    final val maxDay // com.kez.picker.date/DatePickerState.maxDay|{}maxDay[0]
+        final fun <get-maxDay>(): kotlin/Int // com.kez.picker.date/DatePickerState.maxDay.<get-maxDay>|<get-maxDay>(){}[0]
+    final val selectedDate // com.kez.picker.date/DatePickerState.selectedDate|{}selectedDate[0]
+        final fun <get-selectedDate>(): kotlinx.datetime/LocalDate // com.kez.picker.date/DatePickerState.selectedDate.<get-selectedDate>|<get-selectedDate>(){}[0]
+    final val selectedDay // com.kez.picker.date/DatePickerState.selectedDay|{}selectedDay[0]
+        final fun <get-selectedDay>(): kotlin/Int // com.kez.picker.date/DatePickerState.selectedDay.<get-selectedDay>|<get-selectedDay>(){}[0]
+    final val selectedMonth // com.kez.picker.date/DatePickerState.selectedMonth|{}selectedMonth[0]
+        final fun <get-selectedMonth>(): kotlin/Int // com.kez.picker.date/DatePickerState.selectedMonth.<get-selectedMonth>|<get-selectedMonth>(){}[0]
+    final val selectedYear // com.kez.picker.date/DatePickerState.selectedYear|{}selectedYear[0]
+        final fun <get-selectedYear>(): kotlin/Int // com.kez.picker.date/DatePickerState.selectedYear.<get-selectedYear>|<get-selectedYear>(){}[0]
+
+    final fun selectDate(kotlinx.datetime/LocalDate) // com.kez.picker.date/DatePickerState.selectDate|selectDate(kotlinx.datetime.LocalDate){}[0]
+
+    final object Companion { // com.kez.picker.date/DatePickerState.Companion|null[0]
+        final val Saver // com.kez.picker.date/DatePickerState.Companion.Saver|{}Saver[0]
+            final fun <get-Saver>(): androidx.compose.runtime.saveable/Saver<com.kez.picker.date/DatePickerState, kotlin/Any> // com.kez.picker.date/DatePickerState.Companion.Saver.<get-Saver>|<get-Saver>(){}[0]
+    }
+}
+
+final class com.kez.picker/PickerColors { // com.kez.picker/PickerColors|null[0]
+    constructor <init>(androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color) // com.kez.picker/PickerColors.<init>|<init>(androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color){}[0]
+
+    final val dividerColor // com.kez.picker/PickerColors.dividerColor|{}dividerColor[0]
+        final fun <get-dividerColor>(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.dividerColor.<get-dividerColor>|<get-dividerColor>(){}[0]
+    final val selectedItemBackgroundColor // com.kez.picker/PickerColors.selectedItemBackgroundColor|{}selectedItemBackgroundColor[0]
+        final fun <get-selectedItemBackgroundColor>(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.selectedItemBackgroundColor.<get-selectedItemBackgroundColor>|<get-selectedItemBackgroundColor>(){}[0]
+    final val selectedTextColor // com.kez.picker/PickerColors.selectedTextColor|{}selectedTextColor[0]
+        final fun <get-selectedTextColor>(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.selectedTextColor.<get-selectedTextColor>|<get-selectedTextColor>(){}[0]
+    final val textColor // com.kez.picker/PickerColors.textColor|{}textColor[0]
+        final fun <get-textColor>(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.textColor.<get-textColor>|<get-textColor>(){}[0]
+
+    final fun component1(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.component1|component1(){}[0]
+    final fun component2(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.component2|component2(){}[0]
+    final fun component3(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.component3|component3(){}[0]
+    final fun component4(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerColors.component4|component4(){}[0]
+    final fun copy(androidx.compose.ui.graphics/Color = ..., androidx.compose.ui.graphics/Color = ..., androidx.compose.ui.graphics/Color = ..., androidx.compose.ui.graphics/Color = ...): com.kez.picker/PickerColors // com.kez.picker/PickerColors.copy|copy(androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kez.picker/PickerColors.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kez.picker/PickerColors.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kez.picker/PickerColors.toString|toString(){}[0]
+}
+
+final class com.kez.picker/PickerTextStyles { // com.kez.picker/PickerTextStyles|null[0]
+    constructor <init>(androidx.compose.ui.text/TextStyle, androidx.compose.ui.text/TextStyle) // com.kez.picker/PickerTextStyles.<init>|<init>(androidx.compose.ui.text.TextStyle;androidx.compose.ui.text.TextStyle){}[0]
+
+    final val selectedTextStyle // com.kez.picker/PickerTextStyles.selectedTextStyle|{}selectedTextStyle[0]
+        final fun <get-selectedTextStyle>(): androidx.compose.ui.text/TextStyle // com.kez.picker/PickerTextStyles.selectedTextStyle.<get-selectedTextStyle>|<get-selectedTextStyle>(){}[0]
+    final val textStyle // com.kez.picker/PickerTextStyles.textStyle|{}textStyle[0]
+        final fun <get-textStyle>(): androidx.compose.ui.text/TextStyle // com.kez.picker/PickerTextStyles.textStyle.<get-textStyle>|<get-textStyle>(){}[0]
+
+    final fun component1(): androidx.compose.ui.text/TextStyle // com.kez.picker/PickerTextStyles.component1|component1(){}[0]
+    final fun component2(): androidx.compose.ui.text/TextStyle // com.kez.picker/PickerTextStyles.component2|component2(){}[0]
+    final fun copy(androidx.compose.ui.text/TextStyle = ..., androidx.compose.ui.text/TextStyle = ...): com.kez.picker/PickerTextStyles // com.kez.picker/PickerTextStyles.copy|copy(androidx.compose.ui.text.TextStyle;androidx.compose.ui.text.TextStyle){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kez.picker/PickerTextStyles.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kez.picker/PickerTextStyles.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kez.picker/PickerTextStyles.toString|toString(){}[0]
+}
+
+final class com.kez.picker/TimePickerState { // com.kez.picker/TimePickerState|null[0]
+    constructor <init>(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod, com.kez.picker.util/TimeFormat) // com.kez.picker/TimePickerState.<init>|<init>(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod;com.kez.picker.util.TimeFormat){}[0]
+
+    final val selectedHour // com.kez.picker/TimePickerState.selectedHour|{}selectedHour[0]
+        final fun <get-selectedHour>(): kotlin/Int // com.kez.picker/TimePickerState.selectedHour.<get-selectedHour>|<get-selectedHour>(){}[0]
+    final val selectedHourOfDay // com.kez.picker/TimePickerState.selectedHourOfDay|{}selectedHourOfDay[0]
+        final fun <get-selectedHourOfDay>(): kotlin/Int // com.kez.picker/TimePickerState.selectedHourOfDay.<get-selectedHourOfDay>|<get-selectedHourOfDay>(){}[0]
+    final val selectedMinute // com.kez.picker/TimePickerState.selectedMinute|{}selectedMinute[0]
+        final fun <get-selectedMinute>(): kotlin/Int // com.kez.picker/TimePickerState.selectedMinute.<get-selectedMinute>|<get-selectedMinute>(){}[0]
+    final val selectedPeriod // com.kez.picker/TimePickerState.selectedPeriod|{}selectedPeriod[0]
+        final fun <get-selectedPeriod>(): com.kez.picker.util/TimePeriod // com.kez.picker/TimePickerState.selectedPeriod.<get-selectedPeriod>|<get-selectedPeriod>(){}[0]
+    final val selectedTime // com.kez.picker/TimePickerState.selectedTime|{}selectedTime[0]
+        final fun <get-selectedTime>(): kotlinx.datetime/LocalTime // com.kez.picker/TimePickerState.selectedTime.<get-selectedTime>|<get-selectedTime>(){}[0]
+    final val timeFormat // com.kez.picker/TimePickerState.timeFormat|{}timeFormat[0]
+        final fun <get-timeFormat>(): com.kez.picker.util/TimeFormat // com.kez.picker/TimePickerState.timeFormat.<get-timeFormat>|<get-timeFormat>(){}[0]
+
+    final fun selectTime(kotlinx.datetime/LocalTime) // com.kez.picker/TimePickerState.selectTime|selectTime(kotlinx.datetime.LocalTime){}[0]
+
+    final object Companion { // com.kez.picker/TimePickerState.Companion|null[0]
+        final val Saver // com.kez.picker/TimePickerState.Companion.Saver|{}Saver[0]
+            final fun <get-Saver>(): androidx.compose.runtime.saveable/Saver<com.kez.picker/TimePickerState, kotlin/Any> // com.kez.picker/TimePickerState.Companion.Saver.<get-Saver>|<get-Saver>(){}[0]
+    }
+}
+
+final class com.kez.picker/YearMonthPickerState { // com.kez.picker/YearMonthPickerState|null[0]
+    constructor <init>(kotlin/Int, kotlin/Int) // com.kez.picker/YearMonthPickerState.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
+
+    final val selectedMonth // com.kez.picker/YearMonthPickerState.selectedMonth|{}selectedMonth[0]
+        final fun <get-selectedMonth>(): kotlin/Int // com.kez.picker/YearMonthPickerState.selectedMonth.<get-selectedMonth>|<get-selectedMonth>(){}[0]
+    final val selectedMonthDate // com.kez.picker/YearMonthPickerState.selectedMonthDate|{}selectedMonthDate[0]
+        final fun <get-selectedMonthDate>(): kotlinx.datetime/LocalDate // com.kez.picker/YearMonthPickerState.selectedMonthDate.<get-selectedMonthDate>|<get-selectedMonthDate>(){}[0]
+    final val selectedYear // com.kez.picker/YearMonthPickerState.selectedYear|{}selectedYear[0]
+        final fun <get-selectedYear>(): kotlin/Int // com.kez.picker/YearMonthPickerState.selectedYear.<get-selectedYear>|<get-selectedYear>(){}[0]
+
+    final fun selectDate(kotlinx.datetime/LocalDate) // com.kez.picker/YearMonthPickerState.selectDate|selectDate(kotlinx.datetime.LocalDate){}[0]
+    final fun selectYearMonth(kotlin/Int, kotlin/Int) // com.kez.picker/YearMonthPickerState.selectYearMonth|selectYearMonth(kotlin.Int;kotlin.Int){}[0]
+
+    final object Companion { // com.kez.picker/YearMonthPickerState.Companion|null[0]
+        final val Saver // com.kez.picker/YearMonthPickerState.Companion.Saver|{}Saver[0]
+            final fun <get-Saver>(): androidx.compose.runtime.saveable/Saver<com.kez.picker/YearMonthPickerState, kotlin/Any> // com.kez.picker/YearMonthPickerState.Companion.Saver.<get-Saver>|<get-Saver>(){}[0]
+    }
+}
+
+final object com.kez.picker.resources/Res { // com.kez.picker.resources/Res|null[0]
+    final fun getUri(kotlin/String): kotlin/String // com.kez.picker.resources/Res.getUri|getUri(kotlin.String){}[0]
+    final suspend fun readBytes(kotlin/String): kotlin/ByteArray // com.kez.picker.resources/Res.readBytes|readBytes(kotlin.String){}[0]
+
+    final object array // com.kez.picker.resources/Res.array|null[0]
+
+    final object drawable // com.kez.picker.resources/Res.drawable|null[0]
+
+    final object font // com.kez.picker.resources/Res.font|null[0]
+
+    final object plurals // com.kez.picker.resources/Res.plurals|null[0]
+
+    final object string // com.kez.picker.resources/Res.string|null[0]
+}
+
+final object com.kez.picker/PickerDefaults { // com.kez.picker/PickerDefaults|null[0]
+    final const val NextItemActionLabel // com.kez.picker/PickerDefaults.NextItemActionLabel|{}NextItemActionLabel[0]
+        final fun <get-NextItemActionLabel>(): kotlin/String // com.kez.picker/PickerDefaults.NextItemActionLabel.<get-NextItemActionLabel>|<get-NextItemActionLabel>(){}[0]
+    final const val PreviousItemActionLabel // com.kez.picker/PickerDefaults.PreviousItemActionLabel|{}PreviousItemActionLabel[0]
+        final fun <get-PreviousItemActionLabel>(): kotlin/String // com.kez.picker/PickerDefaults.PreviousItemActionLabel.<get-PreviousItemActionLabel>|<get-PreviousItemActionLabel>(){}[0]
+    final const val VisibleItemsCount // com.kez.picker/PickerDefaults.VisibleItemsCount|{}VisibleItemsCount[0]
+        final fun <get-VisibleItemsCount>(): kotlin/Int // com.kez.picker/PickerDefaults.VisibleItemsCount.<get-VisibleItemsCount>|<get-VisibleItemsCount>(){}[0]
+
+    final val DividerShape // com.kez.picker/PickerDefaults.DividerShape|{}DividerShape[0]
+        final fun <get-DividerShape>(): androidx.compose.ui.graphics/Shape // com.kez.picker/PickerDefaults.DividerShape.<get-DividerShape>|<get-DividerShape>(){}[0]
+    final val DividerThickness // com.kez.picker/PickerDefaults.DividerThickness|{}DividerThickness[0]
+        final fun <get-DividerThickness>(): androidx.compose.ui.unit/Dp // com.kez.picker/PickerDefaults.DividerThickness.<get-DividerThickness>|<get-DividerThickness>(){}[0]
+    final val ItemPadding // com.kez.picker/PickerDefaults.ItemPadding|{}ItemPadding[0]
+        final fun <get-ItemPadding>(): androidx.compose.foundation.layout/PaddingValues // com.kez.picker/PickerDefaults.ItemPadding.<get-ItemPadding>|<get-ItemPadding>(){}[0]
+    final val SelectedItemBackgroundShape // com.kez.picker/PickerDefaults.SelectedItemBackgroundShape|{}SelectedItemBackgroundShape[0]
+        final fun <get-SelectedItemBackgroundShape>(): androidx.compose.ui.graphics/Shape // com.kez.picker/PickerDefaults.SelectedItemBackgroundShape.<get-SelectedItemBackgroundShape>|<get-SelectedItemBackgroundShape>(){}[0]
+    final val SpacingBetweenPickers // com.kez.picker/PickerDefaults.SpacingBetweenPickers|{}SpacingBetweenPickers[0]
+        final fun <get-SpacingBetweenPickers>(): androidx.compose.ui.unit/Dp // com.kez.picker/PickerDefaults.SpacingBetweenPickers.<get-SpacingBetweenPickers>|<get-SpacingBetweenPickers>(){}[0]
+
+    final fun colors(androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color, androidx.compose.ui.graphics/Color, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker/PickerColors // com.kez.picker/PickerDefaults.colors|colors(androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.ui.graphics.Color;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+    final fun fadingEdgeGradient(): androidx.compose.ui.graphics/Brush // com.kez.picker/PickerDefaults.fadingEdgeGradient|fadingEdgeGradient(){}[0]
+    final fun textStyles(androidx.compose.ui.text/TextStyle?, androidx.compose.ui.text/TextStyle?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker/PickerTextStyles // com.kez.picker/PickerDefaults.textStyles|textStyles(androidx.compose.ui.text.TextStyle?;androidx.compose.ui.text.TextStyle?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+}
+
+final val com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop // com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop|#static{}com_kez_picker_date_DatePickerState$stableprop[0]
+final val com.kez.picker.resources/allDrawableResources // com.kez.picker.resources/allDrawableResources|@com.kez.picker.resources.Res{}allDrawableResources[0]
+    final fun (com.kez.picker.resources/Res).<get-allDrawableResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/DrawableResource> // com.kez.picker.resources/allDrawableResources.<get-allDrawableResources>|<get-allDrawableResources>@com.kez.picker.resources.Res(){}[0]
+final val com.kez.picker.resources/allFontResources // com.kez.picker.resources/allFontResources|@com.kez.picker.resources.Res{}allFontResources[0]
+    final fun (com.kez.picker.resources/Res).<get-allFontResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/FontResource> // com.kez.picker.resources/allFontResources.<get-allFontResources>|<get-allFontResources>@com.kez.picker.resources.Res(){}[0]
+final val com.kez.picker.resources/allPluralStringResources // com.kez.picker.resources/allPluralStringResources|@com.kez.picker.resources.Res{}allPluralStringResources[0]
+    final fun (com.kez.picker.resources/Res).<get-allPluralStringResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/PluralStringResource> // com.kez.picker.resources/allPluralStringResources.<get-allPluralStringResources>|<get-allPluralStringResources>@com.kez.picker.resources.Res(){}[0]
+final val com.kez.picker.resources/allStringArrayResources // com.kez.picker.resources/allStringArrayResources|@com.kez.picker.resources.Res{}allStringArrayResources[0]
+    final fun (com.kez.picker.resources/Res).<get-allStringArrayResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/StringArrayResource> // com.kez.picker.resources/allStringArrayResources.<get-allStringArrayResources>|<get-allStringArrayResources>@com.kez.picker.resources.Res(){}[0]
+final val com.kez.picker.resources/allStringResources // com.kez.picker.resources/allStringResources|@com.kez.picker.resources.Res{}allStringResources[0]
+    final fun (com.kez.picker.resources/Res).<get-allStringResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/StringResource> // com.kez.picker.resources/allStringResources.<get-allStringResources>|<get-allStringResources>@com.kez.picker.resources.Res(){}[0]
+final val com.kez.picker.resources/com_kez_picker_resources_Res$stableprop // com.kez.picker.resources/com_kez_picker_resources_Res$stableprop|#static{}com_kez_picker_resources_Res$stableprop[0]
+final val com.kez.picker.resources/com_kez_picker_resources_Res_array$stableprop // com.kez.picker.resources/com_kez_picker_resources_Res_array$stableprop|#static{}com_kez_picker_resources_Res_array$stableprop[0]
+final val com.kez.picker.resources/com_kez_picker_resources_Res_drawable$stableprop // com.kez.picker.resources/com_kez_picker_resources_Res_drawable$stableprop|#static{}com_kez_picker_resources_Res_drawable$stableprop[0]
+final val com.kez.picker.resources/com_kez_picker_resources_Res_font$stableprop // com.kez.picker.resources/com_kez_picker_resources_Res_font$stableprop|#static{}com_kez_picker_resources_Res_font$stableprop[0]
+final val com.kez.picker.resources/com_kez_picker_resources_Res_plurals$stableprop // com.kez.picker.resources/com_kez_picker_resources_Res_plurals$stableprop|#static{}com_kez_picker_resources_Res_plurals$stableprop[0]
+final val com.kez.picker.resources/com_kez_picker_resources_Res_string$stableprop // com.kez.picker.resources/com_kez_picker_resources_Res_string$stableprop|#static{}com_kez_picker_resources_Res_string$stableprop[0]
+final val com.kez.picker.util/HOUR12_RANGE // com.kez.picker.util/HOUR12_RANGE|{}HOUR12_RANGE[0]
+    final fun <get-HOUR12_RANGE>(): kotlin.collections/List<kotlin/Int> // com.kez.picker.util/HOUR12_RANGE.<get-HOUR12_RANGE>|<get-HOUR12_RANGE>(){}[0]
+final val com.kez.picker.util/HOUR24_RANGE // com.kez.picker.util/HOUR24_RANGE|{}HOUR24_RANGE[0]
+    final fun <get-HOUR24_RANGE>(): kotlin.collections/List<kotlin/Int> // com.kez.picker.util/HOUR24_RANGE.<get-HOUR24_RANGE>|<get-HOUR24_RANGE>(){}[0]
+final val com.kez.picker.util/MINUTE_RANGE // com.kez.picker.util/MINUTE_RANGE|{}MINUTE_RANGE[0]
+    final fun <get-MINUTE_RANGE>(): kotlin.collections/List<kotlin/Int> // com.kez.picker.util/MINUTE_RANGE.<get-MINUTE_RANGE>|<get-MINUTE_RANGE>(){}[0]
+final val com.kez.picker.util/MONTH_RANGE // com.kez.picker.util/MONTH_RANGE|{}MONTH_RANGE[0]
+    final fun <get-MONTH_RANGE>(): kotlin.collections/List<kotlin/Int> // com.kez.picker.util/MONTH_RANGE.<get-MONTH_RANGE>|<get-MONTH_RANGE>(){}[0]
+final val com.kez.picker.util/YEAR_RANGE // com.kez.picker.util/YEAR_RANGE|{}YEAR_RANGE[0]
+    final fun <get-YEAR_RANGE>(): kotlin.collections/List<kotlin/Int> // com.kez.picker.util/YEAR_RANGE.<get-YEAR_RANGE>|<get-YEAR_RANGE>(){}[0]
+final val com.kez.picker/com_kez_picker_PickerColors$stableprop // com.kez.picker/com_kez_picker_PickerColors$stableprop|#static{}com_kez_picker_PickerColors$stableprop[0]
+final val com.kez.picker/com_kez_picker_PickerDefaults$stableprop // com.kez.picker/com_kez_picker_PickerDefaults$stableprop|#static{}com_kez_picker_PickerDefaults$stableprop[0]
+final val com.kez.picker/com_kez_picker_PickerState$stableprop // com.kez.picker/com_kez_picker_PickerState$stableprop|#static{}com_kez_picker_PickerState$stableprop[0]
+final val com.kez.picker/com_kez_picker_PickerTextStyles$stableprop // com.kez.picker/com_kez_picker_PickerTextStyles$stableprop|#static{}com_kez_picker_PickerTextStyles$stableprop[0]
+final val com.kez.picker/com_kez_picker_TimePickerState$stableprop // com.kez.picker/com_kez_picker_TimePickerState$stableprop|#static{}com_kez_picker_TimePickerState$stableprop[0]
+final val com.kez.picker/com_kez_picker_YearMonthPickerState$stableprop // com.kez.picker/com_kez_picker_YearMonthPickerState$stableprop|#static{}com_kez_picker_YearMonthPickerState$stableprop[0]
+
+final fun <#A: kotlin/Any?> com.kez.picker/Picker(kotlin.collections/List<#A>, com.kez.picker/PickerState<#A>, androidx.compose.ui/Modifier?, kotlin/Int, kotlin/Int, com.kez.picker/PickerColors?, com.kez.picker/PickerTextStyles?, androidx.compose.ui.graphics/Shape?, androidx.compose.foundation.layout/PaddingValues?, androidx.compose.ui.graphics/Brush?, androidx.compose.ui/Alignment.Horizontal?, androidx.compose.ui/Alignment.Vertical?, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/Shape?, kotlin/Boolean, kotlin/Boolean, kotlin/String?, kotlin/Function1<#A, kotlin/String>?, kotlin/String?, kotlin/String?, kotlin/Function3<#A, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // com.kez.picker/Picker|Picker(kotlin.collections.List<0:0>;com.kez.picker.PickerState<0:0>;androidx.compose.ui.Modifier?;kotlin.Int;kotlin.Int;com.kez.picker.PickerColors?;com.kez.picker.PickerTextStyles?;androidx.compose.ui.graphics.Shape?;androidx.compose.foundation.layout.PaddingValues?;androidx.compose.ui.graphics.Brush?;androidx.compose.ui.Alignment.Horizontal?;androidx.compose.ui.Alignment.Vertical?;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.Shape?;kotlin.Boolean;kotlin.Boolean;kotlin.String?;kotlin.Function1<0:0,kotlin.String>?;kotlin.String?;kotlin.String?;kotlin.Function3<0:0,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> com.kez.picker/rememberPickerState(#A, androidx.compose.runtime/Composer?, kotlin/Int): com.kez.picker/PickerState<#A> // com.kez.picker/rememberPickerState|rememberPickerState(0:0;androidx.compose.runtime.Composer?;kotlin.Int){0§<kotlin.Any?>}[0]
+final fun com.kez.picker.date/DatePicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.date/DatePickerState?, kotlinx.datetime/LocalDate?, kotlin.collections/List<kotlin/Int>?, kotlin.collections/List<kotlin/Int>?, kotlin/Int, com.kez.picker/PickerColors?, com.kez.picker/PickerTextStyles?, androidx.compose.ui.graphics/Shape?, androidx.compose.foundation.layout/PaddingValues?, androidx.compose.ui.graphics/Brush?, androidx.compose.ui/Alignment.Horizontal?, androidx.compose.ui/Alignment.Vertical?, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/Shape?, androidx.compose.ui.unit/Dp, kotlin/Boolean, kotlin/String?, kotlin/String?, kotlin/String?, kotlin/Function1<kotlin/Int, kotlin/String>?, kotlin/Function1<kotlin/Int, kotlin/String>?, kotlin/Function1<kotlin/Int, kotlin/String>?, kotlin/String?, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // com.kez.picker.date/DatePicker|DatePicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.date.DatePickerState?;kotlinx.datetime.LocalDate?;kotlin.collections.List<kotlin.Int>?;kotlin.collections.List<kotlin.Int>?;kotlin.Int;com.kez.picker.PickerColors?;com.kez.picker.PickerTextStyles?;androidx.compose.ui.graphics.Shape?;androidx.compose.foundation.layout.PaddingValues?;androidx.compose.ui.graphics.Brush?;androidx.compose.ui.Alignment.Horizontal?;androidx.compose.ui.Alignment.Vertical?;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.Shape?;androidx.compose.ui.unit.Dp;kotlin.Boolean;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Function1<kotlin.Int,kotlin.String>?;kotlin.Function1<kotlin.Int,kotlin.String>?;kotlin.Function1<kotlin.Int,kotlin.String>?;kotlin.String?;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker.date/DatePickerPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.date/DatePickerPreview|DatePickerPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.date/YearMonthPicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker/YearMonthPickerState?, kotlinx.datetime/LocalDate?, kotlin.collections/List<kotlin/Int>?, kotlin.collections/List<kotlin/Int>?, kotlin/Int, com.kez.picker/PickerColors?, com.kez.picker/PickerTextStyles?, androidx.compose.ui.graphics/Shape?, androidx.compose.foundation.layout/PaddingValues?, androidx.compose.ui.graphics/Brush?, androidx.compose.ui/Alignment.Horizontal?, androidx.compose.ui/Alignment.Vertical?, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/Shape?, androidx.compose.ui.unit/Dp, kotlin/Boolean, kotlin/String?, kotlin/String?, kotlin/Function1<kotlin/Int, kotlin/String>?, kotlin/Function1<kotlin/Int, kotlin/String>?, kotlin/String?, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPicker|YearMonthPicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.YearMonthPickerState?;kotlinx.datetime.LocalDate?;kotlin.collections.List<kotlin.Int>?;kotlin.collections.List<kotlin.Int>?;kotlin.Int;com.kez.picker.PickerColors?;com.kez.picker.PickerTextStyles?;androidx.compose.ui.graphics.Shape?;androidx.compose.foundation.layout.PaddingValues?;androidx.compose.ui.graphics.Brush?;androidx.compose.ui.Alignment.Horizontal?;androidx.compose.ui.Alignment.Vertical?;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.Shape?;androidx.compose.ui.unit.Dp;kotlin.Boolean;kotlin.String?;kotlin.String?;kotlin.Function1<kotlin.Int,kotlin.String>?;kotlin.Function1<kotlin.Int,kotlin.String>?;kotlin.String?;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker.date/YearMonthPickerCustomColorsPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.date/YearMonthPickerCustomColorsPreview|YearMonthPickerCustomColorsPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.date/YearMonthPickerLargeTextPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.date/YearMonthPickerLargeTextPreview|YearMonthPickerLargeTextPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.date/YearMonthPickerNoDividerPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.date/YearMonthPickerNoDividerPreview|YearMonthPickerNoDividerPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.date/YearMonthPickerPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.date/YearMonthPickerPreview|YearMonthPickerPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop_getter(): kotlin/Int // com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop_getter|com_kez_picker_date_DatePickerState$stableprop_getter(){}[0]
+final fun com.kez.picker.date/rememberDatePickerState(kotlin/Int, kotlin/Int, kotlin/Int, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker.date/DatePickerState // com.kez.picker.date/rememberDatePickerState|rememberDatePickerState(kotlin.Int;kotlin.Int;kotlin.Int;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker.date/rememberDatePickerState(kotlinx.datetime/LocalDate, androidx.compose.runtime/Composer?, kotlin/Int): com.kez.picker.date/DatePickerState // com.kez.picker.date/rememberDatePickerState|rememberDatePickerState(kotlinx.datetime.LocalDate;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.resources/com_kez_picker_resources_Res$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res$stableprop_getter|com_kez_picker_resources_Res$stableprop_getter(){}[0]
+final fun com.kez.picker.resources/com_kez_picker_resources_Res_array$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_array$stableprop_getter|com_kez_picker_resources_Res_array$stableprop_getter(){}[0]
+final fun com.kez.picker.resources/com_kez_picker_resources_Res_drawable$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_drawable$stableprop_getter|com_kez_picker_resources_Res_drawable$stableprop_getter(){}[0]
+final fun com.kez.picker.resources/com_kez_picker_resources_Res_font$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_font$stableprop_getter|com_kez_picker_resources_Res_font$stableprop_getter(){}[0]
+final fun com.kez.picker.resources/com_kez_picker_resources_Res_plurals$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_plurals$stableprop_getter|com_kez_picker_resources_Res_plurals$stableprop_getter(){}[0]
+final fun com.kez.picker.resources/com_kez_picker_resources_Res_string$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_string$stableprop_getter|com_kez_picker_resources_Res_string$stableprop_getter(){}[0]
+final fun com.kez.picker.time/TimePicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker/TimePickerState?, kotlinx.datetime/LocalDateTime?, kotlin.collections/List<kotlin/Int>?, kotlin.collections/List<kotlin/Int>?, kotlin.collections/List<com.kez.picker.util/TimePeriod>?, kotlin/Int, com.kez.picker/PickerColors?, com.kez.picker/PickerTextStyles?, androidx.compose.ui.graphics/Shape?, androidx.compose.foundation.layout/PaddingValues?, androidx.compose.ui.graphics/Brush?, androidx.compose.ui/Alignment.Horizontal?, androidx.compose.ui/Alignment.Vertical?, androidx.compose.ui.unit/Dp, androidx.compose.ui.graphics/Shape?, androidx.compose.ui.unit/Dp, kotlin/Boolean, kotlin/String?, kotlin/String?, kotlin/String?, kotlin/Function1<kotlin/Int, kotlin/String>?, kotlin/Function1<kotlin/Int, kotlin/String>?, kotlin/Function1<com.kez.picker.util/TimePeriod, kotlin/String>?, kotlin/String?, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int) // com.kez.picker.time/TimePicker|TimePicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.TimePickerState?;kotlinx.datetime.LocalDateTime?;kotlin.collections.List<kotlin.Int>?;kotlin.collections.List<kotlin.Int>?;kotlin.collections.List<com.kez.picker.util.TimePeriod>?;kotlin.Int;com.kez.picker.PickerColors?;com.kez.picker.PickerTextStyles?;androidx.compose.ui.graphics.Shape?;androidx.compose.foundation.layout.PaddingValues?;androidx.compose.ui.graphics.Brush?;androidx.compose.ui.Alignment.Horizontal?;androidx.compose.ui.Alignment.Vertical?;androidx.compose.ui.unit.Dp;androidx.compose.ui.graphics.Shape?;androidx.compose.ui.unit.Dp;kotlin.Boolean;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Function1<kotlin.Int,kotlin.String>?;kotlin.Function1<kotlin.Int,kotlin.String>?;kotlin.Function1<com.kez.picker.util.TimePeriod,kotlin.String>?;kotlin.String?;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker.time/TimePickerCustomColorsPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.time/TimePickerCustomColorsPreview|TimePickerCustomColorsPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.time/TimePickerLargeTextPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.time/TimePickerLargeTextPreview|TimePickerLargeTextPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.time/TimePickerNoDividerPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.time/TimePickerNoDividerPreview|TimePickerNoDividerPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.time/TimePickerPreview12Hour(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.time/TimePickerPreview12Hour|TimePickerPreview12Hour(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.time/TimePickerPreview24Hour(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker.time/TimePickerPreview24Hour|TimePickerPreview24Hour(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker.util/calculateTime(kotlin/Int, kotlin/Int, com.kez.picker.util/TimeFormat, com.kez.picker.util/TimePeriod? = ...): kotlinx.datetime/LocalDateTime // com.kez.picker.util/calculateTime|calculateTime(kotlin.Int;kotlin.Int;com.kez.picker.util.TimeFormat;com.kez.picker.util.TimePeriod?){}[0]
+final fun com.kez.picker.util/currentDate(): kotlinx.datetime/LocalDate // com.kez.picker.util/currentDate|currentDate(){}[0]
+final fun com.kez.picker.util/currentDateTime(): kotlinx.datetime/LocalDateTime // com.kez.picker.util/currentDateTime|currentDateTime(){}[0]
+final fun com.kez.picker.util/currentHour(): kotlin/Int // com.kez.picker.util/currentHour|currentHour(){}[0]
+final fun com.kez.picker.util/currentMinute(): kotlin/Int // com.kez.picker.util/currentMinute|currentMinute(){}[0]
+final fun com.kez.picker.util/currentMonth(): kotlin/Int // com.kez.picker.util/currentMonth|currentMonth(){}[0]
+final fun com.kez.picker.util/currentYear(): kotlin/Int // com.kez.picker.util/currentYear|currentYear(){}[0]
+final fun com.kez.picker/Picker5VisibleItemsPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/Picker5VisibleItemsPreview|Picker5VisibleItemsPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/PickerBoundedPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/PickerBoundedPreview|PickerBoundedPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/PickerCustomColorsPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/PickerCustomColorsPreview|PickerCustomColorsPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/PickerLongTextPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/PickerLongTextPreview|PickerLongTextPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/PickerManyItemsPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/PickerManyItemsPreview|PickerManyItemsPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/PickerNoDividerPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/PickerNoDividerPreview|PickerNoDividerPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/PickerPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/PickerPreview|PickerPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/PickerSelectedBackgroundPreview(androidx.compose.runtime/Composer?, kotlin/Int) // com.kez.picker/PickerSelectedBackgroundPreview|PickerSelectedBackgroundPreview(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+final fun com.kez.picker/com_kez_picker_PickerColors$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerColors$stableprop_getter|com_kez_picker_PickerColors$stableprop_getter(){}[0]
+final fun com.kez.picker/com_kez_picker_PickerDefaults$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerDefaults$stableprop_getter|com_kez_picker_PickerDefaults$stableprop_getter(){}[0]
+final fun com.kez.picker/com_kez_picker_PickerState$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerState$stableprop_getter|com_kez_picker_PickerState$stableprop_getter(){}[0]
+final fun com.kez.picker/com_kez_picker_PickerTextStyles$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerTextStyles$stableprop_getter|com_kez_picker_PickerTextStyles$stableprop_getter(){}[0]
+final fun com.kez.picker/com_kez_picker_TimePickerState$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_TimePickerState$stableprop_getter|com_kez_picker_TimePickerState$stableprop_getter(){}[0]
+final fun com.kez.picker/com_kez_picker_YearMonthPickerState$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_YearMonthPickerState$stableprop_getter|com_kez_picker_YearMonthPickerState$stableprop_getter(){}[0]
+final fun com.kez.picker/rememberTimePickerState(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod?, com.kez.picker.util/TimeFormat?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker/TimePickerState // com.kez.picker/rememberTimePickerState|rememberTimePickerState(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod?;com.kez.picker.util.TimeFormat?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker/rememberTimePickerState(kotlinx.datetime/LocalTime, com.kez.picker.util/TimeFormat?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker/TimePickerState // com.kez.picker/rememberTimePickerState|rememberTimePickerState(kotlinx.datetime.LocalTime;com.kez.picker.util.TimeFormat?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker/rememberYearMonthPickerState(kotlin/Int, kotlin/Int, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker/YearMonthPickerState // com.kez.picker/rememberYearMonthPickerState|rememberYearMonthPickerState(kotlin.Int;kotlin.Int;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker/rememberYearMonthPickerState(kotlinx.datetime/LocalDate, androidx.compose.runtime/Composer?, kotlin/Int): com.kez.picker/YearMonthPickerState // com.kez.picker/rememberYearMonthPickerState|rememberYearMonthPickerState(kotlinx.datetime.LocalDate;androidx.compose.runtime.Composer?;kotlin.Int){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -1,0 +1,225 @@
+public final class com/kez/picker/PickerColors {
+	public static final field $stable I
+	public synthetic fun <init> (JJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-0d7_KjU ()J
+	public final fun component2-0d7_KjU ()J
+	public final fun component3-0d7_KjU ()J
+	public final fun component4-0d7_KjU ()J
+	public final fun copy-jRlVdoo (JJJJ)Lcom/kez/picker/PickerColors;
+	public static synthetic fun copy-jRlVdoo$default (Lcom/kez/picker/PickerColors;JJJJILjava/lang/Object;)Lcom/kez/picker/PickerColors;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDividerColor-0d7_KjU ()J
+	public final fun getSelectedItemBackgroundColor-0d7_KjU ()J
+	public final fun getSelectedTextColor-0d7_KjU ()J
+	public final fun getTextColor-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/PickerDefaults {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/PickerDefaults;
+	public static final field NextItemActionLabel Ljava/lang/String;
+	public static final field PreviousItemActionLabel Ljava/lang/String;
+	public static final field VisibleItemsCount I
+	public final fun colors-ro_MJ88 (JJJJLandroidx/compose/runtime/Composer;II)Lcom/kez/picker/PickerColors;
+	public final fun fadingEdgeGradient ()Landroidx/compose/ui/graphics/Brush;
+	public final fun getDividerShape ()Landroidx/compose/ui/graphics/Shape;
+	public final fun getDividerThickness-D9Ej5fM ()F
+	public final fun getItemPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public final fun getSelectedItemBackgroundShape ()Landroidx/compose/ui/graphics/Shape;
+	public final fun getSpacingBetweenPickers-D9Ej5fM ()F
+	public final fun textStyles (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/PickerTextStyles;
+}
+
+public final class com/kez/picker/PickerKt {
+	public static final fun Picker-RZLgG4U (Ljava/util/List;Lcom/kez/picker/PickerState;Landroidx/compose/ui/Modifier;IILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;ZZLjava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun Picker5VisibleItemsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerBoundedPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerCustomColorsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerLongTextPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerManyItemsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerNoDividerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun PickerSelectedBackgroundPreview (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/PickerState {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getSelectedItem ()Ljava/lang/Object;
+	public final fun selectItem (Ljava/lang/Object;)V
+}
+
+public final class com/kez/picker/PickerStateKt {
+	public static final fun rememberPickerState (Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Lcom/kez/picker/PickerState;
+	public static final fun rememberTimePickerState (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/util/TimeFormat;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/TimePickerState;
+	public static final fun rememberTimePickerState (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/TimePickerState;
+	public static final fun rememberYearMonthPickerState (IILandroidx/compose/runtime/Composer;II)Lcom/kez/picker/YearMonthPickerState;
+	public static final fun rememberYearMonthPickerState (Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;I)Lcom/kez/picker/YearMonthPickerState;
+}
+
+public final class com/kez/picker/PickerTextStyles {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
+	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
+	public final fun component2 ()Landroidx/compose/ui/text/TextStyle;
+	public final fun copy (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)Lcom/kez/picker/PickerTextStyles;
+	public static synthetic fun copy$default (Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;ILjava/lang/Object;)Lcom/kez/picker/PickerTextStyles;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSelectedTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public final fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/TimePickerState {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/TimePickerState$Companion;
+	public fun <init> (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/util/TimeFormat;)V
+	public final fun getSelectedHour ()I
+	public final fun getSelectedHourOfDay ()I
+	public final fun getSelectedMinute ()I
+	public final fun getSelectedPeriod ()Lcom/kez/picker/util/TimePeriod;
+	public final fun getSelectedTime ()Lkotlinx/datetime/LocalTime;
+	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
+	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
+}
+
+public final class com/kez/picker/TimePickerState$Companion {
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+}
+
+public final class com/kez/picker/YearMonthPickerState {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/YearMonthPickerState$Companion;
+	public fun <init> (II)V
+	public final fun getSelectedMonth ()I
+	public final fun getSelectedMonthDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getSelectedYear ()I
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+	public final fun selectYearMonth (II)V
+}
+
+public final class com/kez/picker/YearMonthPickerState$Companion {
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+}
+
+public final class com/kez/picker/date/DatePickerKt {
+	public static final fun DatePicker-D2qtrsM (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/DatePickerState;Lkotlinx/datetime/LocalDate;Ljava/util/List;Ljava/util/List;ILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;FZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun DatePickerPreview (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/date/DatePickerState {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/date/DatePickerState$Companion;
+	public fun <init> (III)V
+	public final fun getMaxDay ()I
+	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
+	public final fun getSelectedDay ()I
+	public final fun getSelectedMonth ()I
+	public final fun getSelectedYear ()I
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+}
+
+public final class com/kez/picker/date/DatePickerState$Companion {
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+}
+
+public final class com/kez/picker/date/DatePickerStateKt {
+	public static final fun rememberDatePickerState (IIILandroidx/compose/runtime/Composer;II)Lcom/kez/picker/date/DatePickerState;
+	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;I)Lcom/kez/picker/date/DatePickerState;
+}
+
+public final class com/kez/picker/date/YearMonthPickerKt {
+	public static final fun YearMonthPicker-7WfaJQo (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/YearMonthPickerState;Lkotlinx/datetime/LocalDate;Ljava/util/List;Ljava/util/List;ILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;FZLjava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun YearMonthPickerCustomColorsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun YearMonthPickerLargeTextPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun YearMonthPickerNoDividerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun YearMonthPickerPreview (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/resources/ActualResourceCollectorsKt {
+	public static final fun getAllDrawableResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllFontResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllPluralStringResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringArrayResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringResources (Lcom/kez/picker/resources/Res;)Ljava/util/Map;
+}
+
+public final class com/kez/picker/resources/Res {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res;
+	public final fun getUri (Ljava/lang/String;)Ljava/lang/String;
+	public final fun readBytes (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/kez/picker/resources/Res$array {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$array;
+}
+
+public final class com/kez/picker/resources/Res$drawable {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$drawable;
+}
+
+public final class com/kez/picker/resources/Res$font {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$font;
+}
+
+public final class com/kez/picker/resources/Res$plurals {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$plurals;
+}
+
+public final class com/kez/picker/resources/Res$string {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/kez/picker/resources/Res$string;
+}
+
+public final class com/kez/picker/time/TimePickerKt {
+	public static final fun TimePicker-5tL9tX4 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/TimePickerState;Lkotlinx/datetime/LocalDateTime;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILcom/kez/picker/PickerColors;Lcom/kez/picker/PickerTextStyles;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Alignment$Vertical;FLandroidx/compose/ui/graphics/Shape;FZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun TimePickerCustomColorsPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerLargeTextPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerNoDividerPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerPreview12Hour (Landroidx/compose/runtime/Composer;I)V
+	public static final fun TimePickerPreview24Hour (Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/kez/picker/util/TimeCalculationKt {
+	public static final fun calculateTime (IILcom/kez/picker/util/TimeFormat;Lcom/kez/picker/util/TimePeriod;)Lkotlinx/datetime/LocalDateTime;
+	public static synthetic fun calculateTime$default (IILcom/kez/picker/util/TimeFormat;Lcom/kez/picker/util/TimePeriod;ILjava/lang/Object;)Lkotlinx/datetime/LocalDateTime;
+}
+
+public final class com/kez/picker/util/TimeFormat : java/lang/Enum {
+	public static final field HOUR_12 Lcom/kez/picker/util/TimeFormat;
+	public static final field HOUR_24 Lcom/kez/picker/util/TimeFormat;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kez/picker/util/TimeFormat;
+	public static fun values ()[Lcom/kez/picker/util/TimeFormat;
+}
+
+public final class com/kez/picker/util/TimePeriod : java/lang/Enum {
+	public static final field AM Lcom/kez/picker/util/TimePeriod;
+	public static final field PM Lcom/kez/picker/util/TimePeriod;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/kez/picker/util/TimePeriod;
+	public static fun values ()[Lcom/kez/picker/util/TimePeriod;
+}
+
+public final class com/kez/picker/util/TimeUtilKt {
+	public static final fun currentDate ()Lkotlinx/datetime/LocalDate;
+	public static final fun currentDateTime ()Lkotlinx/datetime/LocalDateTime;
+	public static final fun currentHour ()I
+	public static final fun currentMinute ()I
+	public static final fun currentMonth ()I
+	public static final fun currentYear ()I
+	public static final fun getHOUR12_RANGE ()Ljava/util/List;
+	public static final fun getHOUR24_RANGE ()Ljava/util/List;
+	public static final fun getMINUTE_RANGE ()Ljava/util/List;
+	public static final fun getMONTH_RANGE ()Ljava/util/List;
+	public static final fun getYEAR_RANGE ()Ljava/util/List;
+}
+

--- a/datetimepicker/build.gradle.kts
+++ b/datetimepicker/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -11,6 +12,11 @@ plugins {
 }
 
 kotlin {
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation {
+        enabled.set(true)
+    }
+
     jvmToolchain(17)
 
     androidTarget {


### PR DESCRIPTION
## Summary
- enable Kotlin Gradle Plugin ABI validation for the datetimepicker module
- commit the initial Android, Desktop, and KLIB ABI reference dumps
- add a dedicated macOS CI ABI check and maintainer notes for updating dumps intentionally

## Validation
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:checkLegacyAbi --no-daemon
- ./gradlew :datetimepicker:check :sample:assembleDebug --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon
- git diff --check
- git diff --cached --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/integration-build-test.yml"); puts "yaml-ok"'\n\n## Review loop\nSix-agent review completed. Fixed the common Must-fix by committing ABI dumps, moved the ABI gate into a dedicated macOS job, and documented that ABI checks are separate from :datetimepicker:check.