### PR TITLE
docs: clarify date picker custom ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   samples.
 - Documented generic `Picker<T>` usage, initial `startIndex` alignment, and the regular `remember`
   behavior of `rememberPickerState`.
+- Clarified `DatePicker` README examples for custom year ranges and state synchronization after composition.
 - Clarified README installation guidance to distinguish published `0.4.0` artifacts from unreleased `main`/`0.6.0` API documentation.
 - Made library `@Preview` composables private tooling code so preview functions do not appear in the supported public API surface.
 

--- a/README.md
+++ b/README.md
@@ -119,17 +119,25 @@ import com.kez.picker.util.currentDate
 @Composable
 fun DatePickerExample() {
     val initialDate = remember { currentDate() }
+    val selectableYears = remember(initialDate.year) {
+        ((initialDate.year - 1)..(initialDate.year + 1)).toList()
+    }
     val state = rememberDatePickerState(
         initialDate = initialDate
     )
 
     DatePicker(
-        state = state
+        state = state,
+        yearItems = selectableYears
     )
 
     // Use state.selectedDate when passing the result to app logic.
 }
 ```
+
+When you restrict `yearItems` or `monthItems`, keep the remembered initial or restored
+state value inside those lists. If an external date changes after composition, call
+`state.selectDate(newDate)` instead of relying on a new `initialDate` argument.
 
 ### YearMonthPicker
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -116,15 +116,25 @@ import com.kez.picker.util.currentDate
 @Composable
 fun DatePickerExample() {
     val initialDate = remember { currentDate() }
+    val selectableYears = remember(initialDate.year) {
+        ((initialDate.year - 1)..(initialDate.year + 1)).toList()
+    }
     val state = rememberDatePickerState(
         initialDate = initialDate
     )
 
-    DatePicker(state = state)
+    DatePicker(
+        state = state,
+        yearItems = selectableYears
+    )
 
     // 앱 로직에 전달할 때는 state.selectedDate를 사용합니다.
 }
 ```
+
+`yearItems`나 `monthItems`를 제한할 때는 기억된 초기값 또는 복원된 state 값이 해당 목록 안에
+들어가도록 함께 설계하세요. composition 이후 외부 날짜가 바뀐다면 새 `initialDate` 인자에
+의존하지 말고 `state.selectDate(newDate)`를 호출하세요.
 
 ### YearMonthPicker
 


### PR DESCRIPTION
## Summary
- Show a copyable DatePicker example with a custom year range derived from the remembered initial date
- Clarify that custom year/month lists should include the initial or restored state value
- Update the unreleased changelog

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check