### PR TITLE
test: cover time state saver edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,6 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Extended Android accessibility action coverage for `TimePicker`, `DatePicker`, and `YearMonthPicker`
   child picker state updates.
 - Added Android state restoration coverage for `rememberTimePickerState`, `rememberDatePickerState`, and `rememberYearMonthPickerState`.
+- Added `TimePickerState.Saver` edge-case coverage for 12-hour midnight and noon restoration.
 - Added Kotlin ABI validation with committed Android, Desktop, and KLIB API dumps.
 - Pull requests now run Android build/unit, Desktop, Wasm, iOS simulator, Kotlin ABI, Android managed-device instrumented test, and PR diff hygiene checks.

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -627,6 +627,37 @@ class TimePickerStateTest {
     }
 
     @Test
+    fun timePickerState_saver_roundTrips12HourMidnightAndNoon() {
+        val midnight = TimePickerState(
+            initialHour = 12,
+            initialMinute = 5,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        ).saveAndRestore()
+
+        assertEquals(12, midnight.selectedHour)
+        assertEquals(5, midnight.selectedMinute)
+        assertEquals(TimePeriod.AM, midnight.selectedPeriod)
+        assertEquals(TimeFormat.HOUR_12, midnight.timeFormat)
+        assertEquals(0, midnight.selectedHourOfDay)
+        assertEquals(LocalTime(0, 5), midnight.selectedTime)
+
+        val noon = TimePickerState(
+            initialHour = 12,
+            initialMinute = 15,
+            initialPeriod = TimePeriod.PM,
+            timeFormat = TimeFormat.HOUR_12
+        ).saveAndRestore()
+
+        assertEquals(12, noon.selectedHour)
+        assertEquals(15, noon.selectedMinute)
+        assertEquals(TimePeriod.PM, noon.selectedPeriod)
+        assertEquals(TimeFormat.HOUR_12, noon.timeFormat)
+        assertEquals(12, noon.selectedHourOfDay)
+        assertEquals(LocalTime(12, 15), noon.selectedTime)
+    }
+
+    @Test
     fun initialHourForTimeFormat_converts24HourInputFor12HourMode() {
         assertEquals(12, initialHourForTimeFormat(0, TimeFormat.HOUR_12))
         assertEquals(12, initialHourForTimeFormat(12, TimeFormat.HOUR_12))


### PR DESCRIPTION
## Summary
- Add `TimePickerState.Saver` round-trip coverage for 12-hour midnight and noon edge cases
- Assert restored display hour, period, time format, hour-of-day, and selected time
- Record the state restoration coverage in the changelog

## Validation
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon`
- `git diff --check`

## Review
- Six-agent review completed; added explicit `timeFormat` and `selectedHourOfDay` assertions from review feedback.