### PR TITLE
test: cover time state restoration noon edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Added Android instrumented accessibility semantics coverage and a Gradle Managed Device CI gate.
 - Extended Android accessibility action coverage for `TimePicker`, `DatePicker`, and `YearMonthPicker`
   child picker state updates.
-- Added Android state restoration coverage for `rememberTimePickerState`, `rememberDatePickerState`, and `rememberYearMonthPickerState`.
+- Added Android state restoration coverage for `rememberTimePickerState`, including 12-hour noon,
+  `rememberDatePickerState`, and `rememberYearMonthPickerState`.
 - Added `TimePickerState.Saver` edge-case coverage for 12-hour midnight and noon restoration.
 - Added Kotlin ABI validation with committed Android, Desktop, and KLIB API dumps.
 - Pull requests now run Android build/unit, Desktop, Wasm, iOS simulator, Kotlin ABI, Android managed-device instrumented test, and PR diff hygiene checks.

--- a/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerStateRestorationAndroidTest.kt
+++ b/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerStateRestorationAndroidTest.kt
@@ -48,6 +48,35 @@ class PickerStateRestorationAndroidTest {
     }
 
     @Test
+    fun rememberTimePickerState_restoresNoonAfterSaveRestore() {
+        lateinit var state: TimePickerState
+        val restorationTester = StateRestorationTester(composeRule)
+
+        restorationTester.setContent {
+            state = rememberTimePickerState(
+                initialTime = LocalTime(1, 0),
+                timeFormat = TimeFormat.HOUR_12
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectTime(LocalTime(12, 15))
+            assertEquals(LocalTime(12, 15), state.selectedTime)
+        }
+
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        composeRule.runOnIdle {
+            assertEquals(LocalTime(12, 15), state.selectedTime)
+            assertEquals(TimeFormat.HOUR_12, state.timeFormat)
+            assertEquals(12, state.selectedHour)
+            assertEquals(12, state.selectedHourOfDay)
+            assertEquals(15, state.selectedMinute)
+            assertEquals(TimePeriod.PM, state.selectedPeriod)
+        }
+    }
+
+    @Test
     fun timePicker_restoresSelectionIntoRenderedSemanticsAfterSaveRestore() {
         lateinit var state: TimePickerState
         val restorationTester = StateRestorationTester(composeRule)


### PR DESCRIPTION
## Summary
- Add Android `StateRestorationTester` coverage for `rememberTimePickerState` 12-hour noon restoration
- Assert restored selected time, display hour, hour-of-day, minute, period, and time format
- Fold the new edge case into the changelog state restoration entry

## Validation
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:compileDebugAndroidTestKotlinAndroid --no-daemon`
- `git diff --check`

## Review
- Six-agent review completed; folded duplicate changelog wording and added a pre-restore selectedTime assertion from review feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for time picker state restoration with 12-hour format noon handling.

* **Documentation**
  * Updated changelog to clarify noon handling details for time picker state restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->