### PR TITLE
docs: clean up sample Android theme entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Refined sample screens with shared result cards, picker panels, real reset/confirm actions, and
   bottom-sheet draft state separate from committed selection values.
 - Improved sample accessibility semantics for selected-value cards and home-screen navigation items.
+- Removed the redundant Android sample `MaterialTheme` wrapper so the sample entry point uses the shared `AppTheme`.
 - Documented generic `Picker<T>` usage, initial `startIndex` alignment, and the regular `remember`
   behavior of `rememberPickerState`.
 - Clarified `DatePicker` README examples for custom year ranges and state synchronization after composition.

--- a/sample/src/androidMain/kotlin/com/kez/picker/sample/MainActivity.kt
+++ b/sample/src/androidMain/kotlin/com/kez/picker/sample/MainActivity.kt
@@ -4,14 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.ui.Modifier
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,9 +11,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         setContent {
-            MaterialTheme {
-                App()
-            }
+            App()
         }
     }
-} 
+}


### PR DESCRIPTION
## Summary
- Remove the redundant MaterialTheme wrapper from the Android sample activity
- Let the sample entry point rely on the shared AppTheme defined in App()
- Record the cleanup in the unreleased changelog

## Review
- Must-fix: none
- Should-fix: none; this is sample entry cleanup with no public API change
- Residual risk: visual behavior is compile-verified, not screenshot-tested

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :sample:assembleDebug --no-daemon
- git diff --check HEAD~2..HEAD