### PR TITLE
Add composite picker value callbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ DatePicker (year + month + day)
 - `date/DatePickerState.kt` contains `DatePickerState` and `rememberDatePickerState`
 - `date/YearMonthPickerState.kt` contains `YearMonthPickerState` and `rememberYearMonthPickerState`
 - `TimePickerState` exposes `selectedTime: LocalTime` and `selectedHourOfDay`
-- `YearMonthPickerState` exposes `selectedMonthDate: LocalDate`
+- `YearMonthPickerState` exposes `selectedYearMonth: YearMonth`; `selectedMonthDate: LocalDate` is for interoperability with date APIs
 - Specialized picker states use saveable state; generic `Picker<T>` is controlled by caller-owned state because arbitrary `T` is not guaranteed saveable
 
 **`DatePicker.kt`** / **`DatePickerState.kt`**
@@ -93,6 +93,8 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - During 0.x API stabilization, prefer the best long-term API shape over source compatibility when the maintainer explicitly authorizes breaking changes. Document every breaking change in README/CHANGELOG and update ABI dumps.
 - Keep public state APIs colocated with their component package unless there is a strong API-design reason not to. For example, `TimePickerState` and `rememberTimePickerState` live in `com.kez.picker.time`; date and year-month state APIs live in `com.kez.picker.date`.
 - Prefer controlled picker APIs with a single source of truth. Avoid APIs where both a state object and positional parameter can initialize or mutate the same selection.
+- For composite pickers, expose a state object for saveable logical selection plus an optional `onSelected*Change` callback for user-driven changes. Document that programmatic `state.select*` calls require the caller to update app-owned state in the same event handler.
+- For year/month-only values, prefer `date.YearMonth` over encoding the selection as the first day of a `LocalDate`; keep `selectedMonthDate` only as an interop convenience.
 - Keep repeated visual/layout picker configuration grouped in `PickerStyle` instead of expanding the public composable parameter list. New visual options should usually be added to `PickerDefaults.style(...)` and documented as a breaking API change while the library is still 0.x.
 - Keep repeated accessibility/semantics configuration grouped in `PickerAccessibility` or the component-specific accessibility option objects instead of expanding composable signatures with more label/action parameters.
 - Keep repeated custom item-list configuration grouped in component-specific item option objects instead of adding separate list parameters to picker composables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Added programmatic selection APIs for picker state objects:
   `TimePickerState.selectTime`, `DatePickerState.selectDate`,
   `YearMonthPickerState.selectYearMonth`, and `YearMonthPickerState.selectDate`.
+- Added user-selection callbacks to composite pickers:
+  `onSelectedTimeChange`, `onSelectedDateChange`, and `onSelectedYearMonthChange`.
+- Added `date.YearMonth` as the primary value model for year/month-only selections.
 - Added picker accessibility descriptions and localized item description hooks so Android apps can provide clearer TalkBack output.
 - Added previous/next accessibility actions for picker columns, with public labels that apps can localize.
 
@@ -39,6 +42,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   item descriptions, and previous/next action labels can be passed as one reusable object.
 - Added component-specific item-list option objects so custom selectable values can be passed as one
   reusable `items` object.
+- `YearMonthPickerState` now exposes `selectedYearMonth: YearMonth` in addition to
+  `selectedMonthDate` for `LocalDate` interoperability.
 - Custom item lists are now strict: required lists must be non-empty and distinct, values must be in range, and the current selected value must be present before composition proceeds.
 
 ### Compatibility Notes
@@ -59,6 +64,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   `accessibility = PickerDefaults.*Accessibility(...)`.
 - Picker custom item-list parameters such as `minuteItems`, `hourItems`, `periodItems`, `yearItems`,
   and `monthItems` moved under `items = PickerDefaults.*Items(...)`.
+- Composite picker function signatures now include user-selection callbacks immediately after `state`.
+  Named-argument call sites are straightforward to migrate; positional call sites may need argument
+  reordering.
 
 ### Maintenance
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ fun TimePicker24hExample() {
     )
 
     TimePicker(
-        state = state
+        state = state,
+        onSelectedTimeChange = { selectedTime ->
+            // Update app state, ViewModel, or form data here.
+        }
     )
 
     // Use state.selectedTime when passing the result to app logic.
