### PR TITLE
ci: check pull request diff whitespace

### DIFF
--- a/.github/workflows/integration-build-test.yml
+++ b/.github/workflows/integration-build-test.yml
@@ -15,6 +15,18 @@ env:
   LIBRARY_MODULE: ":datetimepicker"
   SAMPLE_MODULE: ":sample"
 jobs:
+  repository-hygiene:
+    name: Linux • Repository hygiene
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check PR diff whitespace
+        run: git diff --check "origin/${{ github.base_ref }}...HEAD"
+
   abi-check:
     name: macOS • Kotlin ABI Check
     runs-on: macos-14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,9 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 # Run checks (tests + lint)
 ./gradlew :datetimepicker:check --no-daemon
 
+# Check PR diff whitespace/conflict markers (same hygiene gate as CI)
+git diff --check origin/main...HEAD
+
 # Check public Kotlin ABI against the committed reference dump.
 # Run this explicitly; do not assume :datetimepicker:check covers the ABI gate.
 ./gradlew :datetimepicker:checkLegacyAbi --no-daemon
@@ -250,7 +253,7 @@ Follow **Semantic Versioning**: MAJOR.MINOR.PATCH
 ## CI/CD
 
 GitHub Actions workflows:
-- **`integration-build-test.yml`**: Runs multiplatform library checks on pull requests to `main`; the dedicated macOS ABI job runs `checkLegacyAbi`, and the Android matrix runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for instrumented tests.
+- **`integration-build-test.yml`**: Runs repository hygiene and multiplatform library checks on pull requests to `main`; the hygiene job runs `git diff --check` on the PR diff, the dedicated macOS ABI job runs `checkLegacyAbi`, and the Android matrix runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for instrumented tests.
 - **`maven-central-deploy.yml`**: Publishes releases to Maven Central
 
 Build matrix: Ubuntu latest for Android/Desktop/Wasm and macOS 14 for iOS, using JDK 17 (Temurin)


### PR DESCRIPTION
## Summary
- add a lightweight repository hygiene job to the PR workflow
- run `git diff --check` against the PR diff to catch whitespace errors and conflict markers in CI
- document the CI hygiene gate and matching local command in AGENTS.md

## Validation
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check
- git diff --cached --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/integration-build-test.yml')"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated repository hygiene checks to the CI workflow to validate code formatting and detect whitespace issues in pull requests.
  * Updated documentation to reflect new CI/CD validation requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->