### PR TITLE
docs: document generic picker state behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Updated the sample app to show programmatic selection buttons, a `DatePicker` example that passes
   selectable year values through `yearItems = 2024..2026`, and Korean localized picker accessibility
   labels across the `TimePicker`, `BackgroundStyle`, `Integrated`, and `BottomSheet` samples.
+- Documented generic `Picker<T>` usage, initial `startIndex` alignment, and the regular `remember`
+  behavior of `rememberPickerState`.
 - Clarified README installation guidance to distinguish published `0.4.0` artifacts from unreleased `main`/`0.6.0` API documentation.
 - Made library `@Preview` composables private tooling code so preview functions do not appear in the supported public API surface.
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,42 @@ through Compose `selected` semantics rather than appended as a hardcoded English
 custom accessibility actions for selecting the previous or next item. Use `previousItemActionLabel` and
 `nextItemActionLabel` to localize those action labels, or pass `null`/blank to omit an action.
 
+### Generic Picker
+
+Use `Picker<T>` when you need a single custom picker column.
+
+```kotlin
+import androidx.compose.runtime.Composable
+import com.kez.picker.Picker
+import com.kez.picker.rememberPickerState
+
+@Composable
+fun SizePickerExample() {
+    val items = listOf("Small", "Medium", "Large")
+    val initialItem = "Medium"
+    val startIndex = items.indexOf(initialItem)
+    require(startIndex >= 0) { "initialItem must exist in items." }
+
+    val state = rememberPickerState(initialItem)
+
+    Picker(
+        items = items,
+        state = state,
+        startIndex = startIndex,
+        isInfinity = false,
+        pickerLabel = "Size",
+        itemContentDescription = { it }
+    )
+}
+```
+
+`rememberPickerState` uses regular `remember`, not `rememberSaveable`, because arbitrary `T` values
+may not be saveable. If a generic picker selection must survive Android Activity recreation, keep a
+saveable representation in your app state, pass it when the picker state is first created, and pass
+a matching `startIndex` to `Picker`. If the app value changes after composition, synchronize the
+existing picker with `state.selectItem(newValue)`; changing the `initialItem` argument alone does not
+update an already remembered `PickerState`.
+
 ### Programmatic Selection
 
 Create picker state with `remember*State`, pass it to the picker, then call the public selection method

--- a/README_KO.md
+++ b/README_KO.md
@@ -195,6 +195,42 @@ fun BottomSheetPickerExample() {
 accessibility action도 제공합니다. `previousItemActionLabel`과 `nextItemActionLabel`로 action label을
 현지화할 수 있고, `null`이나 blank를 전달하면 해당 action을 생략합니다.
 
+### Generic Picker
+
+단일 custom picker column이 필요하면 `Picker<T>`를 사용하세요.
+
+```kotlin
+import androidx.compose.runtime.Composable
+import com.kez.picker.Picker
+import com.kez.picker.rememberPickerState
+
+@Composable
+fun SizePickerExample() {
+    val items = listOf("Small", "Medium", "Large")
+    val initialItem = "Medium"
+    val startIndex = items.indexOf(initialItem)
+    require(startIndex >= 0) { "initialItem must exist in items." }
+
+    val state = rememberPickerState(initialItem)
+
+    Picker(
+        items = items,
+        state = state,
+        startIndex = startIndex,
+        isInfinity = false,
+        pickerLabel = "Size",
+        itemContentDescription = { it }
+    )
+}
+```
+
+`rememberPickerState`는 `rememberSaveable`이 아니라 일반 `remember`를 사용합니다. 임의의 `T` 값이
+saveable하다고 보장할 수 없기 때문입니다. generic picker 선택값을 Android Activity 재생성 후에도
+유지해야 한다면 앱 state에 saveable한 표현을 보관하고, picker state가 처음 만들어질 때 그 값을
+전달하며, `Picker`에도 같은 값에 맞는 `startIndex`를 전달하세요. composition 이후 앱 값이 바뀐다면
+`initialItem` 인자만 바꾸어도 이미 기억된 `PickerState`는 갱신되지 않으므로 `state.selectItem(newValue)`로
+기존 picker를 동기화하세요.
+
 ### 프로그래밍 방식 선택
 
 `remember*State`로 picker state를 만들고 picker에 전달한 뒤, 이벤트 핸들러나

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerState.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import com.kez.picker.date.DatePickerState
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDate
@@ -20,6 +21,11 @@ import kotlinx.datetime.number
 
 /**
  * Remember a [PickerState] with the given initial item.
+ *
+ * This uses [remember] instead of [rememberSaveable] because arbitrary [T] values are not
+ * guaranteed to be saveable. Higher-level picker states such as [TimePickerState],
+ * [DatePickerState], and [YearMonthPickerState] provide saveable state for their supported value
+ * types.
  *
  * @param initialItem The initial selected item.
  * @return A [PickerState] with the given initial item.


### PR DESCRIPTION
## Summary
- Document generic `Picker<T>` copy-paste usage with matching initial state and `startIndex`
- Explain `rememberPickerState` regular `remember` behavior and Android recreation caveat
- Link KDoc to saveable higher-level states including `DatePickerState`

## Validation
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon`
- `git diff --check`

## Review
- Six-agent review completed; fixed `startIndex` and state synchronization feedback before opening.