### PR TITLE
test: cover integrated sample summary semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Refined sample screens with shared result cards, picker panels, real reset/confirm actions, and
   bottom-sheet draft state separate from committed selection values.
 - Improved sample accessibility semantics for selected-value cards and home-screen navigation items.
+- Improved the integrated sample summary semantics and covered it in the sample Android smoke test.
 - Removed the redundant Android sample `MaterialTheme` wrapper so the sample entry point uses the shared `AppTheme`.
 - Reworked README bottom-sheet examples to use separate committed and draft picker state.
 - Clarified `DatePickerState` initial-day documentation to distinguish invalid values from max-day clamping.

--- a/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
+++ b/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
@@ -1,5 +1,8 @@
 package com.kez.picker.sample
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -50,6 +53,29 @@ class SampleAppSmokeAndroidTest {
             .onNodeWithText("Compose DateTimePicker")
             .assertIsDisplayed()
     }
+
+    @Test
+    fun integratedMenuAction_opensAccessibleSelectionSummaryAndReturnsHome() {
+        composeRule
+            .onNodeWithTag("sample-menu-integrated")
+            .performScrollTo()
+            .performClick()
+
+        composeRule
+            .onNodeWithText("Integrated Sample")
+            .assertIsDisplayed()
+        composeRule
+            .onNode(hasContentDescriptionStartingWith("Selected date,"))
+            .assertIsDisplayed()
+
+        composeRule
+            .onNodeWithContentDescription("Back")
+            .performClick()
+
+        composeRule
+            .onNodeWithText("Compose DateTimePicker")
+            .assertIsDisplayed()
+    }
 }
 
 private val sampleMenuTags = listOf(
@@ -60,3 +86,11 @@ private val sampleMenuTags = listOf(
     "sample-menu-bottom-sheet",
     "sample-menu-background-style"
 )
+
+private fun hasContentDescriptionStartingWith(prefix: String): SemanticsMatcher {
+    return SemanticsMatcher("content description starts with $prefix") { node ->
+        node.config
+            .getOrNull(SemanticsProperties.ContentDescription)
+            ?.any { it.startsWith(prefix) } == true
+    }
+}

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/IntegratedPickerScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -222,9 +224,12 @@ internal fun IntegratedPickerScreen(
 
 @Composable
 internal fun SelectedDateTimeCard(date: String, time: String) {
-    // Simple solid color card (gradient removed)
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clearAndSetSemantics {
+                contentDescription = "Selected date, $date, selected time, $time"
+            },
         shape = RoundedCornerShape(16.dp),
         elevation = CardDefaults.cardElevation(2.dp),
         colors = CardDefaults.cardColors(
@@ -244,7 +249,7 @@ internal fun SelectedDateTimeCard(date: String, time: String) {
             ) {
                 Icon(
                     imageVector = FeatherIcons.Calendar,
-                    contentDescription = "Date",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(20.dp)
                 )
@@ -267,7 +272,7 @@ internal fun SelectedDateTimeCard(date: String, time: String) {
             ) {
                 Icon(
                     imageVector = FeatherIcons.Clock,
-                    contentDescription = "Time",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(20.dp)
                 )


### PR DESCRIPTION
## Summary
- expose the integrated sample selected date/time card as one concise accessibility summary
- mark decorative date/time icons as non-semantic
- extend sample Android smoke coverage for the integrated sample path and summary semantics

## Review
- Must-fix: fixed initial compile issue from an unnecessary onNode import before PR creation
- Should-fix: none
- Nit: none
- Residual risk: semantics are smoke-tested by prefix because date/time values are dynamic

## Local verification
- ./gradlew :sample:assembleDebugAndroidTest --no-daemon
- ./gradlew :sample:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --stacktrace --no-daemon
- ./gradlew :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution --no-daemon
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke test coverage for the integrated sample feature.

* **Improvements**
  * Enhanced accessibility semantics for the integrated picker screen with improved content descriptions for assistive technologies.

* **Documentation**
  * Updated changelog with notes on integrated sample improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->