### PR TITLE
Add unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+This project tracks notable user-facing and maintainer-facing changes here. The repository version is `0.6.0`; the `Unreleased` section documents changes queued for the next release.
+
+## Unreleased
+
+### Added
+
+- Added programmatic selection APIs for picker state objects:
+  `PickerState.selectItem`, `TimePickerState.selectTime`, `DatePickerState.selectDate`,
+  `YearMonthPickerState.selectYearMonth`, and `YearMonthPickerState.selectDate`.
+- Added picker accessibility descriptions and localized item description hooks so Android apps can provide clearer TalkBack output.
+- Added previous/next accessibility actions for picker columns, with public labels that apps can localize.
+
+### Changed
+
+- Updated the sample app to show localized accessibility labels, programmatic selection buttons, and a `DatePicker` example that passes selectable year values through `yearItems = 2024..2026`.
+- Made library `@Preview` composables private tooling code so preview functions do not appear in the supported public API surface.
+
+### Compatibility Notes
+
+- The `*Preview` cleanup removes previously exposed but undocumented tooling symbols from repository ABI dumps. It does not remove supported picker/state APIs. If app code imported those preview functions from a local or snapshot build, remove those calls and use the actual picker composables instead.
+- ABI dump updates are now part of public API review. Intentional public API changes should update `datetimepicker/api/` and explain the compatibility impact.
+
+### Maintenance
+
+- Added Android instrumented accessibility semantics coverage and a Gradle Managed Device CI gate.
+- Added Kotlin ABI validation with committed Android, Desktop, and KLIB API dumps.
+- Pull requests now run Android build/unit, Desktop, Wasm, iOS simulator, Kotlin ABI, and Android managed-device instrumented test gates.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ dependencies {
 }
 ```
 
+For release notes and upgrade-impact details, see [CHANGELOG.md](CHANGELOG.md).
+
 ## Usage
 
 ### TimePicker

--- a/README_KO.md
+++ b/README_KO.md
@@ -37,6 +37,8 @@ dependencies {
 }
 ```
 
+릴리스 노트와 업그레이드 영향은 영문 [CHANGELOG.md](CHANGELOG.md)를 참고하세요.
+
 ## 사용법
 
 ### TimePicker


### PR DESCRIPTION
## Summary
- add CHANGELOG.md with an Unreleased section for the next release
- document programmatic selection APIs, accessibility improvements, sample updates, ABI validation, and CI gates
- link the changelog from README.md and README_KO.md

## Compatibility note
The changelog calls out the `*Preview` symbol cleanup as an undocumented tooling ABI cleanup and tells local/snapshot consumers to stop importing those preview functions.

## Validation
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check
- git diff --cached --check

## Review loop
Six-agent review completed. Fixed wording that overclaimed published/main state, narrowed the Preview compatibility language, and made CI/ABI notes maintainer-facing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Picker state programmatic selection APIs
  * Accessibility improvements for picker columns with navigation actions
  * Localization enhancements

* **Documentation**
  * Added release notes documentation for upcoming version
  * Updated README files with CHANGELOG references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->