### PR TITLE
docs: clarify public release version status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 Compose-DateTimePicker is a Kotlin Multiplatform library providing date and time picker components for Compose. It targets Android, iOS, Desktop (JVM), and Web with a shared codebase, published to Maven Central as `io.github.kez-lab:compose-date-time-picker`.
 
-**Current version**: 0.6.0
+**Repository VERSION_NAME**: 0.6.0
 **License**: Apache 2.0
 
 ## Architecture
@@ -98,6 +98,8 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - Kotlin 2.2.21 ABI validation uses `checkLegacyAbi`/`updateLegacyAbi` in this repo. Re-check task names and dump format after Kotlin upgrades.
 - Treat `datetimepicker/api/` as committed release-gate data. Public API changes must include reviewed ABI dump updates, and reviewers should separate intended picker/state API changes from preview/generated resource churn.
 - Keep `@Preview` composables private tooling code so sample previews do not become part of the supported public API surface. Reject ABI dump changes that add `*Preview` symbols back to `datetimepicker/api/`. If accidental preview symbols are removed from ABI dumps, call out the compatibility impact in the PR and release notes.
+- Distinguish the latest public Maven Central/GitHub Release version from the repository `VERSION_NAME`. Before changing README install snippets, verify the public release and do not point copy-paste dependency examples at unpublished versions unless the docs explicitly mark them as unreleased/local-publish usage.
+- When README install snippets use the latest public release but Usage/API Reference examples target `main` or unreleased APIs, add visible release-status notes near Installation, Usage, and API Reference, including the `publishToMavenLocal` command for local testing.
 - Keep repository guidance up to date in this `AGENTS.md` when the maintainer gives durable process feedback.
 - Do not include local agent/tooling folders such as `.agents/` or `.claude/` in product PRs unless the change is explicitly about agent workflow assets.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the dependency to your version catalog or build file.
 
 ```toml
 [versions]
-composeDateTimePicker = "0.6.0"
+composeDateTimePicker = "0.4.0"
 
 [libraries]
 compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picker", version.ref = "composeDateTimePicker" }
@@ -35,13 +35,17 @@ compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picke
 
 ```kotlin
 dependencies {
-    implementation("io.github.kez-lab:compose-date-time-picker:0.6.0")
+    implementation("io.github.kez-lab:compose-date-time-picker:0.4.0")
 }
 ```
+
+> **Release status:** `0.4.0` is the latest public Maven Central/GitHub Releases version. This README is maintained from `main` and documents unreleased `0.6.0` API work, so the Usage and API Reference sections may include APIs that are not available in `0.4.0`. For published APIs, use the `0.4.0` release/tag docs. To test `main` locally, run `./gradlew :datetimepicker:publishToMavenLocal`, add `mavenLocal()` to your consuming build, and depend on `0.6.0`.
 
 For release notes and upgrade-impact details, see [CHANGELOG.md](CHANGELOG.md).
 
 ## Usage
+
+> The examples below target the current `main` branch API. They may require unreleased `0.6.0` APIs rather than the public `0.4.0` dependency shown above.
 
 ### TimePicker
 
@@ -187,6 +191,8 @@ fun BottomSheetPickerExample() {
 ```
 
 ## API Reference
+
+> This reference describes the current `main` branch API. Check [CHANGELOG.md](CHANGELOG.md) and the `0.4.0` release/tag docs before copying API examples into a project that depends on the public `0.4.0` artifact.
 
 Accessibility label parameters customize the picker-column prefix used in semantics. `*ItemContentDescription`
 parameters customize the accessibility value text without changing the visual item text. Selection is exposed

--- a/README_KO.md
+++ b/README_KO.md
@@ -23,7 +23,7 @@ Android, iOS, Desktop (JVM), Web (Wasm) 등 다양한 플랫폼에서 일관된 
 
 ```toml
 [versions]
-composeDateTimePicker = "0.6.0"
+composeDateTimePicker = "0.4.0"
 
 [libraries]
 compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picker", version.ref = "composeDateTimePicker" }
@@ -33,13 +33,17 @@ compose-date-time-picker = { module = "io.github.kez-lab:compose-date-time-picke
 
 ```kotlin
 dependencies {
-    implementation("io.github.kez-lab:compose-date-time-picker:0.6.0")
+    implementation("io.github.kez-lab:compose-date-time-picker:0.4.0")
 }
 ```
+
+> **릴리스 상태:** `0.4.0`이 현재 Maven Central/GitHub Releases에 공개된 최신 버전입니다. 이 README는 `main` 기준으로 유지되며 아직 릴리스되지 않은 `0.6.0` API 작업도 문서화하므로, 아래 사용법과 API 레퍼런스에는 `0.4.0`에 없는 API가 포함될 수 있습니다. 공개 버전 기준 API는 `0.4.0` release/tag 문서를 확인하세요. `main`을 로컬에서 테스트하려면 `./gradlew :datetimepicker:publishToMavenLocal`을 실행하고, 소비 프로젝트에 `mavenLocal()`을 추가한 뒤 `0.6.0`에 의존하세요.
 
 릴리스 노트와 업그레이드 영향은 영문 [CHANGELOG.md](CHANGELOG.md)를 참고하세요.
 
 ## 사용법
+
+> 아래 예제는 현재 `main` 브랜치 API를 기준으로 합니다. 위 설치 스니펫의 공개 `0.4.0` 의존성이 아니라, 아직 릴리스되지 않은 `0.6.0` API가 필요할 수 있습니다.
 
 ### TimePicker
 
@@ -182,6 +186,8 @@ fun BottomSheetPickerExample() {
 ```
 
 ## API 레퍼런스
+
+> 이 레퍼런스는 현재 `main` 브랜치 API를 설명합니다. 공개 `0.4.0` artifact에 의존하는 프로젝트에 예제를 복사하기 전에는 [CHANGELOG.md](CHANGELOG.md)와 `0.4.0` release/tag 문서를 확인하세요.
 
 접근성 label 파라미터는 semantics에 들어가는 picker column prefix를 바꿉니다. `*ItemContentDescription`
 파라미터는 화면에 보이는 텍스트를 바꾸지 않고 접근성 값 설명만 바꿉니다. 선택 상태는 고정된 영어 문구를


### PR DESCRIPTION
## Summary
- use the currently published 0.4.0 version in README install snippets
- clarify that README Usage/API Reference sections track main and may include unreleased 0.6.0 APIs
- add maintainer guidance so install snippets and unreleased examples stay clearly separated

## Validation
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check

## Release evidence
- Maven Central metadata and GitHub Releases currently expose 0.4.0 as the latest public release, while this repository VERSION_NAME is 0.6.0.