### PR TITLE
docs: align sample picker accessibility labels

### DIFF
--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/StringUtils.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/StringUtils.kt
@@ -10,7 +10,7 @@ internal fun formatTime12(hour: Int?, minute: Int?, period: TimePeriod?): String
     val h = hour ?: 12
     val m = minute ?: 0
     val p = period ?: TimePeriod.AM
-    return "${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')} $p"
+    return "${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')} ${getTimePeriodContentDescription(p)}"
 }
 
 internal fun formatTime12(time: LocalTime): String {
@@ -54,5 +54,12 @@ internal fun getMonthContentDescription(month: Int): String {
     return when (month) {
         in 1..12 -> "${month}월"
         else -> "알 수 없음"
+    }
+}
+
+internal fun getTimePeriodContentDescription(period: TimePeriod): String {
+    return when (period) {
+        TimePeriod.AM -> "오전"
+        TimePeriod.PM -> "오후"
     }
 }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
@@ -35,7 +35,9 @@ import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.formatTime12
+import com.kez.picker.sample.getMonthContentDescription
 import com.kez.picker.sample.getMonthName
+import com.kez.picker.sample.getTimePeriodContentDescription
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.currentDateTime
@@ -119,6 +121,12 @@ internal fun BackgroundStylePickerScreen(
                 ) {
                     YearMonthPicker(
                         state = yearMonthState,
+                        yearPickerLabel = "연도",
+                        monthPickerLabel = "월",
+                        yearItemContentDescription = { "${it}년" },
+                        monthItemContentDescription = { getMonthContentDescription(it) },
+                        previousItemActionLabel = "이전 항목 선택",
+                        nextItemActionLabel = "다음 항목 선택",
                         textStyles = PickerDefaults.textStyles(
                             textStyle = TextStyle(
                                 fontSize = 18.sp
@@ -156,6 +164,14 @@ internal fun BackgroundStylePickerScreen(
                 ) {
                     TimePicker(
                         state = timeState,
+                        hourPickerLabel = "시간",
+                        minutePickerLabel = "분",
+                        periodPickerLabel = "오전/오후",
+                        hourItemContentDescription = { "${it}시" },
+                        minuteItemContentDescription = { "${it}분" },
+                        periodItemContentDescription = { getTimePeriodContentDescription(it) },
+                        previousItemActionLabel = "이전 항목 선택",
+                        nextItemActionLabel = "다음 항목 선택",
                         textStyles = PickerDefaults.textStyles(
                             textStyle = TextStyle(
                                 fontSize = 18.sp

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
@@ -42,7 +42,9 @@ import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.formatTime12
+import com.kez.picker.sample.getMonthContentDescription
 import com.kez.picker.sample.getMonthName
+import com.kez.picker.sample.getTimePeriodContentDescription
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.currentDate
@@ -237,6 +239,12 @@ internal fun BottomSheetSampleScreen(
                     ) {
                         YearMonthPicker(
                             state = yearMonthState,
+                            yearPickerLabel = "연도",
+                            monthPickerLabel = "월",
+                            yearItemContentDescription = { "${it}년" },
+                            monthItemContentDescription = { getMonthContentDescription(it) },
+                            previousItemActionLabel = "이전 항목 선택",
+                            nextItemActionLabel = "다음 항목 선택",
                             textStyles = PickerDefaults.textStyles(
                                 textStyle = TextStyle(
                                     fontSize = 18.sp
@@ -306,6 +314,14 @@ internal fun BottomSheetSampleScreen(
                     ) {
                         TimePicker(
                             state = timeState,
+                            hourPickerLabel = "시간",
+                            minutePickerLabel = "분",
+                            periodPickerLabel = "오전/오후",
+                            hourItemContentDescription = { "${it}시" },
+                            minuteItemContentDescription = { "${it}분" },
+                            periodItemContentDescription = { getTimePeriodContentDescription(it) },
+                            previousItemActionLabel = "이전 항목 선택",
+                            nextItemActionLabel = "다음 항목 선택",
                             textStyles = PickerDefaults.textStyles(
                                 textStyle = TextStyle(
                                     fontSize = 18.sp

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
@@ -54,7 +54,9 @@ import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.formatTime12
+import com.kez.picker.sample.getMonthContentDescription
 import com.kez.picker.sample.getMonthName
+import com.kez.picker.sample.getTimePeriodContentDescription
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.currentDateTime
@@ -167,6 +169,12 @@ internal fun IntegratedPickerScreen(
                             if (tabIndex == 0) {
                                 YearMonthPicker(
                                     state = yearMonthState,
+                                    yearPickerLabel = "연도",
+                                    monthPickerLabel = "월",
+                                    yearItemContentDescription = { "${it}년" },
+                                    monthItemContentDescription = { getMonthContentDescription(it) },
+                                    previousItemActionLabel = "이전 항목 선택",
+                                    nextItemActionLabel = "다음 항목 선택",
                                     textStyles = PickerDefaults.textStyles(
                                         textStyle = TextStyle(
                                             fontSize = 18.sp
@@ -185,6 +193,14 @@ internal fun IntegratedPickerScreen(
                             } else {
                                 TimePicker(
                                     state = timeState,
+                                    hourPickerLabel = "시간",
+                                    minutePickerLabel = "분",
+                                    periodPickerLabel = "오전/오후",
+                                    hourItemContentDescription = { "${it}시" },
+                                    minuteItemContentDescription = { "${it}분" },
+                                    periodItemContentDescription = { getTimePeriodContentDescription(it) },
+                                    previousItemActionLabel = "이전 항목 선택",
+                                    nextItemActionLabel = "다음 항목 선택",
                                     textStyles = PickerDefaults.textStyles(
                                         textStyle = TextStyle(
                                             fontSize = 18.sp

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -40,9 +40,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kez.picker.rememberTimePickerState
+import com.kez.picker.sample.getTimePeriodContentDescription
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
-import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
@@ -74,7 +74,7 @@ internal fun TimePickerSampleScreen(
         char(':')
         minute(padding = Padding.ZERO)
         char(' ')
-        amPmMarker(am = TimePeriod.AM.name, pm = TimePeriod.PM.name)
+        amPmMarker(am = "오전", pm = "오후")
     }
 
     val ktxTimeFormat24 = LocalTime.Format {
@@ -193,12 +193,12 @@ internal fun TimePickerSampleScreen(
             if (selectedFormat == 0) {
                 TimePicker(
                     state = timeState12,
-                    hourPickerLabel = "시",
+                    hourPickerLabel = "시간",
                     minutePickerLabel = "분",
                     periodPickerLabel = "오전/오후",
                     hourItemContentDescription = { "${it}시" },
                     minuteItemContentDescription = { "${it}분" },
-                    periodItemContentDescription = { it.name },
+                    periodItemContentDescription = { getTimePeriodContentDescription(it) },
                     previousItemActionLabel = "이전 항목 선택",
                     nextItemActionLabel = "다음 항목 선택"
                 )
@@ -206,7 +206,7 @@ internal fun TimePickerSampleScreen(
                 TimePicker(
                     state = timeState24,
                     visibleItemsCount = 5,
-                    hourPickerLabel = "시",
+                    hourPickerLabel = "시간",
                     minutePickerLabel = "분",
                     hourItemContentDescription = { "${it}시" },
                     minuteItemContentDescription = { "${it}분" },


### PR DESCRIPTION
## Summary
- pass localized picker labels, item content descriptions, and custom action labels in flow-style sample screens
- reuse a sample helper for AM/PM content descriptions
- align selected time display with the same 오전/오후 wording used by picker accessibility text

## Review feedback addressed
- changed hour picker labels from 시 to 시간 to avoid duplicate TalkBack output like 시: 2시
- aligned visual selected-time text and picker period content descriptions around 오전/오후

## Validation
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :sample:assembleDebug :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution --no-daemon
- git diff --check
- git diff --cached --check