### PR TITLE
docs: polish sample accessibility semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   samples.
 - Refined sample screens with shared result cards, picker panels, real reset/confirm actions, and
   bottom-sheet draft state separate from committed selection values.
+- Improved sample accessibility semantics for selected-value cards and home-screen navigation items.
 - Documented generic `Picker<T>` usage, initial `startIndex` alignment, and the regular `remember`
   behavior of `rememberPickerState`.
 - Clarified `DatePicker` README examples for custom year ranges and state synchronization after composition.

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -127,7 +130,10 @@ internal fun MenuListItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable(onClick = onClick)
+            .semantics {
+                role = Role.Button
+            },
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(1.dp),
         colors = CardDefaults.cardColors(
@@ -157,7 +163,7 @@ internal fun MenuListItem(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            Icon(FeatherIcons.ArrowRight, contentDescription = "Navigate")
+            Icon(FeatherIcons.ArrowRight, contentDescription = null)
         }
     }
 }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
@@ -27,8 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -130,10 +128,10 @@ internal fun MenuListItem(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .semantics {
-                role = Role.Button
-            },
+            .clickable(
+                role = Role.Button,
+                onClick = onClick
+            ),
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(1.dp),
         colors = CardDefaults.cardColors(

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/SampleComponents.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/SampleComponents.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import compose.icons.FeatherIcons
@@ -66,8 +68,18 @@ internal fun SelectedValueCard(
     modifier: Modifier = Modifier,
     supportingText: String? = null,
 ) {
+    val cardDescription = if (supportingText == null) {
+        "$label, $value"
+    } else {
+        "$label, $value, $supportingText"
+    }
+
     Card(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = cardDescription
+            },
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
         colors = CardDefaults.cardColors(
@@ -83,7 +95,7 @@ internal fun SelectedValueCard(
         ) {
             Icon(
                 imageVector = icon,
-                contentDescription = label,
+                contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(24.dp)
             )

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/SampleComponents.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/SampleComponents.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import compose.icons.FeatherIcons
@@ -77,7 +77,7 @@ internal fun SelectedValueCard(
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .semantics(mergeDescendants = true) {
+            .clearAndSetSemantics {
                 contentDescription = cardDescription
             },
         shape = RoundedCornerShape(16.dp),


### PR DESCRIPTION
## Summary
- Give sample selected-value cards a single concise accessibility description and mark their icons decorative
- Expose home screen sample rows as button-role clickable items
- Record the sample accessibility polish in the unreleased changelog

## Review
- Must-fix: none after local review
- Should-fix addressed: use clearAndSetSemantics for summary cards and clickable(role = Role.Button) for menu rows
- Residual risk: sample-only semantics are compile-verified, not device TalkBack-recorded

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :sample:assembleDebug --no-daemon
- git diff --check HEAD~4..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved accessibility semantics for selected-value cards and home screen navigation components
  - Enhanced accessibility descriptions and semantic roles throughout the sample application UI

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->