### PR TITLE
test: add sample Android smoke coverage

### DIFF
--- a/.github/workflows/integration-build-test.yml
+++ b/.github/workflows/integration-build-test.yml
@@ -121,6 +121,7 @@ jobs:
         run: |
           ./gradlew \
             ${{ env.LIBRARY_MODULE }}:pixel2Api35DebugAndroidTest \
+            ${{ env.SAMPLE_MODULE }}:pixel2Api35DebugAndroidTest \
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
             --stacktrace \
             --no-daemon
@@ -134,6 +135,9 @@ jobs:
             datetimepicker/build/reports/androidTests/**
             datetimepicker/build/outputs/androidTest-results/**
             datetimepicker/build/outputs/managed_device_android_test_additional_output/**
+            sample/build/reports/androidTests/**
+            sample/build/outputs/androidTest-results/**
+            sample/build/outputs/managed_device_android_test_additional_output/**
           if-no-files-found: ignore
 
       # Web(WASM) Build/Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,12 +225,14 @@ color = lerp(selectedTextStyle.color, textStyle.color, fraction)
 **Current coverage** (estimated):
 - Unit tests: picker states, date validation, time calculation, picker index utility behavior, and accessibility description formatting
 - Android instrumented tests: picker accessibility semantics for selected values, custom labels, state descriptions, and higher-level picker forwarding
-- Missing: broader UI interaction tests, screenshot tests, full TalkBack/readout validation, and sample smoke tests
+- Sample Android smoke tests: home-screen example entry points and a representative navigation path
+- Missing: broader UI interaction tests, screenshot tests, and full TalkBack/readout validation
 
 **When adding tests**:
 - Unit tests → `datetimepicker/src/commonTest/kotlin/`
 - Android UI/instrumented tests → `datetimepicker/src/androidInstrumentedTest/kotlin/`
-- Use `:datetimepicker:assembleDebugAndroidTest` to verify Android test APK compilation/packaging. Use `:datetimepicker:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect` for the Gradle Managed Device path used by CI; it requires Android Emulator, the API 35 AOSP ATD x86_64 system image, and local virtualization/KVM. Use `:datetimepicker:connectedDebugAndroidTest` when a local device or emulator is already available. If managed-device prerequisites are unavailable locally, run `assembleDebugAndroidTest` or a managed-device `--dry-run` and rely on CI for the actual emulator run.
+- Sample Android smoke tests → `sample/src/androidInstrumentedTest/kotlin/`
+- Use `:datetimepicker:assembleDebugAndroidTest` or `:sample:assembleDebugAndroidTest` to verify Android test APK compilation/packaging. Use `:datetimepicker:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect` and `:sample:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect` for the Gradle Managed Device path used by CI; it requires Android Emulator, the API 35 AOSP ATD system image for the host architecture, and local virtualization/KVM. Use `:datetimepicker:connectedDebugAndroidTest` when a local device or emulator is already available. If managed-device prerequisites are unavailable locally, run `assembleDebugAndroidTest` or a managed-device `--dry-run` and rely on CI for the actual emulator run.
 - Public Kotlin API/ABI changes → run `:datetimepicker:checkLegacyAbi`. If the API change is intentional and SemVer-appropriate, run `:datetimepicker:updateLegacyAbi`, commit the updated `datetimepicker/api/` dumps, and review preview/generated resource changes separately from supported picker/state API changes.
 - Follow naming: `<ComponentName>Test.kt` or `<ComponentName>AndroidTest.kt`
 
@@ -253,7 +255,7 @@ Follow **Semantic Versioning**: MAJOR.MINOR.PATCH
 ## CI/CD
 
 GitHub Actions workflows:
-- **`integration-build-test.yml`**: Runs repository hygiene and multiplatform library checks on pull requests to `main`; the hygiene job runs `git diff --check` on the PR diff, the dedicated macOS ABI job runs `checkLegacyAbi`, and the Android matrix runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for instrumented tests.
+- **`integration-build-test.yml`**: Runs repository hygiene and multiplatform library checks on pull requests to `main`; the hygiene job runs `git diff --check` on the PR diff, the dedicated macOS ABI job runs `checkLegacyAbi`, and the Android matrix runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for library and sample instrumented tests.
 - **`maven-central-deploy.yml`**: Publishes releases to Maven Central
 
 Build matrix: Ubuntu latest for Android/Desktop/Wasm and macOS 14 for iOS, using JDK 17 (Temurin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 ### Maintenance
 
+- Added Android managed-device smoke coverage for the sample app home screen and `DatePicker` navigation path.
 - Added Android instrumented accessibility semantics coverage and a Gradle Managed Device CI gate.
 - Extended Android accessibility action coverage for `TimePicker`, `DatePicker`, and `YearMonthPicker`
   child picker state updates.

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -74,6 +74,12 @@ kotlin {
             implementation(libs.androidx.core.splashscreen)
         }
 
+        val androidInstrumentedTest by getting {
+            dependencies {
+                implementation(libs.androidx.uitest.junit4)
+            }
+        }
+
         iosMain.dependencies {
             // iOS-specific dependencies if needed
         }
@@ -91,6 +97,10 @@ kotlin {
     }
 }
 
+dependencies {
+    debugImplementation(libs.androidx.uitest.testManifest)
+}
+
 android {
     namespace = "com.kez.picker.sample"
     compileSdk = 36
@@ -101,6 +111,7 @@ android {
         targetSdk = 36
         versionCode = 1
         versionName = "1.0.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     packaging {
@@ -127,4 +138,17 @@ android {
     buildFeatures {
         compose = true
     }
-} 
+
+    testOptions {
+        managedDevices {
+            localDevices {
+                create("pixel2Api35") {
+                    device = "Pixel 2"
+                    apiLevel = 35
+                    systemImageSource = "aosp-atd"
+                    require64Bit = true
+                }
+            }
+        }
+    }
+}

--- a/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
+++ b/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
@@ -1,0 +1,62 @@
+package com.kez.picker.sample
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import org.junit.Rule
+import org.junit.Test
+
+class SampleAppSmokeAndroidTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun homeScreen_displaysPrimarySampleMenuActions() {
+        composeRule
+            .onNodeWithText("Compose DateTimePicker")
+            .assertIsDisplayed()
+
+        sampleMenuTags.forEach { tag ->
+            composeRule
+                .onNodeWithTag(tag)
+                .performScrollTo()
+                .assertIsDisplayed()
+                .assertHasClickAction()
+        }
+    }
+
+    @Test
+    fun datePickerMenuAction_opensDatePickerSampleAndReturnsHome() {
+        composeRule
+            .onNodeWithTag("sample-menu-date-picker")
+            .performScrollTo()
+            .performClick()
+
+        composeRule
+            .onNodeWithText("DatePicker Sample")
+            .assertIsDisplayed()
+
+        composeRule
+            .onNodeWithContentDescription("Back")
+            .performClick()
+
+        composeRule
+            .onNodeWithText("Compose DateTimePicker")
+            .assertIsDisplayed()
+    }
+}
+
+private val sampleMenuTags = listOf(
+    "sample-menu-integrated",
+    "sample-menu-time-picker",
+    "sample-menu-year-month-picker",
+    "sample-menu-date-picker",
+    "sample-menu-bottom-sheet",
+    "sample-menu-background-style"
+)

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/HomeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -70,6 +71,7 @@ internal fun HomeScreen(navController: NavController) {
                     title = "Integrated Sample",
                     description = "Tabs with shared date and time state",
                     icon = FeatherIcons.CheckCircle,
+                    modifier = Modifier.testTag("sample-menu-integrated"),
                     onClick = { navController.navigate(Screen.Integrated.route) }
                 )
             }
@@ -78,6 +80,7 @@ internal fun HomeScreen(navController: NavController) {
                     title = "TimePicker Sample",
                     description = "12-hour and 24-hour state updates",
                     icon = FeatherIcons.Clock,
+                    modifier = Modifier.testTag("sample-menu-time-picker"),
                     onClick = { navController.navigate(Screen.TimePicker.route) }
                 )
             }
@@ -86,6 +89,7 @@ internal fun HomeScreen(navController: NavController) {
                     title = "YearMonthPicker Sample",
                     description = "Month selection with programmatic reset",
                     icon = FeatherIcons.Calendar,
+                    modifier = Modifier.testTag("sample-menu-year-month-picker"),
                     onClick = { navController.navigate(Screen.YearMonthPicker.route) }
                 )
             }
@@ -94,6 +98,7 @@ internal fun HomeScreen(navController: NavController) {
                     title = "DatePicker Sample",
                     description = "Custom year range and leap-day target",
                     icon = FeatherIcons.Calendar,
+                    modifier = Modifier.testTag("sample-menu-date-picker"),
                     onClick = { navController.navigate(Screen.DatePicker.route) }
                 )
             }
@@ -102,6 +107,7 @@ internal fun HomeScreen(navController: NavController) {
                     title = "BottomSheet Sample",
                     description = "Committed value plus draft sheet state",
                     icon = FeatherIcons.Layers,
+                    modifier = Modifier.testTag("sample-menu-bottom-sheet"),
                     onClick = { navController.navigate(Screen.BottomSheet.route) }
                 )
             }
@@ -110,6 +116,7 @@ internal fun HomeScreen(navController: NavController) {
                     title = "Background Style",
                     description = "Divider-free picker styling",
                     icon = FeatherIcons.Square,
+                    modifier = Modifier.testTag("sample-menu-background-style"),
                     onClick = { navController.navigate(Screen.BackgroundStyle.route) }
                 )
             }
@@ -123,10 +130,11 @@ internal fun MenuListItem(
     title: String,
     description: String,
     icon: ImageVector,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .clickable(
                 role = Role.Button,


### PR DESCRIPTION
## Summary
- add Android instrumented smoke tests for the sample app home menu and DatePicker navigation path
- wire the sample module into the managed-device Android CI gate and upload sample test reports
- update maintainer guidance and changelog for the new sample smoke coverage

## Review
- Must-fix: none from self-review
- Should-fix: AGENTS.md coverage notes were stale after this change, updated in this PR
- Nit: none
- Residual risk: local run covered sample managed-device tests on macOS arm64; GitHub Actions will run the Ubuntu x86_64 managed-device path

## Local verification
- ./gradlew :sample:assembleDebugAndroidTest --no-daemon
- ./gradlew :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution --no-daemon
- ./gradlew :sample:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --stacktrace --no-daemon
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :sample:assembleDebug :sample:assembleDebugAndroidTest --no-daemon
- git diff --check origin/main...HEAD