### PR TITLE
docs: clarify DatePicker initial day clamping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Improved sample accessibility semantics for selected-value cards and home-screen navigation items.
 - Removed the redundant Android sample `MaterialTheme` wrapper so the sample entry point uses the shared `AppTheme`.
 - Reworked README bottom-sheet examples to use separate committed and draft picker state.
+- Clarified `DatePickerState` initial-day documentation to distinguish invalid values from max-day clamping.
 - Documented generic `Picker<T>` usage, initial `startIndex` alignment, and the regular `remember`
   behavior of `rememberPickerState`.
 - Clarified `DatePicker` README examples for custom year ranges and state synchronization after composition.

--- a/README.md
+++ b/README.md
@@ -414,7 +414,11 @@ Invalid custom item values throw `IllegalArgumentException` during composition. 
 
 `rememberDatePickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
-For initial values, use either `rememberDatePickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth`/`initialDay` parameters. Initial years must be in `1000..9999`. The `startLocalDate` component parameter is retained only for source compatibility and is not used.
+For initial values, use either `rememberDatePickerState(initialDate = LocalDate(...))` or the
+explicit `initialYear`/`initialMonth`/`initialDay` parameters. Initial years must be in
+`1000..9999`, months in `1..12`, and days must be at least `1`. If `initialDay` is greater than
+the maximum valid day for the initial year/month, it is clamped to that maximum. The
+`startLocalDate` component parameter is retained only for source compatibility and is not used.
 
 To change the selection after state creation, call `state.selectDate(LocalDate(...))`.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -410,7 +410,10 @@ custom item 값이 유효 범위를 벗어나면 composition 중 `IllegalArgumen
 
 `rememberDatePickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
-초기값은 `rememberDatePickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth`/`initialDay` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
+초기값은 `rememberDatePickerState(initialDate = LocalDate(...))` 또는
+`initialYear`/`initialMonth`/`initialDay` 파라미터로 설정합니다. 초기 연도는 `1000..9999`,
+월은 `1..12` 범위여야 하고 일은 최소 `1`이어야 합니다. `initialDay`가 초기 연/월의 최대 일수보다
+크면 그 최대 일수로 보정됩니다. 컴포넌트의 `startLocalDate` 파라미터는 소스 호환성 때문에 남아 있지만 사용되지 않습니다.
 
 상태 생성 이후 선택값을 바꾸려면 `state.selectDate(LocalDate(...))`를 호출합니다.
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -58,9 +58,11 @@ fun rememberDatePickerState(initialDate: LocalDate): DatePickerState {
  * Internal picker states are not directly accessible to prevent inconsistent state modifications.
  *
  * @param initialYear The initial year to be selected. Must be in 1000..9999.
- * @param initialMonth The initial month to be selected.
- * @param initialDay The initial day to be selected.
- * @throws IllegalArgumentException if [initialYear], [initialMonth], or [initialDay] is outside the supported range.
+ * @param initialMonth The initial month to be selected. Must be in 1..12.
+ * @param initialDay The initial day to be selected. Must be at least 1. Values greater than the
+ * maximum valid day for [initialYear] and [initialMonth] are clamped to that maximum.
+ * @throws IllegalArgumentException if [initialYear] or [initialMonth] is outside the supported
+ * range, or if [initialDay] is less than 1.
  */
 @Stable
 class DatePickerState(


### PR DESCRIPTION
## Summary
- clarify DatePickerState KDoc for initialMonth and initialDay validation
- document that initialDay above the initial month maximum is clamped, while values below 1 are invalid
- mirror the clarification in English/Korean READMEs and CHANGELOG

## Review
- Must-fix: none from self-review
- Should-fix: none
- Nit: none
- Residual risk: documentation-only behavior clarification; no runtime behavior changed

## Local verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check origin/main...HEAD