### PR TITLE
test: cover blank picker accessibility action labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 - Added Android managed-device smoke coverage for the sample app home screen and `DatePicker` navigation path.
 - Added Android instrumented accessibility semantics coverage and a Gradle Managed Device CI gate.
+- Added Android coverage for omitting picker custom accessibility actions with null or blank labels.
 - Added Android rendered state-restoration coverage for `DatePicker` and `YearMonthPicker`.
 - Extended Android accessibility action coverage for `TimePicker`, `DatePicker`, and `YearMonthPicker`
   child picker state updates.

--- a/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
+++ b/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
@@ -273,6 +273,27 @@ class PickerAccessibilitySemanticsAndroidTest {
     }
 
     @Test
+    fun picker_omitsCustomAccessibilityActionsWhenActionLabelsAreNullOrBlank() {
+        composeRule.setContent {
+            val state = rememberPickerState(2)
+
+            Picker(
+                items = listOf(1, 2, 3),
+                state = state,
+                startIndex = 1,
+                visibleItemsCount = 3,
+                isInfinity = false,
+                pickerLabel = "Value",
+                itemContentDescription = { "$it" },
+                previousItemActionLabel = null,
+                nextItemActionLabel = " "
+            )
+        }
+
+        assertNoCustomAccessibilityActions("Value: 2")
+    }
+
+    @Test
     fun picker_updatesAccessibilitySemanticsWhenSelectionChangesProgrammatically() {
         lateinit var state: PickerState<Int>
 
@@ -972,6 +993,19 @@ class PickerAccessibilitySemanticsAndroidTest {
             .fetchSemanticsNodes()
 
         assertTrue(nodes.isEmpty())
+    }
+
+    private fun assertNoCustomAccessibilityActions(contentDescription: String) {
+        val actions = composeRule
+            .onAllNodes(hasContentDescription(contentDescription))
+            .fetchSemanticsNodes()
+            .flatMap { node ->
+                node.config
+                    .getOrNull(SemanticsActions.CustomActions)
+                    .orEmpty()
+            }
+
+        assertTrue(actions.isNullOrEmpty())
     }
 }
 


### PR DESCRIPTION
## Summary
- add Android instrumented coverage that null or blank picker accessibility action labels omit custom actions
- record the maintainer-facing coverage change in CHANGELOG

## Self-review
- Must-fix: none after fixing the ambiguous semantics-node lookup found by managed-device execution
- Should-fix: none
- Nit: none
- Residual risk: this covers action omission at the semantics layer, not a full TalkBack readout pass

## Local verification
- `git diff --check`
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon`
- `./gradlew :datetimepicker:assembleDebugAndroidTest --no-daemon`
- `./gradlew :datetimepicker:pixel2Api35DebugAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --stacktrace --no-daemon`