### PR TITLE
docs: polish sample app flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   selectable years from the current year and a nearby leap-day target, and Korean localized picker
   accessibility labels across the `TimePicker`, `BackgroundStyle`, `Integrated`, and `BottomSheet`
   samples.
+- Refined sample screens with shared result cards, picker panels, real reset/confirm actions, and
+  bottom-sheet draft state separate from committed selection values.
 - Documented generic `Picker<T>` usage, initial `startIndex` alignment, and the regular `remember`
   behavior of `rememberPickerState`.
 - Clarified `DatePicker` README examples for custom year ranges and state synchronization after composition.

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BackgroundStylePickerScreen.kt
@@ -12,19 +12,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -42,7 +37,8 @@ import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
-import compose.icons.feathericons.ArrowLeft
+import compose.icons.feathericons.Calendar
+import compose.icons.feathericons.Clock
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,22 +64,9 @@ internal fun BackgroundStylePickerScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        "Background Style Sample",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = { onBackPressed() }) {
-                        Icon(
-                            FeatherIcons.ArrowLeft,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+            SampleTopAppBar(
+                title = "Background Style Sample",
+                onBackPressed = onBackPressed
             )
         },
         containerColor = MaterialTheme.colorScheme.background
@@ -96,17 +79,18 @@ internal fun BackgroundStylePickerScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text(
-                text = "Background를 사용한 디자인",
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
+            SelectedValueCard(
+                icon = FeatherIcons.Calendar,
+                label = "Selected month",
+                value = selectedDateText,
+                supportingText = "YearMonthPicker styled without dividers"
             )
 
-            Text(
-                text = "선택된 항목: $selectedDateText",
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium
+            SelectedValueCard(
+                icon = FeatherIcons.Clock,
+                label = "Selected time",
+                value = selectedTimeText,
+                supportingText = "TimePicker using the same state/update pattern"
             )
 
             Card(
@@ -145,12 +129,6 @@ internal fun BackgroundStylePickerScreen(
                     )
                 }
             }
-
-            Text(
-                text = "선택된 시간: $selectedTimeText",
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Medium
-            )
 
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -194,12 +172,15 @@ internal fun BackgroundStylePickerScreen(
             Spacer(modifier = Modifier.weight(1f))
 
             Button(
-                onClick = { /* Selection complete logic */ },
+                onClick = {
+                    yearMonthState.selectDate(now.date)
+                    timeState.selectTime(now.time)
+                },
                 modifier = Modifier.fillMaxWidth().height(56.dp),
                 shape = RoundedCornerShape(12.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
-                Text("확인", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Text("Reset to launch values", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
             }
         }
     }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
@@ -14,11 +14,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
@@ -26,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -50,10 +49,10 @@ import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.currentDate
 import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
-import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
 import compose.icons.feathericons.Clock
 import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.number
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -71,12 +70,16 @@ internal fun BottomSheetSampleScreen(
         timeFormat = TimeFormat.HOUR_12
     )
 
-    // Selected date/time text
-    var selectedDateText by rememberSaveable {
-        mutableStateOf("${currentDate.year}년 ${getMonthName(currentDate.month.number)}")
+    var selectedYear by rememberSaveable { mutableIntStateOf(currentDate.year) }
+    var selectedMonth by rememberSaveable { mutableIntStateOf(currentDate.month.number) }
+    var selectedHour by rememberSaveable { mutableIntStateOf(currentTime.hour) }
+    var selectedMinute by rememberSaveable { mutableIntStateOf(currentTime.minute) }
+
+    val selectedDateText = remember(selectedYear, selectedMonth) {
+        "${selectedYear}년 ${getMonthName(selectedMonth)}"
     }
-    var selectedTimeText by rememberSaveable {
-        mutableStateOf(formatTime12(timeState.selectedTime))
+    val selectedTimeText = remember(selectedHour, selectedMinute) {
+        formatTime12(LocalTime(selectedHour, selectedMinute))
     }
 
     // Bottom sheet state
@@ -88,13 +91,9 @@ internal fun BottomSheetSampleScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("BottomSheet Sample", fontWeight = FontWeight.Bold) },
-                navigationIcon = {
-                    IconButton(onClick = { onBackPressed() }) {
-                        Icon(FeatherIcons.ArrowLeft, contentDescription = "Back")
-                    }
-                }
+            SampleTopAppBar(
+                title = "BottomSheet Sample",
+                onBackPressed = onBackPressed
             )
         }
     ) { innerPadding ->
@@ -182,7 +181,13 @@ internal fun BottomSheetSampleScreen(
 
             // Date selection button
             Button(
-                onClick = { showDateBottomSheet = true },
+                onClick = {
+                    yearMonthState.selectYearMonth(
+                        year = selectedYear,
+                        month = selectedMonth
+                    )
+                    showDateBottomSheet = true
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(56.dp),
@@ -201,7 +206,10 @@ internal fun BottomSheetSampleScreen(
 
             // Time selection button
             Button(
-                onClick = { showTimeBottomSheet = true },
+                onClick = {
+                    timeState.selectTime(LocalTime(selectedHour, selectedMinute))
+                    showTimeBottomSheet = true
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(56.dp),
@@ -267,9 +275,8 @@ internal fun BottomSheetSampleScreen(
                     Button(
                         onClick = {
                             val selectedMonthDate = yearMonthState.selectedMonthDate
-                            selectedDateText = "${selectedMonthDate.year}년 ${
-                                getMonthName(selectedMonthDate.month.number)
-                            }"
+                            selectedYear = selectedMonthDate.year
+                            selectedMonth = selectedMonthDate.month.number
                             scope.launch {
                                 dateSheetState.hide()
                                 showDateBottomSheet = false
@@ -343,7 +350,8 @@ internal fun BottomSheetSampleScreen(
 
                     Button(
                         onClick = {
-                            selectedTimeText = formatTime12(timeState.selectedTime)
+                            selectedHour = timeState.selectedTime.hour
+                            selectedMinute = timeState.selectedTime.minute
                             scope.launch {
                                 timeSheetState.hide()
                                 showTimeBottomSheet = false

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -1,34 +1,24 @@
 package com.kez.picker.sample.ui.screen
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -39,7 +29,6 @@ import com.kez.picker.date.rememberDatePickerState
 import com.kez.picker.sample.getMonthContentDescription
 import com.kez.picker.util.currentDate
 import compose.icons.FeatherIcons
-import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
@@ -51,20 +40,9 @@ fun DatePickerSampleScreen(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("DatePicker Sample") },
-                navigationIcon = {
-                    IconButton(onClick = onBackPressed) {
-                        Icon(
-                            imageVector = FeatherIcons.ArrowLeft,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                )
+            SampleTopAppBar(
+                title = "DatePicker Sample",
+                onBackPressed = onBackPressed
             )
         }
     ) { paddingValues ->
@@ -89,12 +67,39 @@ fun DatePickerSampleScreen(
             }
             val state = rememberDatePickerState(initialDate = today)
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
-                    .padding(24.dp)
-            ) {
+            SelectedValueCard(
+                icon = FeatherIcons.Calendar,
+                label = "Selected date",
+                value = state.selectedDate.toString(),
+                supportingText = "Selectable years: ${allowedYears.joinToString()}"
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            SampleActionRow {
+                Button(
+                    onClick = { state.selectDate(today) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(
+                        imageVector = FeatherIcons.Calendar,
+                        contentDescription = null
+                    )
+                    IconTextGap()
+                    Text("Set $today")
+                }
+
+                OutlinedButton(
+                    onClick = { state.selectDate(leapDate) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Set $leapDate")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            PickerPanel {
                 DatePicker(
                     state = state,
                     yearItems = allowedYears,
@@ -119,69 +124,6 @@ fun DatePickerSampleScreen(
                     previousItemActionLabel = "이전 항목 선택",
                     nextItemActionLabel = "다음 항목 선택"
                 )
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Button(
-                    onClick = { state.selectDate(today) },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Icon(
-                        imageVector = FeatherIcons.Calendar,
-                        contentDescription = null
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Set $today")
-                }
-
-                OutlinedButton(
-                    onClick = { state.selectDate(leapDate) },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Set $leapDate")
-                }
-            }
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            // Display Selected Value
-            Box(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.secondaryContainer)
-                    .padding(16.dp)
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = "Selected Date",
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer
-                    )
-                    Text(
-                        text = "Selectable years: ${allowedYears.joinToString()}",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSecondaryContainer
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = FeatherIcons.Calendar,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = state.selectedDate.toString(),
-                            style = MaterialTheme.typography.headlineSmall,
-                            color = MaterialTheme.colorScheme.onSecondaryContainer
-                        )
-                    }
-                }
             }
         }
     }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.kez.picker.sample.ui.screen
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -59,12 +60,14 @@ internal fun HomeScreen(navController: NavController) {
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding).padding(16.dp)
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             item {
                 MenuListItem(
                     title = "Integrated Sample",
-                    description = "Date and time picker combined",
+                    description = "Tabs with shared date and time state",
                     icon = FeatherIcons.CheckCircle,
                     onClick = { navController.navigate(Screen.Integrated.route) }
                 )
@@ -72,7 +75,7 @@ internal fun HomeScreen(navController: NavController) {
             item {
                 MenuListItem(
                     title = "TimePicker Sample",
-                    description = "Standalone TimePicker component",
+                    description = "12-hour and 24-hour state updates",
                     icon = FeatherIcons.Clock,
                     onClick = { navController.navigate(Screen.TimePicker.route) }
                 )
@@ -80,7 +83,7 @@ internal fun HomeScreen(navController: NavController) {
             item {
                 MenuListItem(
                     title = "YearMonthPicker Sample",
-                    description = "Standalone YearMonthPicker component",
+                    description = "Month selection with programmatic reset",
                     icon = FeatherIcons.Calendar,
                     onClick = { navController.navigate(Screen.YearMonthPicker.route) }
                 )
@@ -88,7 +91,7 @@ internal fun HomeScreen(navController: NavController) {
             item {
                 MenuListItem(
                     title = "DatePicker Sample",
-                    description = "Full DatePicker (Year, Month, Day)",
+                    description = "Custom year range and leap-day target",
                     icon = FeatherIcons.Calendar,
                     onClick = { navController.navigate(Screen.DatePicker.route) }
                 )
@@ -96,7 +99,7 @@ internal fun HomeScreen(navController: NavController) {
             item {
                 MenuListItem(
                     title = "BottomSheet Sample",
-                    description = "Date/time selection in bottom sheet",
+                    description = "Committed value plus draft sheet state",
                     icon = FeatherIcons.Layers,
                     onClick = { navController.navigate(Screen.BottomSheet.route) }
                 )
@@ -104,7 +107,7 @@ internal fun HomeScreen(navController: NavController) {
             item {
                 MenuListItem(
                     title = "Background Style",
-                    description = "Picker with background design",
+                    description = "Divider-free picker styling",
                     icon = FeatherIcons.Square,
                     onClick = { navController.navigate(Screen.BackgroundStyle.route) }
                 )
@@ -124,10 +127,12 @@ internal fun MenuListItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp)
             .clickable(onClick = onClick),
         shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(2.dp)
+        elevation = CardDefaults.cardElevation(1.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
     ) {
         Row(
             modifier = Modifier.padding(16.dp),
@@ -146,7 +151,11 @@ internal fun MenuListItem(
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold
                 )
-                Text(description, style = MaterialTheme.typography.bodyMedium, color = Color.Gray)
+                Text(
+                    description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
             Icon(FeatherIcons.ArrowRight, contentDescription = "Navigate")
         }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
@@ -24,17 +24,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -43,7 +40,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -61,7 +57,6 @@ import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
-import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
 import compose.icons.feathericons.Clock
 import kotlinx.datetime.number
@@ -95,22 +90,9 @@ internal fun IntegratedPickerScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        "Integrated Sample",
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = { onBackPressed() }) {
-                        Icon(
-                            FeatherIcons.ArrowLeft,
-                            contentDescription = "Back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+            SampleTopAppBar(
+                title = "Integrated Sample",
+                onBackPressed = onBackPressed
             )
         },
         containerColor = MaterialTheme.colorScheme.background
@@ -223,12 +205,15 @@ internal fun IntegratedPickerScreen(
             }
             Spacer(modifier = Modifier.weight(1f))
             Button(
-                onClick = { /* Selection complete logic (sample app demo) */ },
+                onClick = {
+                    yearMonthState.selectDate(currentDate)
+                    timeState.selectTime(currentTime)
+                },
                 modifier = Modifier.fillMaxWidth().height(56.dp),
                 shape = RoundedCornerShape(12.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
             ) {
-                Text("Confirm Selection", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Text("Reset to launch selection", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
             }
         }
     }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/SampleComponents.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/SampleComponents.kt
@@ -1,0 +1,154 @@
+package com.kez.picker.sample.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import compose.icons.FeatherIcons
+import compose.icons.feathericons.ArrowLeft
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SampleTopAppBar(
+    title: String,
+    onBackPressed: () -> Unit,
+) {
+    CenterAlignedTopAppBar(
+        title = {
+            Text(
+                text = title,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onBackPressed) {
+                Icon(
+                    imageVector = FeatherIcons.ArrowLeft,
+                    contentDescription = "Back"
+                )
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = Color.Transparent
+        )
+    )
+}
+
+@Composable
+internal fun SelectedValueCard(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                if (supportingText != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = supportingText,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun PickerPanel(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            content = content
+        )
+    }
+}
+
+@Composable
+internal fun SampleActionRow(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        content = content
+    )
+}
+
+@Composable
+internal fun IconTextGap() {
+    Spacer(modifier = Modifier.width(8.dp))
+}

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -1,26 +1,17 @@
 package com.kez.picker.sample.ui.screen
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
@@ -35,17 +26,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.kez.picker.rememberTimePickerState
 import com.kez.picker.sample.getTimePeriodContentDescription
 import com.kez.picker.time.TimePicker
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.currentDateTime
 import compose.icons.FeatherIcons
-import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Clock
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.format
@@ -95,13 +83,9 @@ internal fun TimePickerSampleScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("TimePicker Sample", fontWeight = FontWeight.Bold) },
-                navigationIcon = {
-                    IconButton(onClick = { onBackPressed() }) {
-                        Icon(FeatherIcons.ArrowLeft, contentDescription = "Back")
-                    }
-                }
+            SampleTopAppBar(
+                title = "TimePicker Sample",
+                onBackPressed = onBackPressed
             )
         }
     ) {
@@ -113,41 +97,16 @@ internal fun TimePickerSampleScreen(
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(12.dp),
-                elevation = CardDefaults.cardElevation(2.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = FeatherIcons.Clock,
-                        contentDescription = "Selected time",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.padding(horizontal = 8.dp))
-                    Text(
-                        text = "Selected time: $selectedTimeText",
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                }
-            }
+            SelectedValueCard(
+                icon = FeatherIcons.Clock,
+                label = "Selected time",
+                value = selectedTimeText,
+                supportingText = if (selectedFormat == 0) "12-hour state" else "24-hour state"
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
+            SampleActionRow {
                 Button(
                     onClick = {
                         val now = currentDateTime().time
@@ -160,7 +119,7 @@ internal fun TimePickerSampleScreen(
                         imageVector = FeatherIcons.Clock,
                         contentDescription = null
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
+                    IconTextGap()
                     Text("Set now")
                 }
                 OutlinedButton(
@@ -190,29 +149,31 @@ internal fun TimePickerSampleScreen(
                     text = { Text("24-Hour") })
             }
             Spacer(modifier = Modifier.height(32.dp))
-            if (selectedFormat == 0) {
-                TimePicker(
-                    state = timeState12,
-                    hourPickerLabel = "시간",
-                    minutePickerLabel = "분",
-                    periodPickerLabel = "오전/오후",
-                    hourItemContentDescription = { "${it}시" },
-                    minuteItemContentDescription = { "${it}분" },
-                    periodItemContentDescription = { getTimePeriodContentDescription(it) },
-                    previousItemActionLabel = "이전 항목 선택",
-                    nextItemActionLabel = "다음 항목 선택"
-                )
-            } else {
-                TimePicker(
-                    state = timeState24,
-                    visibleItemsCount = 5,
-                    hourPickerLabel = "시간",
-                    minutePickerLabel = "분",
-                    hourItemContentDescription = { "${it}시" },
-                    minuteItemContentDescription = { "${it}분" },
-                    previousItemActionLabel = "이전 항목 선택",
-                    nextItemActionLabel = "다음 항목 선택"
-                )
+            PickerPanel {
+                if (selectedFormat == 0) {
+                    TimePicker(
+                        state = timeState12,
+                        hourPickerLabel = "시간",
+                        minutePickerLabel = "분",
+                        periodPickerLabel = "오전/오후",
+                        hourItemContentDescription = { "${it}시" },
+                        minuteItemContentDescription = { "${it}분" },
+                        periodItemContentDescription = { getTimePeriodContentDescription(it) },
+                        previousItemActionLabel = "이전 항목 선택",
+                        nextItemActionLabel = "다음 항목 선택"
+                    )
+                } else {
+                    TimePicker(
+                        state = timeState24,
+                        visibleItemsCount = 5,
+                        hourPickerLabel = "시간",
+                        minutePickerLabel = "분",
+                        hourItemContentDescription = { "${it}시" },
+                        minuteItemContentDescription = { "${it}분" },
+                        previousItemActionLabel = "이전 항목 선택",
+                        nextItemActionLabel = "다음 항목 선택"
+                    )
+                }
             }
         }
     }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
@@ -1,48 +1,34 @@
 package com.kez.picker.sample.ui.screen
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.rememberYearMonthPickerState
 import com.kez.picker.sample.getMonthContentDescription
 import com.kez.picker.sample.getMonthName
 import com.kez.picker.util.currentDate
 import compose.icons.FeatherIcons
-import compose.icons.feathericons.ArrowLeft
 import compose.icons.feathericons.Calendar
+import kotlinx.datetime.number
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,18 +49,9 @@ internal fun YearMonthPickerSampleScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("YearMonthPicker Sample", fontWeight = FontWeight.Bold) },
-                navigationIcon = {
-                    IconButton(onClick = {
-                        onBackPressed()
-                    }) {
-                        Icon(FeatherIcons.ArrowLeft, contentDescription = "Back")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = Color.Transparent
-                )
+            SampleTopAppBar(
+                title = "YearMonthPicker Sample",
+                onBackPressed = onBackPressed
             )
         }
     ) {
@@ -86,42 +63,16 @@ internal fun YearMonthPickerSampleScreen(
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Selected result display card
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(12.dp),
-                elevation = CardDefaults.cardElevation(2.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(
-                        imageVector = FeatherIcons.Calendar,
-                        contentDescription = "Selected date",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.padding(horizontal = 8.dp))
-                    Text(
-                        text = "Selected date: $selectedDateText",
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                }
-            }
+            SelectedValueCard(
+                icon = FeatherIcons.Calendar,
+                label = "Selected month",
+                value = selectedDateText,
+                supportingText = "Stored as ${state.selectedMonthDate}"
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
+            SampleActionRow {
                 Button(
                     onClick = { state.selectDate(currentDate()) },
                     modifier = Modifier.fillMaxWidth()
@@ -130,29 +81,36 @@ internal fun YearMonthPickerSampleScreen(
                         imageVector = FeatherIcons.Calendar,
                         contentDescription = null
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
+                    IconTextGap()
                     Text("This month")
                 }
                 OutlinedButton(
-                    onClick = { state.selectYearMonth(year = 2026, month = 12) },
+                    onClick = {
+                        state.selectYearMonth(
+                            year = currentDate.year + 1,
+                            month = currentDate.month.number
+                        )
+                    },
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text("Set Dec 2026")
+                    Text("Same month next year")
                 }
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-            YearMonthPicker(
-                modifier = Modifier.padding(horizontal = 12.dp),
-                state = state,
-                yearPickerLabel = "연도",
-                monthPickerLabel = "월",
-                yearItemContentDescription = { "${it}년" },
-                monthItemContentDescription = { getMonthContentDescription(it) },
-                previousItemActionLabel = "이전 항목 선택",
-                nextItemActionLabel = "다음 항목 선택"
-            )
+            PickerPanel {
+                YearMonthPicker(
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                    state = state,
+                    yearPickerLabel = "연도",
+                    monthPickerLabel = "월",
+                    yearItemContentDescription = { "${it}년" },
+                    monthItemContentDescription = { getMonthContentDescription(it) },
+                    previousItemActionLabel = "이전 항목 선택",
+                    nextItemActionLabel = "다음 항목 선택"
+                )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
         }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/theme/Color.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/theme/Color.kt
@@ -4,23 +4,46 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 
-// 심플한 단색 테마 (라이브러리 샘플 앱)
 internal val LightThemeColors = lightColorScheme(
-    primary = Color(0xFF2196F3),        // 표준 블루
+    primary = Color(0xFF006C5B),
     onPrimary = Color.White,
-    secondary = Color(0xFF64B5F6),      // 라이트 블루 (톤온톤)
-    background = Color(0xFFFAFAFA),     // 거의 흰색
+    primaryContainer = Color(0xFFBFEDE1),
+    onPrimaryContainer = Color(0xFF002019),
+    secondary = Color(0xFF6750A4),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFEADDFF),
+    onSecondaryContainer = Color(0xFF22005D),
+    tertiary = Color(0xFF7D5260),
+    onTertiary = Color.White,
+    tertiaryContainer = Color(0xFFFFD8E4),
+    onTertiaryContainer = Color(0xFF31111D),
+    background = Color(0xFFFCFCF8),
+    onBackground = Color(0xFF1B1C18),
     surface = Color.White,
-    onSurface = Color(0xFF212121),      // 진한 회색 (대비 향상)
-    onSurfaceVariant = Color(0xFF757575) // 보조 텍스트
+    onSurface = Color(0xFF1B1C18),
+    surfaceVariant = Color(0xFFE0E4DA),
+    onSurfaceVariant = Color(0xFF44483F),
+    outline = Color(0xFF74796F)
 )
 
 internal val DarkThemeColors = darkColorScheme(
-    primary = Color(0xFF42A5F5),        // 밝은 블루
-    onPrimary = Color(0xFF001D35),
-    secondary = Color(0xFF90CAF9),      // 라이트 블루
-    background = Color(0xFF121212),
-    surface = Color(0xFF1E1E1E),
-    onSurface = Color(0xFFE0E0E0),
-    onSurfaceVariant = Color(0xFFBDBDBD)
+    primary = Color(0xFF7FD7C5),
+    onPrimary = Color(0xFF00382F),
+    primaryContainer = Color(0xFF005144),
+    onPrimaryContainer = Color(0xFFBFEDE1),
+    secondary = Color(0xFFD0BCFF),
+    onSecondary = Color(0xFF381E72),
+    secondaryContainer = Color(0xFF4F378B),
+    onSecondaryContainer = Color(0xFFEADDFF),
+    tertiary = Color(0xFFEFB8C8),
+    onTertiary = Color(0xFF492532),
+    tertiaryContainer = Color(0xFF633B48),
+    onTertiaryContainer = Color(0xFFFFD8E4),
+    background = Color(0xFF121410),
+    onBackground = Color(0xFFE3E3DD),
+    surface = Color(0xFF1B1C18),
+    onSurface = Color(0xFFE3E3DD),
+    surfaceVariant = Color(0xFF44483F),
+    onSurfaceVariant = Color(0xFFC4C8BD),
+    outline = Color(0xFF8E9287)
 )

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/theme/Theme.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/theme/Theme.kt
@@ -1,13 +1,16 @@
 package com.kez.picker.sample.ui.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 
 @Composable
 fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
     MaterialTheme(
+        colorScheme = if (darkTheme) DarkThemeColors else LightThemeColors,
         content = content
     )
 }


### PR DESCRIPTION
## Summary
- Add shared sample UI components for consistent result cards, picker panels, and top app bars
- Make standalone picker screens follow a clearer selected value -> action -> picker flow
- Separate BottomSheet committed values from draft picker state before confirmation
- Apply the sample app color scheme through AppTheme and refresh home screen descriptions

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :sample:assembleDebug --no-daemon
- ./gradlew :sample:compileKotlinDesktop --no-daemon
- ./gradlew :sample:wasmJsBrowserDistribution --no-daemon
- git diff --check