@@ -140,6 +143,9 @@ fun DatePickerExample() {
 
     DatePicker(
         state = state,
+        onSelectedDateChange = { selectedDate ->
+            // Update app state, ViewModel, or form data here.
+        },
         items = PickerDefaults.datePickerItems(
             yearItems = selectableYears
         )
@@ -160,6 +166,7 @@ Use `YearMonthPicker` for selecting a specific month in a year.
 ```kotlin
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.kez.picker.date.YearMonth
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.date.rememberYearMonthPickerState
 import com.kez.picker.util.currentDate
@@ -172,10 +179,14 @@ fun YearMonthPickerExample() {
     )
 
     YearMonthPicker(
-        state = state
+        state = state,
+        onSelectedYearMonthChange = { selectedYearMonth: YearMonth ->
+            // Update app state, ViewModel, or form data here.
+        }
     )
 
-    // state.selectedMonthDate is the first day of the selected month.
+    // state.selectedYearMonth is YearMonth(year, month).
+    // state.selectedMonthDate is still available for LocalDate interoperability.
 }
 ```
 
@@ -353,7 +364,7 @@ selection.
 | Generic `Picker<T>` | Update the app-owned `selectedItem` value |
 | `time.TimePickerState` | `selectTime(LocalTime(...))` |
 | `date.DatePickerState` | `selectDate(LocalDate(...))` |
-| `date.YearMonthPickerState` | `selectYearMonth(year, month)` or `selectDate(LocalDate(...))` |
+| `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, or `selectDate(LocalDate(...))` |
 
 ```kotlin
 import androidx.compose.foundation.layout.Column
@@ -383,11 +394,16 @@ item lists are strict: they must be non-empty, distinct, within the supported va
 current selected value. If an app can restore or request values outside a custom list, clamp or reject that
 app state before rendering the picker.
 
+`onSelectedTimeChange`, `onSelectedDateChange`, and `onSelectedYearMonthChange` are called for
+user-driven picker changes. Programmatic `state.select*` calls update the state directly; update your
+app-owned value in the same event handler when you trigger programmatic changes.
+
 ### TimePicker
 
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberTimePickerState()` |
+| `onSelectedTimeChange` | Called after user interaction changes the selected `LocalTime`. | `{}` |
 | `items` | Selectable minute, 24-hour hour, 12-hour display-hour, and AM/PM item lists. | `PickerDefaults.timePickerItems()` |
 | `style` | Visual and layout styling for each picker column. | `PickerDefaults.style()` |
 | `spacingBetweenPickers` | Horizontal spacing between picker columns. | `0.dp` |
@@ -414,6 +430,7 @@ Invalid custom item values, duplicate items, empty required lists, or current se
 | Parameter           | Description                             | Default                     |
 |:--------------------|:----------------------------------------|:----------------------------|
 | `state`             | The state object to control the picker. | `rememberDatePickerState()` |
+| `onSelectedDateChange` | Called after user interaction changes the selected `LocalDate`. | `{}` |
 | `items`             | Selectable year and month item lists. Values must be in `1000..9999` and `1..12`. | `PickerDefaults.datePickerItems()` |
 | `style`             | Visual and layout styling for each picker column. | `PickerDefaults.style()` |
 | `spacingBetweenPickers` | Horizontal spacing between picker columns. | `0.dp` |
@@ -443,6 +460,7 @@ Invalid custom item values, duplicate items, empty lists, or current selected ye
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberYearMonthPickerState()` |
+| `onSelectedYearMonthChange` | Called after user interaction changes the selected `YearMonth`. | `{}` |
 | `items` | Selectable year and month item lists. Values must be in `1000..9999` and `1..12`. | `PickerDefaults.yearMonthPickerItems()` |
 | `style` | Visual and layout styling for each picker column. | `PickerDefaults.style()` |
 | `spacingBetweenPickers` | Horizontal spacing between picker columns. | `0.dp` |
@@ -452,13 +470,15 @@ Invalid custom item values, duplicate items, empty lists, or current selected ye
 
 - `selectedYear`: The currently selected year.
 - `selectedMonth`: The currently selected month (1-12).
+- `selectedYearMonth`: The selected value as `date.YearMonth`.
 - `selectedMonthDate`: The selected year/month represented as the first day of that month.
 
 `rememberYearMonthPickerState` uses saveable state. On Android, selected values can be restored across Activity recreation when the platform saveable registry is available.
 
 For initial values, use either `rememberYearMonthPickerState(initialDate = LocalDate(...))` or the explicit `initialYear`/`initialMonth` parameters. Initial years must be in `1000..9999`.
 
-To change the selection after state creation, call `state.selectYearMonth(year, month)` or `state.selectDate(LocalDate(...))`.
+To change the selection after state creation, call `state.selectYearMonth(YearMonth(...))`,
+`state.selectYearMonth(year, month)`, or `state.selectDate(LocalDate(...))`.
 
 Invalid custom item values, duplicate items, empty lists, or current selected year/month values missing from custom lists throw `IllegalArgumentException` during composition.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -79,7 +79,10 @@ fun TimePicker24hExample() {
     )
 
     TimePicker(
-        state = state
+        state = state,
+        onSelectedTimeChange = { selectedTime ->
+            // 앱 state, ViewModel, form data를 여기서 갱신합니다.
+        }
     )
 
     // 앱 로직에 전달할 때는 state.selectedTime을 사용합니다.
@@ -137,6 +140,9 @@ fun DatePickerExample() {
 
     DatePicker(
         state = state,
+        onSelectedDateChange = { selectedDate ->
+            // 앱 state, ViewModel, form data를 여기서 갱신합니다.
+        },
         items = PickerDefaults.datePickerItems(
             yearItems = selectableYears
         )
@@ -157,6 +163,7 @@ fun DatePickerExample() {
 ```kotlin
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.kez.picker.date.YearMonth
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.date.rememberYearMonthPickerState
 import com.kez.picker.util.currentDate
@@ -169,10 +176,14 @@ fun YearMonthPickerExample() {
     )
 
     YearMonthPicker(
-        state = state
+        state = state,
+        onSelectedYearMonthChange = { selectedYearMonth: YearMonth ->
+            // 앱 state, ViewModel, form data를 여기서 갱신합니다.
+        }
     )
 
-    // state.selectedMonthDate는 선택된 월의 1일을 나타냅니다.
+    // state.selectedYearMonth는 YearMonth(year, month)입니다.
+    // state.selectedMonthDate는 LocalDate 연동이 필요할 때 사용할 수 있습니다.
 }
 ```
 
@@ -350,7 +361,7 @@ state를 새로 만들 필요는 없습니다.
 | Generic `Picker<T>` | 앱이 소유한 `selectedItem` 값을 갱신 |
 | `time.TimePickerState` | `selectTime(LocalTime(...))` |
 | `date.DatePickerState` | `selectDate(LocalDate(...))` |
-| `date.YearMonthPickerState` | `selectYearMonth(year, month)` 또는 `selectDate(LocalDate(...))` |
+| `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, 또는 `selectDate(LocalDate(...))` |
 
 ```kotlin
 import androidx.compose.foundation.layout.Column
@@ -380,11 +391,16 @@ fun ProgrammaticTimePickerExample() {
 반드시 포함해야 합니다. 앱이 custom list 밖의 값을 복원하거나 요청할 수 있다면 picker를 렌더링하기 전에
 앱 state를 보정하거나 거부하세요.
 
+`onSelectedTimeChange`, `onSelectedDateChange`, `onSelectedYearMonthChange`는 사용자가 picker를
+조작해서 값이 바뀔 때 호출됩니다. 프로그래밍 방식의 `state.select*` 호출은 state를 직접 변경하므로,
+그 이벤트 핸들러 안에서 앱이 소유한 값도 함께 갱신하세요.
+
 ### TimePicker
 
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberTimePickerState()` |
+| `onSelectedTimeChange` | 사용자 조작으로 선택된 `LocalTime`이 바뀐 뒤 호출됩니다. | `{}` |
 | `items` | 선택 가능한 분, 24시간제 시간, 12시간제 표시 시간, 오전/오후 목록입니다. | `PickerDefaults.timePickerItems()` |
 | `style` | 각 picker column의 시각/레이아웃 스타일입니다. | `PickerDefaults.style()` |
 | `spacingBetweenPickers` | picker column 사이의 가로 간격입니다. | `0.dp` |
@@ -411,6 +427,7 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 필수
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberDatePickerState()` |
+| `onSelectedDateChange` | 사용자 조작으로 선택된 `LocalDate`가 바뀐 뒤 호출됩니다. | `{}` |
 | `items` | 선택 가능한 연도/월 목록입니다. 값은 `1000..9999`와 `1..12` 범위여야 합니다. | `PickerDefaults.datePickerItems()` |
 | `style` | 각 picker column의 시각/레이아웃 스타일입니다. | `PickerDefaults.style()` |
 | `spacingBetweenPickers` | picker column 사이의 가로 간격입니다. | `0.dp` |
@@ -440,6 +457,7 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberYearMonthPickerState()` |
+| `onSelectedYearMonthChange` | 사용자 조작으로 선택된 `YearMonth`가 바뀐 뒤 호출됩니다. | `{}` |
 | `items` | 선택 가능한 연도/월 목록입니다. 값은 `1000..9999`와 `1..12` 범위여야 합니다. | `PickerDefaults.yearMonthPickerItems()` |
 | `style` | 각 picker column의 시각/레이아웃 스타일입니다. | `PickerDefaults.style()` |
 | `spacingBetweenPickers` | picker column 사이의 가로 간격입니다. | `0.dp` |
@@ -449,14 +467,15 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 
 - `selectedYear`: 현재 선택된 연도입니다.
 - `selectedMonth`: 현재 선택된 월입니다. (1-12)
+- `selectedYearMonth`: 선택된 값을 `date.YearMonth`로 제공합니다.
 - `selectedMonthDate`: 선택된 연/월을 해당 월의 1일 `LocalDate`로 제공합니다.
 
 `rememberYearMonthPickerState`는 saveable state를 사용합니다. Android에서는 플랫폼 saveable registry가 제공될 때 Activity 재생성 이후에도 선택값을 복원할 수 있습니다.
 
 초기값은 `rememberYearMonthPickerState(initialDate = LocalDate(...))` 또는 `initialYear`/`initialMonth` 파라미터로 설정합니다. 초기 연도는 `1000..9999` 범위여야 합니다.
 
-상태 생성 이후 선택값을 바꾸려면 `state.selectYearMonth(year, month)` 또는
-`state.selectDate(LocalDate(...))`를 호출합니다.
+상태 생성 이후 선택값을 바꾸려면 `state.selectYearMonth(YearMonth(...))`,
+`state.selectYearMonth(year, month)`, 또는 `state.selectDate(LocalDate(...))`를 호출합니다.
 
 custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록이 비어 있거나, 현재 선택된 연도/월이 custom 목록에 없으면 composition 중 `IllegalArgumentException`이 발생합니다.
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -210,7 +210,7 @@ public final class com/kez/picker/YearMonthPickerItems {
 }
 
 public final class com/kez/picker/date/DatePickerKt {
-	public static final fun DatePicker-PfoAEA0 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/DatePickerState;Lcom/kez/picker/DatePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/DatePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
+	public static final fun DatePicker-0vH8DBg (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/DatePickerState;Lkotlin/jvm/functions/Function1;Lcom/kez/picker/DatePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/DatePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/kez/picker/date/DatePickerState {
@@ -234,8 +234,29 @@ public final class com/kez/picker/date/DatePickerStateKt {
 	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/date/DatePickerState;
 }
 
+public final class com/kez/picker/date/YearMonth {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/date/YearMonth$Companion;
+	public fun <init> (II)V
+	public final fun atDay (I)Lkotlinx/datetime/LocalDate;
+	public static synthetic fun atDay$default (Lcom/kez/picker/date/YearMonth;IILjava/lang/Object;)Lkotlinx/datetime/LocalDate;
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lcom/kez/picker/date/YearMonth;
+	public static synthetic fun copy$default (Lcom/kez/picker/date/YearMonth;IIILjava/lang/Object;)Lcom/kez/picker/date/YearMonth;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMonth ()I
+	public final fun getYear ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/date/YearMonth$Companion {
+	public final fun from (Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/YearMonth;
+}
+
 public final class com/kez/picker/date/YearMonthPickerKt {
-	public static final fun YearMonthPicker-PfoAEA0 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/YearMonthPickerState;Lcom/kez/picker/YearMonthPickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/YearMonthPickerAccessibility;Landroidx/compose/runtime/Composer;II)V
+	public static final fun YearMonthPicker-0vH8DBg (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/YearMonthPickerState;Lkotlin/jvm/functions/Function1;Lcom/kez/picker/YearMonthPickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/YearMonthPickerAccessibility;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/kez/picker/date/YearMonthPickerState {
@@ -245,8 +266,10 @@ public final class com/kez/picker/date/YearMonthPickerState {
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedMonthDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedYear ()I
+	public final fun getSelectedYearMonth ()Lcom/kez/picker/date/YearMonth;
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
 	public final fun selectYearMonth (II)V
+	public final fun selectYearMonth (Lcom/kez/picker/date/YearMonth;)V
 }
 
 public final class com/kez/picker/date/YearMonthPickerState$Companion {
@@ -299,7 +322,7 @@ public final class com/kez/picker/resources/Res$string {
 }
 
 public final class com/kez/picker/time/TimePickerKt {
-	public static final fun TimePicker-PfoAEA0 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/time/TimePickerState;Lcom/kez/picker/TimePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/TimePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
+	public static final fun TimePicker-0vH8DBg (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/time/TimePickerState;Lkotlin/jvm/functions/Function1;Lcom/kez/picker/TimePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/TimePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/kez/picker/time/TimePickerState {

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -72,6 +72,27 @@ final class com.kez.picker.date/DatePickerState { // com.kez.picker.date/DatePic
     }
 }
 
+final class com.kez.picker.date/YearMonth { // com.kez.picker.date/YearMonth|null[0]
+    constructor <init>(kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonth.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
+
+    final val month // com.kez.picker.date/YearMonth.month|{}month[0]
+        final fun <get-month>(): kotlin/Int // com.kez.picker.date/YearMonth.month.<get-month>|<get-month>(){}[0]
+    final val year // com.kez.picker.date/YearMonth.year|{}year[0]
+        final fun <get-year>(): kotlin/Int // com.kez.picker.date/YearMonth.year.<get-year>|<get-year>(){}[0]
+
+    final fun atDay(kotlin/Int = ...): kotlinx.datetime/LocalDate // com.kez.picker.date/YearMonth.atDay|atDay(kotlin.Int){}[0]
+    final fun component1(): kotlin/Int // com.kez.picker.date/YearMonth.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // com.kez.picker.date/YearMonth.component2|component2(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin/Int = ...): com.kez.picker.date/YearMonth // com.kez.picker.date/YearMonth.copy|copy(kotlin.Int;kotlin.Int){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.kez.picker.date/YearMonth.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.kez.picker.date/YearMonth.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.kez.picker.date/YearMonth.toString|toString(){}[0]
+
+    final object Companion { // com.kez.picker.date/YearMonth.Companion|null[0]
+        final fun from(kotlinx.datetime/LocalDate): com.kez.picker.date/YearMonth // com.kez.picker.date/YearMonth.Companion.from|from(kotlinx.datetime.LocalDate){}[0]
+    }
+}
+
 final class com.kez.picker.date/YearMonthPickerState { // com.kez.picker.date/YearMonthPickerState|null[0]
     constructor <init>(kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPickerState.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
 
@@ -81,8 +102,11 @@ final class com.kez.picker.date/YearMonthPickerState { // com.kez.picker.date/Ye
         final fun <get-selectedMonthDate>(): kotlinx.datetime/LocalDate // com.kez.picker.date/YearMonthPickerState.selectedMonthDate.<get-selectedMonthDate>|<get-selectedMonthDate>(){}[0]
     final val selectedYear // com.kez.picker.date/YearMonthPickerState.selectedYear|{}selectedYear[0]
         final fun <get-selectedYear>(): kotlin/Int // com.kez.picker.date/YearMonthPickerState.selectedYear.<get-selectedYear>|<get-selectedYear>(){}[0]
+    final val selectedYearMonth // com.kez.picker.date/YearMonthPickerState.selectedYearMonth|{}selectedYearMonth[0]
+        final fun <get-selectedYearMonth>(): com.kez.picker.date/YearMonth // com.kez.picker.date/YearMonthPickerState.selectedYearMonth.<get-selectedYearMonth>|<get-selectedYearMonth>(){}[0]
 
     final fun selectDate(kotlinx.datetime/LocalDate) // com.kez.picker.date/YearMonthPickerState.selectDate|selectDate(kotlinx.datetime.LocalDate){}[0]
+    final fun selectYearMonth(com.kez.picker.date/YearMonth) // com.kez.picker.date/YearMonthPickerState.selectYearMonth|selectYearMonth(com.kez.picker.date.YearMonth){}[0]
     final fun selectYearMonth(kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPickerState.selectYearMonth|selectYearMonth(kotlin.Int;kotlin.Int){}[0]
 
     final object Companion { // com.kez.picker.date/YearMonthPickerState.Companion|null[0]
@@ -352,6 +376,7 @@ final object com.kez.picker/PickerDefaults { // com.kez.picker/PickerDefaults|nu
 }
 
 final val com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop // com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop|#static{}com_kez_picker_date_DatePickerState$stableprop[0]
+final val com.kez.picker.date/com_kez_picker_date_YearMonth$stableprop // com.kez.picker.date/com_kez_picker_date_YearMonth$stableprop|#static{}com_kez_picker_date_YearMonth$stableprop[0]
 final val com.kez.picker.date/com_kez_picker_date_YearMonthPickerState$stableprop // com.kez.picker.date/com_kez_picker_date_YearMonthPickerState$stableprop|#static{}com_kez_picker_date_YearMonthPickerState$stableprop[0]
 final val com.kez.picker.resources/allDrawableResources // com.kez.picker.resources/allDrawableResources|@com.kez.picker.resources.Res{}allDrawableResources[0]
     final fun (com.kez.picker.resources/Res).<get-allDrawableResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/DrawableResource> // com.kez.picker.resources/allDrawableResources.<get-allDrawableResources>|<get-allDrawableResources>@com.kez.picker.resources.Res(){}[0]
@@ -393,9 +418,10 @@ final val com.kez.picker/com_kez_picker_YearMonthPickerAccessibility$stableprop 
 final val com.kez.picker/com_kez_picker_YearMonthPickerItems$stableprop // com.kez.picker/com_kez_picker_YearMonthPickerItems$stableprop|#static{}com_kez_picker_YearMonthPickerItems$stableprop[0]
 
 final fun <#A: kotlin/Any> com.kez.picker/Picker(kotlin.collections/List<#A>, #A, kotlin/Function1<#A, kotlin/Unit>, androidx.compose.ui/Modifier?, com.kez.picker/PickerStyle?, com.kez.picker/PickerAccessibility<#A>?, kotlin/Boolean, kotlin/Function3<#A, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker/Picker|Picker(kotlin.collections.List<0:0>;0:0;kotlin.Function1<0:0,kotlin.Unit>;androidx.compose.ui.Modifier?;com.kez.picker.PickerStyle?;com.kez.picker.PickerAccessibility<0:0>?;kotlin.Boolean;kotlin.Function3<0:0,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<kotlin.Any>}[0]
-final fun com.kez.picker.date/DatePicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.date/DatePickerState?, com.kez.picker/DatePickerItems?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/DatePickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.date/DatePicker|DatePicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.date.DatePickerState?;com.kez.picker.DatePickerItems?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.DatePickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
-final fun com.kez.picker.date/YearMonthPicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.date/YearMonthPickerState?, com.kez.picker/YearMonthPickerItems?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/YearMonthPickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPicker|YearMonthPicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.date.YearMonthPickerState?;com.kez.picker.YearMonthPickerItems?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.YearMonthPickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker.date/DatePicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.date/DatePickerState?, kotlin/Function1<kotlinx.datetime/LocalDate, kotlin/Unit>?, com.kez.picker/DatePickerItems?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/DatePickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.date/DatePicker|DatePicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.date.DatePickerState?;kotlin.Function1<kotlinx.datetime.LocalDate,kotlin.Unit>?;com.kez.picker.DatePickerItems?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.DatePickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker.date/YearMonthPicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.date/YearMonthPickerState?, kotlin/Function1<com.kez.picker.date/YearMonth, kotlin/Unit>?, com.kez.picker/YearMonthPickerItems?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/YearMonthPickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPicker|YearMonthPicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.date.YearMonthPickerState?;kotlin.Function1<com.kez.picker.date.YearMonth,kotlin.Unit>?;com.kez.picker.YearMonthPickerItems?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.YearMonthPickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop_getter(): kotlin/Int // com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop_getter|com_kez_picker_date_DatePickerState$stableprop_getter(){}[0]
+final fun com.kez.picker.date/com_kez_picker_date_YearMonth$stableprop_getter(): kotlin/Int // com.kez.picker.date/com_kez_picker_date_YearMonth$stableprop_getter|com_kez_picker_date_YearMonth$stableprop_getter(){}[0]
 final fun com.kez.picker.date/com_kez_picker_date_YearMonthPickerState$stableprop_getter(): kotlin/Int // com.kez.picker.date/com_kez_picker_date_YearMonthPickerState$stableprop_getter|com_kez_picker_date_YearMonthPickerState$stableprop_getter(){}[0]
 final fun com.kez.picker.date/rememberDatePickerState(kotlin/Int, kotlin/Int, kotlin/Int, androidx.compose.runtime/Composer?, kotlin/Int): com.kez.picker.date/DatePickerState // com.kez.picker.date/rememberDatePickerState|rememberDatePickerState(kotlin.Int;kotlin.Int;kotlin.Int;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
 final fun com.kez.picker.date/rememberDatePickerState(kotlinx.datetime/LocalDate?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker.date/DatePickerState // com.kez.picker.date/rememberDatePickerState|rememberDatePickerState(kotlinx.datetime.LocalDate?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
@@ -407,7 +433,7 @@ final fun com.kez.picker.resources/com_kez_picker_resources_Res_drawable$stablep
 final fun com.kez.picker.resources/com_kez_picker_resources_Res_font$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_font$stableprop_getter|com_kez_picker_resources_Res_font$stableprop_getter(){}[0]
 final fun com.kez.picker.resources/com_kez_picker_resources_Res_plurals$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_plurals$stableprop_getter|com_kez_picker_resources_Res_plurals$stableprop_getter(){}[0]
 final fun com.kez.picker.resources/com_kez_picker_resources_Res_string$stableprop_getter(): kotlin/Int // com.kez.picker.resources/com_kez_picker_resources_Res_string$stableprop_getter|com_kez_picker_resources_Res_string$stableprop_getter(){}[0]
-final fun com.kez.picker.time/TimePicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.time/TimePickerState?, com.kez.picker/TimePickerItems?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/TimePickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.time/TimePicker|TimePicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.time.TimePickerState?;com.kez.picker.TimePickerItems?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.TimePickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.kez.picker.time/TimePicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.time/TimePickerState?, kotlin/Function1<kotlinx.datetime/LocalTime, kotlin/Unit>?, com.kez.picker/TimePickerItems?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/TimePickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.time/TimePicker|TimePicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.time.TimePickerState?;kotlin.Function1<kotlinx.datetime.LocalTime,kotlin.Unit>?;com.kez.picker.TimePickerItems?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.TimePickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.kez.picker.time/com_kez_picker_time_TimePickerState$stableprop_getter(): kotlin/Int // com.kez.picker.time/com_kez_picker_time_TimePickerState$stableprop_getter|com_kez_picker_time_TimePickerState$stableprop_getter(){}[0]
 final fun com.kez.picker.time/rememberTimePickerState(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod?, com.kez.picker.util/TimeFormat?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker.time/TimePickerState // com.kez.picker.time/rememberTimePickerState|rememberTimePickerState(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod?;com.kez.picker.util.TimeFormat?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.kez.picker.time/rememberTimePickerState(kotlinx.datetime/LocalTime?, com.kez.picker.util/TimeFormat?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.kez.picker.time/TimePickerState // com.kez.picker.time/rememberTimePickerState|rememberTimePickerState(kotlinx.datetime.LocalTime?;com.kez.picker.util.TimeFormat?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -210,7 +210,7 @@ public final class com/kez/picker/YearMonthPickerItems {
 }
 
 public final class com/kez/picker/date/DatePickerKt {
-	public static final fun DatePicker-PfoAEA0 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/DatePickerState;Lcom/kez/picker/DatePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/DatePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
+	public static final fun DatePicker-0vH8DBg (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/DatePickerState;Lkotlin/jvm/functions/Function1;Lcom/kez/picker/DatePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/DatePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/kez/picker/date/DatePickerState {
@@ -234,8 +234,29 @@ public final class com/kez/picker/date/DatePickerStateKt {
 	public static final fun rememberDatePickerState (Lkotlinx/datetime/LocalDate;Landroidx/compose/runtime/Composer;II)Lcom/kez/picker/date/DatePickerState;
 }
 
+public final class com/kez/picker/date/YearMonth {
+	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/date/YearMonth$Companion;
+	public fun <init> (II)V
+	public final fun atDay (I)Lkotlinx/datetime/LocalDate;
+	public static synthetic fun atDay$default (Lcom/kez/picker/date/YearMonth;IILjava/lang/Object;)Lkotlinx/datetime/LocalDate;
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lcom/kez/picker/date/YearMonth;
+	public static synthetic fun copy$default (Lcom/kez/picker/date/YearMonth;IIILjava/lang/Object;)Lcom/kez/picker/date/YearMonth;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMonth ()I
+	public final fun getYear ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/date/YearMonth$Companion {
+	public final fun from (Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/YearMonth;
+}
+
 public final class com/kez/picker/date/YearMonthPickerKt {
-	public static final fun YearMonthPicker-PfoAEA0 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/YearMonthPickerState;Lcom/kez/picker/YearMonthPickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/YearMonthPickerAccessibility;Landroidx/compose/runtime/Composer;II)V
+	public static final fun YearMonthPicker-0vH8DBg (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/date/YearMonthPickerState;Lkotlin/jvm/functions/Function1;Lcom/kez/picker/YearMonthPickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/YearMonthPickerAccessibility;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/kez/picker/date/YearMonthPickerState {
@@ -245,8 +266,10 @@ public final class com/kez/picker/date/YearMonthPickerState {
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedMonthDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedYear ()I
+	public final fun getSelectedYearMonth ()Lcom/kez/picker/date/YearMonth;
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
 	public final fun selectYearMonth (II)V
+	public final fun selectYearMonth (Lcom/kez/picker/date/YearMonth;)V
 }
 
 public final class com/kez/picker/date/YearMonthPickerState$Companion {
@@ -299,7 +322,7 @@ public final class com/kez/picker/resources/Res$string {
 }
 
 public final class com/kez/picker/time/TimePickerKt {
-	public static final fun TimePicker-PfoAEA0 (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/time/TimePickerState;Lcom/kez/picker/TimePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/TimePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
+	public static final fun TimePicker-0vH8DBg (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/kez/picker/time/TimePickerState;Lkotlin/jvm/functions/Function1;Lcom/kez/picker/TimePickerItems;Lcom/kez/picker/PickerStyle;FLcom/kez/picker/TimePickerAccessibility;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/kez/picker/time/TimePickerState {

--- a/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
+++ b/datetimepicker/src/androidInstrumentedTest/kotlin/com/kez/picker/PickerAccessibilitySemanticsAndroidTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import com.kez.picker.date.DatePicker
 import com.kez.picker.date.DatePickerState
+import com.kez.picker.date.YearMonth
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.date.YearMonthPickerState
 import com.kez.picker.date.rememberDatePickerState
@@ -571,6 +572,46 @@ class PickerAccessibilitySemanticsAndroidTest {
     }
 
     @Test
+    fun timePicker_callsOnSelectedTimeChangeAfterUserSelection() {
+        lateinit var changedTimeState: MutableState<LocalTime?>
+
+        composeRule.setContent {
+            val state = rememberTimePickerState(
+                initialTime = LocalTime(hour = 10, minute = 5),
+                timeFormat = TimeFormat.HOUR_24
+            )
+            changedTimeState = remember { mutableStateOf(null) }
+
+            TimePicker(
+                state = state,
+                onSelectedTimeChange = { changedTimeState.value = it },
+                items = PickerDefaults.timePickerItems(
+                    minuteItems = listOf(5, 10),
+                    hour24Items = listOf(10, 11)
+                ),
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                accessibility = PickerDefaults.timePickerAccessibility(
+                    hourPickerLabel = "시간",
+                    minutePickerLabel = "분",
+                    hourItemContentDescription = { "${it}시" },
+                    minuteItemContentDescription = { "${it}분" },
+                    nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+                )
+            )
+        }
+
+        performCustomAccessibilityAction(
+            contentDescription = "시간: 10시",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("시간: 11시")
+
+        composeRule.runOnIdle {
+            assertEquals(LocalTime(hour = 11, minute = 5), changedTimeState.value)
+        }
+    }
+
+    @Test
     fun timePicker_forwardsCustomPeriodAccessibilityDescriptionIn12HourMode() {
         composeRule.setContent {
             val state = rememberTimePickerState(
@@ -713,6 +754,45 @@ class PickerAccessibilitySemanticsAndroidTest {
     }
 
     @Test
+    fun datePicker_callsOnSelectedDateChangeAfterUserSelection() {
+        lateinit var changedDateState: MutableState<LocalDate?>
+
+        composeRule.setContent {
+            val state = rememberDatePickerState(
+                initialYear = 2026,
+                initialMonth = 1,
+                initialDay = 31
+            )
+            changedDateState = remember { mutableStateOf(null) }
+
+            DatePicker(
+                state = state,
+                onSelectedDateChange = { changedDateState.value = it },
+                items = PickerDefaults.datePickerItems(
+                    yearItems = listOf(2026),
+                    monthItems = listOf(1, 2)
+                ),
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                accessibility = PickerDefaults.datePickerAccessibility(
+                    monthPickerLabel = "월",
+                    monthItemContentDescription = { "${it}월" },
+                    nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+                )
+            )
+        }
+
+        performCustomAccessibilityAction(
+            contentDescription = "월: 1월",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("월: 2월")
+
+        composeRule.runOnIdle {
+            assertEquals(LocalDate(year = 2026, month = Month.FEBRUARY, day = 28), changedDateState.value)
+        }
+    }
+
+    @Test
     fun yearMonthPicker_forwardsCustomAccessibilityDescriptionsToChildPickers() {
         composeRule.setContent {
             val state = rememberYearMonthPickerState(
@@ -796,6 +876,44 @@ class PickerAccessibilitySemanticsAndroidTest {
                 LocalDate(year = 2027, month = Month.MAY, day = 1),
                 state.selectedMonthDate
             )
+        }
+    }
+
+    @Test
+    fun yearMonthPicker_callsOnSelectedYearMonthChangeAfterUserSelection() {
+        lateinit var changedYearMonthState: MutableState<YearMonth?>
+
+        composeRule.setContent {
+            val state = rememberYearMonthPickerState(
+                initialYear = 2026,
+                initialMonth = 5
+            )
+            changedYearMonthState = remember { mutableStateOf(null) }
+
+            YearMonthPicker(
+                state = state,
+                onSelectedYearMonthChange = { changedYearMonthState.value = it },
+                items = PickerDefaults.yearMonthPickerItems(
+                    yearItems = listOf(2026),
+                    monthItems = listOf(5, 6)
+                ),
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                accessibility = PickerDefaults.yearMonthPickerAccessibility(
+                    monthPickerLabel = "월",
+                    monthItemContentDescription = { "${it}월" },
+                    nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+                )
+            )
+        }
+
+        performCustomAccessibilityAction(
+            contentDescription = "월: 5월",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("월: 6월")
+
+        composeRule.runOnIdle {
+            assertEquals(YearMonth(year = 2026, month = 6), changedYearMonthState.value)
         }
     }
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -16,6 +16,7 @@ import com.kez.picker.Picker
 import com.kez.picker.PickerDefaults
 import com.kez.picker.PickerStyle
 import com.kez.picker.DatePickerAccessibility
+import kotlinx.datetime.LocalDate
 
 /**
  * A date picker component that allows selecting year, month, and day.
@@ -23,6 +24,7 @@ import com.kez.picker.DatePickerAccessibility
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
+ * @param onSelectedDateChange Called after user interaction changes the selected date.
  * @param items Selectable year and month item lists for the picker.
  * @param style Visual and layout styling for each picker column.
  * @param spacingBetweenPickers The spacing between the pickers.
@@ -34,6 +36,7 @@ fun DatePicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
     state: DatePickerState = rememberDatePickerState(),
+    onSelectedDateChange: (LocalDate) -> Unit = {},
     items: DatePickerItems = PickerDefaults.datePickerItems(),
     style: PickerStyle = PickerDefaults.style(),
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
@@ -43,6 +46,15 @@ fun DatePicker(
         state = state,
         items = items
     )
+
+    fun updateSelectedDate(update: () -> Unit) {
+        val previousDate = state.selectedDate
+        update()
+        val nextDate = state.selectedDate
+        if (nextDate != previousDate) {
+            onSelectedDateChange(nextDate)
+        }
+    }
 
     Box(modifier = modifier) {
         Column(
@@ -61,7 +73,9 @@ fun DatePicker(
                 Picker(
                     items = items.yearItems,
                     selectedItem = state.selectedYear,
-                    onSelectedItemChange = state::selectYear,
+                    onSelectedItemChange = { year ->
+                        updateSelectedDate { state.selectYear(year) }
+                    },
                     modifier = pickerModifier.weight(1.2f), // Give Year slightly more width
                     style = style,
                     accessibility = accessibility.year
@@ -70,7 +84,9 @@ fun DatePicker(
                 Picker(
                     items = items.monthItems,
                     selectedItem = state.selectedMonth,
-                    onSelectedItemChange = state::selectMonth,
+                    onSelectedItemChange = { month ->
+                        updateSelectedDate { state.selectMonth(month) }
+                    },
                     modifier = pickerModifier.weight(0.8f),
                     style = style,
                     accessibility = accessibility.month
@@ -80,7 +96,9 @@ fun DatePicker(
                     Picker(
                         items = dayItems,
                         selectedItem = state.selectedDay,
-                        onSelectedItemChange = state::selectDay,
+                        onSelectedItemChange = { day ->
+                            updateSelectedDate { state.selectDay(day) }
+                        },
                         modifier = pickerModifier.weight(0.8f),
                         style = style,
                         isInfinity = false,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonth.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonth.kt
@@ -1,0 +1,42 @@
+package com.kez.picker.date
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
+
+/**
+ * Year and month value selected by [YearMonthPicker].
+ *
+ * This type avoids using a first-day [LocalDate] as the primary value when an app only needs a
+ * year/month pair.
+ *
+ * @param year Year value in 1000..9999.
+ * @param month Month value in 1..12.
+ */
+data class YearMonth(
+    val year: Int,
+    val month: Int
+) {
+    init {
+        require(year in 1000..9999) {
+            "year must be in range [1000, 9999], but was $year"
+        }
+        require(month in 1..12) {
+            "month must be in range [1, 12], but was $month"
+        }
+    }
+
+    /**
+     * Converts this value to a [LocalDate] using [dayOfMonth].
+     */
+    fun atDay(dayOfMonth: Int = 1): LocalDate = LocalDate(year, month, dayOfMonth)
+
+    companion object {
+        /**
+         * Creates a [YearMonth] from [date], ignoring the day value.
+         */
+        fun from(date: LocalDate): YearMonth = YearMonth(
+            year = date.year,
+            month = date.month.number
+        )
+    }
+}

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -24,6 +24,7 @@ import com.kez.picker.YearMonthPickerAccessibility
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
+ * @param onSelectedYearMonthChange Called after user interaction changes the selected year/month.
  * @param items Selectable year and month item lists for the picker.
  * @param style Visual and layout styling for each picker column.
  * @param spacingBetweenPickers The spacing between the pickers.
@@ -35,6 +36,7 @@ fun YearMonthPicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
     state: YearMonthPickerState = rememberYearMonthPickerState(),
+    onSelectedYearMonthChange: (YearMonth) -> Unit = {},
     items: YearMonthPickerItems = PickerDefaults.yearMonthPickerItems(),
     style: PickerStyle = PickerDefaults.style(),
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
@@ -44,6 +46,15 @@ fun YearMonthPicker(
         state = state,
         items = items
     )
+
+    fun updateSelectedYearMonth(update: () -> Unit) {
+        val previousYearMonth = state.selectedYearMonth
+        update()
+        val nextYearMonth = state.selectedYearMonth
+        if (nextYearMonth != previousYearMonth) {
+            onSelectedYearMonthChange(nextYearMonth)
+        }
+    }
 
     Box(modifier = modifier) {
         Column(
@@ -61,7 +72,9 @@ fun YearMonthPicker(
                 Picker(
                     items = items.yearItems,
                     selectedItem = state.selectedYear,
-                    onSelectedItemChange = state::selectYear,
+                    onSelectedItemChange = { year ->
+                        updateSelectedYearMonth { state.selectYear(year) }
+                    },
                     modifier = pickerModifier.weight(1f),
                     style = style,
                     accessibility = accessibility.year
@@ -69,7 +82,9 @@ fun YearMonthPicker(
                 Picker(
                     items = items.monthItems,
                     selectedItem = state.selectedMonth,
-                    onSelectedItemChange = state::selectMonth,
+                    onSelectedItemChange = { month ->
+                        updateSelectedYearMonth { state.selectMonth(month) }
+                    },
                     modifier = pickerModifier.weight(1f),
                     style = style,
                     accessibility = accessibility.month

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPickerState.kt
@@ -93,10 +93,16 @@ class YearMonthPickerState(
         get() = mutableSelectedMonth
 
     /**
+     * The selected year/month value.
+     */
+    val selectedYearMonth: YearMonth
+        get() = YearMonth(selectedYear, selectedMonth)
+
+    /**
      * The selected year and month represented as the first day of that month.
      */
     val selectedMonthDate: LocalDate
-        get() = LocalDate(selectedYear, selectedMonth, 1)
+        get() = selectedYearMonth.atDay()
 
     /**
      * Programmatically selects [year] and [month].
@@ -105,6 +111,13 @@ class YearMonthPickerState(
      */
     fun selectYearMonth(year: Int, month: Int) {
         updateYearMonth(year, month)
+    }
+
+    /**
+     * Programmatically selects [yearMonth].
+     */
+    fun selectYearMonth(yearMonth: YearMonth) {
+        updateYearMonth(yearMonth.year, yearMonth.month)
     }
 
     internal fun selectYear(year: Int) {
@@ -134,7 +147,7 @@ class YearMonthPickerState(
      * @throws IllegalArgumentException if [date]'s year is outside the supported range.
      */
     fun selectDate(date: LocalDate) {
-        selectYearMonth(date.year, date.month.number)
+        selectYearMonth(YearMonth.from(date))
     }
 
     companion object {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -21,6 +21,7 @@ import com.kez.picker.PickerStyle
 import com.kez.picker.TimePickerAccessibility
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalTime
 
 /**
  * A time picker component that allows the user to select hours, minutes, and—when using the 12-hour format—the AM/PM period.
@@ -28,6 +29,7 @@ import com.kez.picker.util.TimePeriod
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
+ * @param onSelectedTimeChange Called after user interaction changes the selected time.
  * @param items Selectable minute, hour, and period item lists for the picker.
  * @param style Visual and layout styling for each picker column.
  * @param spacingBetweenPickers The spacing between the pickers.
@@ -39,6 +41,7 @@ fun TimePicker(
     modifier: Modifier = Modifier,
     pickerModifier: Modifier = Modifier,
     state: TimePickerState = rememberTimePickerState(),
+    onSelectedTimeChange: (LocalTime) -> Unit = {},
     items: TimePickerItems = PickerDefaults.timePickerItems(),
     style: PickerStyle = PickerDefaults.style(),
     spacingBetweenPickers: Dp = PickerDefaults.SpacingBetweenPickers,
@@ -50,6 +53,15 @@ fun TimePicker(
         state = state,
         items = items
     )
+
+    fun updateSelectedTime(update: () -> Unit) {
+        val previousTime = state.selectedTime
+        update()
+        val nextTime = state.selectedTime
+        if (nextTime != previousTime) {
+            onSelectedTimeChange(nextTime)
+        }
+    }
 
     Box(modifier = modifier) {
         Column(
@@ -66,7 +78,9 @@ fun TimePicker(
                     Picker(
                         items = items.periodItems,
                         selectedItem = state.selectedPeriod,
-                        onSelectedItemChange = state::selectPeriod,
+                        onSelectedItemChange = { period ->
+                            updateSelectedTime { state.selectPeriod(period) }
+                        },
                         modifier = pickerModifier.weight(1f),
                         style = style,
                         isInfinity = false,
@@ -77,7 +91,9 @@ fun TimePicker(
                 Picker(
                     items = hourItems,
                     selectedItem = state.selectedHour,
-                    onSelectedItemChange = state::selectHour,
+                    onSelectedItemChange = { hour ->
+                        updateSelectedTime { state.selectHour(hour) }
+                    },
                     modifier = pickerModifier.weight(1f),
                     style = style,
                     accessibility = accessibility.hour
@@ -86,7 +102,9 @@ fun TimePicker(
                 Picker(
                     items = items.minuteItems,
                     selectedItem = state.selectedMinute,
-                    onSelectedItemChange = state::selectMinute,
+                    onSelectedItemChange = { minute ->
+                        updateSelectedTime { state.selectMinute(minute) }
+                    },
                     modifier = pickerModifier.weight(1f),
                     style = style,
                     accessibility = accessibility.minute

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -1,6 +1,7 @@
 package com.kez.picker
 
 import androidx.compose.runtime.saveable.SaverScope
+import com.kez.picker.date.YearMonth
 import com.kez.picker.date.YearMonthPickerState
 import com.kez.picker.date.validateYearMonthPickerItems
 import kotlinx.datetime.LocalDate
@@ -31,6 +32,7 @@ class YearMonthPickerStateTest {
 
         assertEquals(2024, state.selectedYear)
         assertEquals(6, state.selectedMonth)
+        assertEquals(YearMonth(year = 2024, month = 6), state.selectedYearMonth)
         assertEquals(LocalDate(2024, 6, 1), state.selectedMonthDate)
     }
 
@@ -169,6 +171,27 @@ class YearMonthPickerStateTest {
         state.selectYearMonth(year = 2026, month = 12)
 
         assertEquals(LocalDate(2026, 12, 1), state.selectedMonthDate)
+    }
+
+    @Test
+    fun yearMonthPickerState_selectedYearMonth_updatesWhenSelectionChanges() {
+        val state = YearMonthPickerState(
+            initialYear = 2024,
+            initialMonth = 1
+        )
+
+        state.selectYearMonth(YearMonth(year = 2026, month = 12))
+
+        assertEquals(YearMonth(year = 2026, month = 12), state.selectedYearMonth)
+        assertEquals(LocalDate(2026, 12, 1), state.selectedYearMonth.atDay())
+    }
+
+    @Test
+    fun yearMonth_fromLocalDate_ignoresDayValue() {
+        assertEquals(
+            YearMonth(year = 2026, month = 5),
+            YearMonth.from(LocalDate(2026, 5, 20))
+        )
     }
 
     @Test

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/BottomSheetSampleScreen.kt
@@ -278,9 +278,9 @@ internal fun BottomSheetSampleScreen(
 
                     Button(
                         onClick = {
-                            val selectedMonthDate = yearMonthState.selectedMonthDate
-                            selectedYear = selectedMonthDate.year
-                            selectedMonth = selectedMonthDate.month.number
+                            val selectedYearMonth = yearMonthState.selectedYearMonth
+                            selectedYear = selectedYearMonth.year
+                            selectedMonth = selectedYearMonth.month
                             scope.launch {
                                 dateSheetState.hide()
                                 showDateBottomSheet = false

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -16,7 +16,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
@@ -66,11 +70,12 @@ fun DatePickerSampleScreen(
                 ((today.year - 1)..leapDate.year).toList()
             }
             val state = rememberDatePickerState(initialDate = today)
+            var selectedDateText by rememberSaveable { mutableStateOf(today.toString()) }
 
             SelectedValueCard(
                 icon = FeatherIcons.Calendar,
                 label = "Selected date",
-                value = state.selectedDate.toString(),
+                value = selectedDateText,
                 supportingText = "Selectable years: ${allowedYears.joinToString()}"
             )
 
@@ -78,7 +83,10 @@ fun DatePickerSampleScreen(
 
             SampleActionRow {
                 Button(
-                    onClick = { state.selectDate(today) },
+                    onClick = {
+                        state.selectDate(today)
+                        selectedDateText = today.toString()
+                    },
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Icon(
@@ -90,7 +98,10 @@ fun DatePickerSampleScreen(
                 }
 
                 OutlinedButton(
-                    onClick = { state.selectDate(leapDate) },
+                    onClick = {
+                        state.selectDate(leapDate)
+                        selectedDateText = leapDate.toString()
+                    },
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Set $leapDate")
@@ -102,6 +113,7 @@ fun DatePickerSampleScreen(
             PickerPanel {
                 DatePicker(
                     state = state,
+                    onSelectedDateChange = { selectedDateText = it.toString() },
                     items = PickerDefaults.datePickerItems(
                         yearItems = allowedYears
                     ),

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -57,6 +58,8 @@ internal fun TimePickerSampleScreen(
         initialTime = currentTime
     )
     val demoTime = LocalTime(hour = 9, minute = 30)
+    var lastChangedHour by rememberSaveable { mutableIntStateOf(currentTime.hour) }
+    var lastChangedMinute by rememberSaveable { mutableIntStateOf(currentTime.minute) }
 
     val ktxTimeFormat12 = LocalTime.Format {
         amPmHour(padding = Padding.ZERO)
@@ -102,7 +105,9 @@ internal fun TimePickerSampleScreen(
                 icon = FeatherIcons.Clock,
                 label = "Selected time",
                 value = selectedTimeText,
-                supportingText = if (selectedFormat == 0) "12-hour state" else "24-hour state"
+                supportingText = "Last callback: ${
+                    LocalTime(lastChangedHour, lastChangedMinute).format(ktxTimeFormat24)
+                }"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -113,6 +118,8 @@ internal fun TimePickerSampleScreen(
                         val now = currentDateTime().time
                         timeState12.selectTime(now)
                         timeState24.selectTime(now)
+                        lastChangedHour = now.hour
+                        lastChangedMinute = now.minute
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -127,6 +134,8 @@ internal fun TimePickerSampleScreen(
                     onClick = {
                         timeState12.selectTime(demoTime)
                         timeState24.selectTime(demoTime)
+                        lastChangedHour = demoTime.hour
+                        lastChangedMinute = demoTime.minute
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -154,6 +163,10 @@ internal fun TimePickerSampleScreen(
                 if (selectedFormat == 0) {
                     TimePicker(
                         state = timeState12,
+                        onSelectedTimeChange = {
+                            lastChangedHour = it.hour
+                            lastChangedMinute = it.minute
+                        },
                         accessibility = PickerDefaults.timePickerAccessibility(
                             hourPickerLabel = "시간",
                             minutePickerLabel = "분",
@@ -168,6 +181,10 @@ internal fun TimePickerSampleScreen(
                 } else {
                     TimePicker(
                         state = timeState24,
+                        onSelectedTimeChange = {
+                            lastChangedHour = it.hour
+                            lastChangedMinute = it.minute
+                        },
                         style = PickerDefaults.style(visibleItemsCount = 5),
                         accessibility = PickerDefaults.timePickerAccessibility(
                             hourPickerLabel = "시간",

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
@@ -17,11 +17,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.kez.picker.PickerDefaults
+import com.kez.picker.date.YearMonth
 import com.kez.picker.date.YearMonthPicker
 import com.kez.picker.date.rememberYearMonthPickerState
 import com.kez.picker.sample.getMonthContentDescription
@@ -40,11 +44,13 @@ internal fun YearMonthPickerSampleScreen(
     val state = rememberYearMonthPickerState(
         initialDate = currentDate
     )
+    var selectedYear by rememberSaveable { mutableIntStateOf(state.selectedYear) }
+    var selectedMonth by rememberSaveable { mutableIntStateOf(state.selectedMonth) }
 
     // Calculate selected date text
     val selectedDateText by remember {
         derivedStateOf {
-            "${state.selectedYear}년 ${getMonthName(state.selectedMonth)}"
+            "${selectedYear}년 ${getMonthName(selectedMonth)}"
         }
     }
 
@@ -68,14 +74,19 @@ internal fun YearMonthPickerSampleScreen(
                 icon = FeatherIcons.Calendar,
                 label = "Selected month",
                 value = selectedDateText,
-                supportingText = "Stored as ${state.selectedMonthDate}"
+                supportingText = "Stored as ${YearMonth(selectedYear, selectedMonth).atDay()}"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
 
             SampleActionRow {
                 Button(
-                    onClick = { state.selectDate(currentDate()) },
+                    onClick = {
+                        val yearMonth = YearMonth.from(currentDate())
+                        state.selectYearMonth(yearMonth)
+                        selectedYear = yearMonth.year
+                        selectedMonth = yearMonth.month
+                    },
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Icon(
@@ -87,10 +98,13 @@ internal fun YearMonthPickerSampleScreen(
                 }
                 OutlinedButton(
                     onClick = {
-                        state.selectYearMonth(
+                        val yearMonth = YearMonth(
                             year = currentDate.year + 1,
                             month = currentDate.month.number
                         )
+                        state.selectYearMonth(yearMonth)
+                        selectedYear = yearMonth.year
+                        selectedMonth = yearMonth.month
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -104,6 +118,10 @@ internal fun YearMonthPickerSampleScreen(
                 YearMonthPicker(
                     modifier = Modifier.padding(horizontal = 12.dp),
                     state = state,
+                    onSelectedYearMonthChange = {
+                        selectedYear = it.year
+                        selectedMonth = it.month
+                    },
                     accessibility = PickerDefaults.yearMonthPickerAccessibility(
                         yearPickerLabel = "연도",
                         monthPickerLabel = "월",


### PR DESCRIPTION
## Summary
- Add user-driven value callbacks to composite pickers: `onSelectedTimeChange`, `onSelectedDateChange`, and `onSelectedYearMonthChange`.
- Add `date.YearMonth` and `YearMonthPickerState.selectedYearMonth` so year/month-only selections do not have to be modeled as the first day of a `LocalDate`.
- Update samples to show callback-driven app state using saveable primitive values, update docs/CHANGELOG/AGENTS, and refresh ABI dumps.

## Self-review
- Must-fix: sample callback state originally used plain `remember`; changed it to saveable primitive/text state so restored picker state and visible app state do not diverge on Android recreation.
- Should-fix: documented that callbacks are user-driven, while programmatic `state.select*` calls require updating app-owned state in the same event handler.
- Nit: kept `selectedMonthDate` as an interop convenience while making `selectedYearMonth` the preferred year/month value.
- Residual risk: intentional 0.x signature change. Named-argument call sites should migrate cleanly; positional calls may need reordering because callbacks are now placed immediately after `state`.

## Verification
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:assembleDebugAndroidTest :sample:compileDebugKotlinAndroid --no-daemon`
- `./gradlew :datetimepicker:updateLegacyAbi --no-daemon`
- `./gradlew :datetimepicker:check :datetimepicker:checkLegacyAbi :sample:assembleDebug :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution --no-daemon`
- `git diff --check origin/main...HEAD`

## Notes
- `:sample:wasmJsBrowserDistribution` emitted existing webpack asset-size warnings, but the build completed successfully.
