### PR TITLE
Add item coercion selection APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - Keep repeated accessibility/semantics configuration grouped in `PickerAccessibility` or the component-specific accessibility option objects instead of expanding composable signatures with more label/action parameters.
 - Keep repeated custom item-list configuration grouped in component-specific item option objects instead of adding separate list parameters to picker composables.
 - When public picker APIs accept custom item-list option objects, validate non-empty lists, duplicate values, supported value ranges, and presence of the current selected value before composing the underlying `Picker`.
+- When app-driven selection can come from restored values or presets, prefer public `items.coerce*` helpers or `state.select*(value, items)` overloads over asking apps to duplicate picker constraint logic.
 - For `DatePickerItems.dayItems`, remember that the list is filtered by the selected year/month maximum day. If a year/month change makes the current day unavailable, keep the component behavior predictable by moving to the closest available valid day and documenting that behavior.
 - When public validation rules change, update KDoc plus `README.md` and `README_KO.md` in the same PR, including failure mode and whether the app must clamp state before rendering.
 - Do not reintroduce legacy `startTime`, `startLocalDate`, or generic `startIndex` component parameters. Prefer explicit `remember*State` overloads for initial values and controlled `selectedItem` for generic `Picker<T>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Added `date.YearMonth` as the primary value model for year/month-only selections.
 - Added `dayItems` to `DatePickerItems` / `PickerDefaults.datePickerItems(...)` so apps can
   constrain selectable days as well as years and months.
+- Added `TimePickerItems.coerceTime(...)`, `DatePickerItems.coerceDate(...)`, and
+  `YearMonthPickerItems.coerceYearMonth(...)` plus matching state-selection overloads so apps can
+  move restored or preset values to the closest selectable value before rendering custom item lists.
 - Added picker accessibility descriptions and localized item description hooks so Android apps can provide clearer TalkBack output.
 - Added previous/next accessibility actions for picker columns, with public labels that apps can localize.
 

--- a/README.md
+++ b/README.md
@@ -366,9 +366,9 @@ selection.
 | State | Method |
 | :--- | :--- |
 | Generic `Picker<T>` | Update the app-owned `selectedItem` value |
-| `time.TimePickerState` | `selectTime(LocalTime(...))` |
-| `date.DatePickerState` | `selectDate(LocalDate(...))` |
-| `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, or `selectDate(LocalDate(...))` |
+| `time.TimePickerState` | `selectTime(LocalTime(...))` or `selectTime(LocalTime(...), items)` |
+| `date.DatePickerState` | `selectDate(LocalDate(...))` or `selectDate(LocalDate(...), items)` |
+| `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, `selectDate(LocalDate(...))`, or the matching `items` overloads |
 
 ```kotlin
 import androidx.compose.foundation.layout.Column
@@ -397,7 +397,8 @@ The picker scroll position is synchronized when the current item lists contain t
 item lists are strict: they must be non-empty, distinct, within the supported value ranges, and contain the
 current selected value. `DatePicker` filters `dayItems` by the selected year/month maximum day, so
 `dayItems` must include at least one day valid for every selectable year/month combination. If an app can
-restore or request values outside a custom list, clamp or reject that app state before rendering the picker.
+restore or request values outside a custom list, call the `state.select*(value, items)` overload or
+`items.coerce*` helper to move to the closest selectable value before rendering the picker.
 
 `onSelectedTimeChange`, `onSelectedDateChange`, and `onSelectedYearMonthChange` are called for
 user-driven picker changes. Programmatic `state.select*` calls update the state directly; update your

--- a/README_KO.md
+++ b/README_KO.md
@@ -363,9 +363,9 @@ state를 새로 만들 필요는 없습니다.
 | State | Method |
 | :--- | :--- |
 | Generic `Picker<T>` | 앱이 소유한 `selectedItem` 값을 갱신 |
-| `time.TimePickerState` | `selectTime(LocalTime(...))` |
-| `date.DatePickerState` | `selectDate(LocalDate(...))` |
-| `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, 또는 `selectDate(LocalDate(...))` |
+| `time.TimePickerState` | `selectTime(LocalTime(...))` 또는 `selectTime(LocalTime(...), items)` |
+| `date.DatePickerState` | `selectDate(LocalDate(...))` 또는 `selectDate(LocalDate(...), items)` |
+| `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, `selectDate(LocalDate(...))`, 또는 대응되는 `items` overload |
 
 ```kotlin
 import androidx.compose.foundation.layout.Column
@@ -394,7 +394,8 @@ fun ProgrammaticTimePickerExample() {
 검증됩니다. 비어 있지 않아야 하고, 중복이 없어야 하며, 지원 범위 안의 값만 포함해야 하고, 현재 선택값도
 반드시 포함해야 합니다. `DatePicker`는 `dayItems`를 선택된 연/월의 최대 일수로 필터링하므로,
 `dayItems`에는 선택 가능한 모든 연/월 조합에서 유효한 day가 최소 하나 있어야 합니다. 앱이 custom list
-밖의 값을 복원하거나 요청할 수 있다면 picker를 렌더링하기 전에 앱 state를 보정하거나 거부하세요.
+밖의 값을 복원하거나 요청할 수 있다면 `state.select*(value, items)` overload나 `items.coerce*`
+helper로 가장 가까운 선택 가능 값으로 이동한 뒤 picker를 렌더링하세요.
 
 `onSelectedTimeChange`, `onSelectedDateChange`, `onSelectedYearMonthChange`는 사용자가 picker를
 조작해서 값이 바뀔 때 호출됩니다. 프로그래밍 방식의 `state.select*` 호출은 state를 직접 변경하므로,

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -17,6 +17,7 @@ public final class com/kez/picker/DatePickerAccessibility {
 public final class com/kez/picker/DatePickerItems {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun coerceDate (Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/LocalDate;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
@@ -168,6 +169,8 @@ public final class com/kez/picker/TimePickerAccessibility {
 public final class com/kez/picker/TimePickerItems {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun coerceTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)Lkotlinx/datetime/LocalTime;
+	public static synthetic fun coerceTime$default (Lcom/kez/picker/TimePickerItems;Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Lkotlinx/datetime/LocalTime;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
@@ -200,6 +203,8 @@ public final class com/kez/picker/YearMonthPickerAccessibility {
 public final class com/kez/picker/YearMonthPickerItems {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun coerceDate (Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/LocalDate;
+	public final fun coerceYearMonth (Lcom/kez/picker/date/YearMonth;)Lcom/kez/picker/date/YearMonth;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/kez/picker/YearMonthPickerItems;
@@ -225,6 +230,7 @@ public final class com/kez/picker/date/DatePickerState {
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedYear ()I
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;Lcom/kez/picker/DatePickerItems;)V
 }
 
 public final class com/kez/picker/date/DatePickerState$Companion {
@@ -270,8 +276,11 @@ public final class com/kez/picker/date/YearMonthPickerState {
 	public final fun getSelectedYear ()I
 	public final fun getSelectedYearMonth ()Lcom/kez/picker/date/YearMonth;
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;Lcom/kez/picker/YearMonthPickerItems;)V
 	public final fun selectYearMonth (II)V
+	public final fun selectYearMonth (IILcom/kez/picker/YearMonthPickerItems;)V
 	public final fun selectYearMonth (Lcom/kez/picker/date/YearMonth;)V
+	public final fun selectYearMonth (Lcom/kez/picker/date/YearMonth;Lcom/kez/picker/YearMonthPickerItems;)V
 }
 
 public final class com/kez/picker/date/YearMonthPickerState$Companion {
@@ -338,6 +347,7 @@ public final class com/kez/picker/time/TimePickerState {
 	public final fun getSelectedTime ()Lkotlinx/datetime/LocalTime;
 	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
+	public final fun selectTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/TimePickerItems;)V
 }
 
 public final class com/kez/picker/time/TimePickerState$Companion {

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -65,6 +65,7 @@ final class com.kez.picker.date/DatePickerState { // com.kez.picker.date/DatePic
         final fun <get-selectedYear>(): kotlin/Int // com.kez.picker.date/DatePickerState.selectedYear.<get-selectedYear>|<get-selectedYear>(){}[0]
 
     final fun selectDate(kotlinx.datetime/LocalDate) // com.kez.picker.date/DatePickerState.selectDate|selectDate(kotlinx.datetime.LocalDate){}[0]
+    final fun selectDate(kotlinx.datetime/LocalDate, com.kez.picker/DatePickerItems) // com.kez.picker.date/DatePickerState.selectDate|selectDate(kotlinx.datetime.LocalDate;com.kez.picker.DatePickerItems){}[0]
 
     final object Companion { // com.kez.picker.date/DatePickerState.Companion|null[0]
         final val Saver // com.kez.picker.date/DatePickerState.Companion.Saver|{}Saver[0]
@@ -106,8 +107,11 @@ final class com.kez.picker.date/YearMonthPickerState { // com.kez.picker.date/Ye
         final fun <get-selectedYearMonth>(): com.kez.picker.date/YearMonth // com.kez.picker.date/YearMonthPickerState.selectedYearMonth.<get-selectedYearMonth>|<get-selectedYearMonth>(){}[0]
 
     final fun selectDate(kotlinx.datetime/LocalDate) // com.kez.picker.date/YearMonthPickerState.selectDate|selectDate(kotlinx.datetime.LocalDate){}[0]
+    final fun selectDate(kotlinx.datetime/LocalDate, com.kez.picker/YearMonthPickerItems) // com.kez.picker.date/YearMonthPickerState.selectDate|selectDate(kotlinx.datetime.LocalDate;com.kez.picker.YearMonthPickerItems){}[0]
     final fun selectYearMonth(com.kez.picker.date/YearMonth) // com.kez.picker.date/YearMonthPickerState.selectYearMonth|selectYearMonth(com.kez.picker.date.YearMonth){}[0]
+    final fun selectYearMonth(com.kez.picker.date/YearMonth, com.kez.picker/YearMonthPickerItems) // com.kez.picker.date/YearMonthPickerState.selectYearMonth|selectYearMonth(com.kez.picker.date.YearMonth;com.kez.picker.YearMonthPickerItems){}[0]
     final fun selectYearMonth(kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPickerState.selectYearMonth|selectYearMonth(kotlin.Int;kotlin.Int){}[0]
+    final fun selectYearMonth(kotlin/Int, kotlin/Int, com.kez.picker/YearMonthPickerItems) // com.kez.picker.date/YearMonthPickerState.selectYearMonth|selectYearMonth(kotlin.Int;kotlin.Int;com.kez.picker.YearMonthPickerItems){}[0]
 
     final object Companion { // com.kez.picker.date/YearMonthPickerState.Companion|null[0]
         final val Saver // com.kez.picker.date/YearMonthPickerState.Companion.Saver|{}Saver[0]
@@ -132,6 +136,7 @@ final class com.kez.picker.time/TimePickerState { // com.kez.picker.time/TimePic
         final fun <get-timeFormat>(): com.kez.picker.util/TimeFormat // com.kez.picker.time/TimePickerState.timeFormat.<get-timeFormat>|<get-timeFormat>(){}[0]
 
     final fun selectTime(kotlinx.datetime/LocalTime) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlinx.datetime.LocalTime){}[0]
+    final fun selectTime(kotlinx.datetime/LocalTime, com.kez.picker/TimePickerItems) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlinx.datetime.LocalTime;com.kez.picker.TimePickerItems){}[0]
 
     final object Companion { // com.kez.picker.time/TimePickerState.Companion|null[0]
         final val Saver // com.kez.picker.time/TimePickerState.Companion.Saver|{}Saver[0]
@@ -168,6 +173,7 @@ final class com.kez.picker/DatePickerItems { // com.kez.picker/DatePickerItems|n
     final val yearItems // com.kez.picker/DatePickerItems.yearItems|{}yearItems[0]
         final fun <get-yearItems>(): kotlin.collections/List<kotlin/Int> // com.kez.picker/DatePickerItems.yearItems.<get-yearItems>|<get-yearItems>(){}[0]
 
+    final fun coerceDate(kotlinx.datetime/LocalDate): kotlinx.datetime/LocalDate // com.kez.picker/DatePickerItems.coerceDate|coerceDate(kotlinx.datetime.LocalDate){}[0]
     final fun component1(): kotlin.collections/List<kotlin/Int> // com.kez.picker/DatePickerItems.component1|component1(){}[0]
     final fun component2(): kotlin.collections/List<kotlin/Int> // com.kez.picker/DatePickerItems.component2|component2(){}[0]
     final fun component3(): kotlin.collections/List<kotlin/Int> // com.kez.picker/DatePickerItems.component3|component3(){}[0]
@@ -289,6 +295,7 @@ final class com.kez.picker/TimePickerItems { // com.kez.picker/TimePickerItems|n
     final val periodItems // com.kez.picker/TimePickerItems.periodItems|{}periodItems[0]
         final fun <get-periodItems>(): kotlin.collections/List<com.kez.picker.util/TimePeriod> // com.kez.picker/TimePickerItems.periodItems.<get-periodItems>|<get-periodItems>(){}[0]
 
+    final fun coerceTime(kotlinx.datetime/LocalTime, com.kez.picker.util/TimeFormat = ...): kotlinx.datetime/LocalTime // com.kez.picker/TimePickerItems.coerceTime|coerceTime(kotlinx.datetime.LocalTime;com.kez.picker.util.TimeFormat){}[0]
     final fun component1(): kotlin.collections/List<kotlin/Int> // com.kez.picker/TimePickerItems.component1|component1(){}[0]
     final fun component2(): kotlin.collections/List<kotlin/Int> // com.kez.picker/TimePickerItems.component2|component2(){}[0]
     final fun component3(): kotlin.collections/List<kotlin/Int> // com.kez.picker/TimePickerItems.component3|component3(){}[0]
@@ -323,6 +330,8 @@ final class com.kez.picker/YearMonthPickerItems { // com.kez.picker/YearMonthPic
     final val yearItems // com.kez.picker/YearMonthPickerItems.yearItems|{}yearItems[0]
         final fun <get-yearItems>(): kotlin.collections/List<kotlin/Int> // com.kez.picker/YearMonthPickerItems.yearItems.<get-yearItems>|<get-yearItems>(){}[0]
 
+    final fun coerceDate(kotlinx.datetime/LocalDate): kotlinx.datetime/LocalDate // com.kez.picker/YearMonthPickerItems.coerceDate|coerceDate(kotlinx.datetime.LocalDate){}[0]
+    final fun coerceYearMonth(com.kez.picker.date/YearMonth): com.kez.picker.date/YearMonth // com.kez.picker/YearMonthPickerItems.coerceYearMonth|coerceYearMonth(com.kez.picker.date.YearMonth){}[0]
     final fun component1(): kotlin.collections/List<kotlin/Int> // com.kez.picker/YearMonthPickerItems.component1|component1(){}[0]
     final fun component2(): kotlin.collections/List<kotlin/Int> // com.kez.picker/YearMonthPickerItems.component2|component2(){}[0]
     final fun copy(kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ...): com.kez.picker/YearMonthPickerItems // com.kez.picker/YearMonthPickerItems.copy|copy(kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -17,6 +17,7 @@ public final class com/kez/picker/DatePickerAccessibility {
 public final class com/kez/picker/DatePickerItems {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun coerceDate (Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/LocalDate;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
@@ -168,6 +169,8 @@ public final class com/kez/picker/TimePickerAccessibility {
 public final class com/kez/picker/TimePickerItems {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun coerceTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)Lkotlinx/datetime/LocalTime;
+	public static synthetic fun coerceTime$default (Lcom/kez/picker/TimePickerItems;Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Lkotlinx/datetime/LocalTime;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
@@ -200,6 +203,8 @@ public final class com/kez/picker/YearMonthPickerAccessibility {
 public final class com/kez/picker/YearMonthPickerItems {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun coerceDate (Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/LocalDate;
+	public final fun coerceYearMonth (Lcom/kez/picker/date/YearMonth;)Lcom/kez/picker/date/YearMonth;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/kez/picker/YearMonthPickerItems;
@@ -225,6 +230,7 @@ public final class com/kez/picker/date/DatePickerState {
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedYear ()I
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;Lcom/kez/picker/DatePickerItems;)V
 }
 
 public final class com/kez/picker/date/DatePickerState$Companion {
@@ -270,8 +276,11 @@ public final class com/kez/picker/date/YearMonthPickerState {
 	public final fun getSelectedYear ()I
 	public final fun getSelectedYearMonth ()Lcom/kez/picker/date/YearMonth;
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
+	public final fun selectDate (Lkotlinx/datetime/LocalDate;Lcom/kez/picker/YearMonthPickerItems;)V
 	public final fun selectYearMonth (II)V
+	public final fun selectYearMonth (IILcom/kez/picker/YearMonthPickerItems;)V
 	public final fun selectYearMonth (Lcom/kez/picker/date/YearMonth;)V
+	public final fun selectYearMonth (Lcom/kez/picker/date/YearMonth;Lcom/kez/picker/YearMonthPickerItems;)V
 }
 
 public final class com/kez/picker/date/YearMonthPickerState$Companion {
@@ -338,6 +347,7 @@ public final class com/kez/picker/time/TimePickerState {
 	public final fun getSelectedTime ()Lkotlinx/datetime/LocalTime;
 	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
+	public final fun selectTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/TimePickerItems;)V
 }
 
 public final class com/kez/picker/time/TimePickerState$Companion {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
@@ -1,7 +1,14 @@
 package com.kez.picker
 
+import com.kez.picker.date.YearMonth
+import com.kez.picker.date.daysInMonth
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.Month
+import kotlinx.datetime.number
+import kotlin.math.abs
 
 /**
  * Selectable item lists for [com.kez.picker.time.TimePicker].
@@ -21,11 +28,55 @@ data class TimePickerItems(
     val hour12Items: List<Int>,
     val periodItems: List<TimePeriod>
 ) {
+    /**
+     * Returns the closest selectable time for [time] under [timeFormat].
+     *
+     * This is useful before calling [com.kez.picker.time.TimePickerState.selectTime] when app-owned
+     * state can contain values outside custom picker lists.
+     *
+     * @throws IllegalArgumentException if the item lists needed by [timeFormat] are empty, contain
+     * duplicates, or contain values outside their supported ranges.
+     */
+    fun coerceTime(time: LocalTime, timeFormat: TimeFormat = TimeFormat.HOUR_24): LocalTime {
+        requireValid(timeFormat)
+        val minute = minuteItems.closestTo(time.minute)
+        return when (timeFormat) {
+            TimeFormat.HOUR_24 -> LocalTime(
+                hour = hour24Items.closestTo(time.hour),
+                minute = minute
+            )
+
+            TimeFormat.HOUR_12 -> {
+                val period = periodFor(time.hour).takeIf { it in periodItems } ?: periodItems.first()
+                val displayHour = hour12Items.closestTo(displayHourFor(time.hour))
+                LocalTime(
+                    hour = hourOfDayFor(displayHour = displayHour, period = period),
+                    minute = minute
+                )
+            }
+        }
+    }
+
     internal fun hourItemsFor(timeFormat: TimeFormat): List<Int> =
         when (timeFormat) {
             TimeFormat.HOUR_12 -> hour12Items
             TimeFormat.HOUR_24 -> hour24Items
         }
+
+    private fun requireValid(timeFormat: TimeFormat) {
+        minuteItems.requireIntItems(name = "TimePicker minuteItems", range = 0..59)
+        when (timeFormat) {
+            TimeFormat.HOUR_24 -> hour24Items.requireIntItems(
+                name = "TimePicker hour24Items",
+                range = 0..23
+            )
+
+            TimeFormat.HOUR_12 -> {
+                hour12Items.requireIntItems(name = "TimePicker hour12Items", range = 1..12)
+                periodItems.requireItems(name = "TimePicker periodItems")
+            }
+        }
+    }
 }
 
 /**
@@ -44,7 +95,44 @@ data class DatePickerItems(
     val yearItems: List<Int>,
     val monthItems: List<Int>,
     val dayItems: List<Int>
-)
+) {
+    /**
+     * Returns the closest selectable date for [date].
+     *
+     * The year and month are coerced to the closest configured values, then [dayItems] is filtered by
+     * that coerced year/month maximum day before the day is coerced.
+     *
+     * @throws IllegalArgumentException if the configured item lists are empty, contain duplicates,
+     * contain values outside their supported ranges, or cannot provide at least one valid day for every
+     * selectable year/month combination.
+     */
+    fun coerceDate(date: LocalDate): LocalDate {
+        requireValid()
+        val year = yearItems.closestTo(date.year)
+        val month = monthItems.closestTo(date.month.number)
+        val day = dayItems
+            .filter { it <= daysInMonth(year, month) }
+            .closestTo(date.day)
+        return LocalDate(year = year, month = monthFor(month), day = day)
+    }
+
+    private fun requireValid() {
+        yearItems.requireIntItems(name = "DatePicker yearItems", range = 1000..9999)
+        monthItems.requireIntItems(name = "DatePicker monthItems", range = 1..12)
+        dayItems.requireIntItems(name = "DatePicker dayItems", range = 1..31)
+        val minimumMaxDay = monthItems.minOf { month ->
+            when (month) {
+                2 -> if (yearItems.any { daysInMonth(it, month) == 28 }) 28 else 29
+                4, 6, 9, 11 -> 30
+                else -> 31
+            }
+        }
+        require(dayItems.any { it <= minimumMaxDay }) {
+            "DatePicker dayItems must contain at least one day valid for every selectable " +
+                    "year/month combination. Smallest maximum day is $minimumMaxDay."
+        }
+    }
+}
 
 /**
  * Selectable item lists for [com.kez.picker.date.YearMonthPicker].
@@ -59,4 +147,64 @@ data class DatePickerItems(
 data class YearMonthPickerItems(
     val yearItems: List<Int>,
     val monthItems: List<Int>
-)
+) {
+    /**
+     * Returns the closest selectable [YearMonth] for [yearMonth].
+     *
+     * @throws IllegalArgumentException if [yearItems] or [monthItems] are empty, contain duplicates,
+     * or contain values outside their supported ranges.
+     */
+    fun coerceYearMonth(yearMonth: YearMonth): YearMonth {
+        requireValid()
+        return YearMonth(
+            year = yearItems.closestTo(yearMonth.year),
+            month = monthItems.closestTo(yearMonth.month)
+        )
+    }
+
+    /**
+     * Returns the closest selectable [YearMonth] for the year/month portion of [date].
+     */
+    fun coerceDate(date: LocalDate): LocalDate =
+        coerceYearMonth(YearMonth.from(date)).atDay()
+
+    private fun requireValid() {
+        yearItems.requireIntItems(name = "YearMonthPicker yearItems", range = 1000..9999)
+        monthItems.requireIntItems(name = "YearMonthPicker monthItems", range = 1..12)
+    }
+}
+
+private fun <T> List<T>.requireItems(name: String) {
+    require(isNotEmpty()) { "$name must not be empty." }
+    require(distinct().size == size) { "$name must not contain duplicate values." }
+}
+
+private fun List<Int>.requireIntItems(name: String, range: IntRange) {
+    requireItems(name)
+    val invalidValues = filterNot { it in range }.distinct()
+    require(invalidValues.isEmpty()) {
+        "$name must contain only values in range [${range.first}, ${range.last}]. " +
+                "Invalid values: $invalidValues"
+    }
+}
+
+private fun List<Int>.closestTo(value: Int): Int =
+    minWith(compareBy<Int> { abs(it - value) }.thenBy { it })
+
+private fun displayHourFor(hourOfDay: Int): Int {
+    val hour = hourOfDay % 12
+    return if (hour == 0) 12 else hour
+}
+
+private fun monthFor(monthNumber: Int): Month =
+    Month.entries.first { it.number == monthNumber }
+
+private fun periodFor(hourOfDay: Int): TimePeriod =
+    if (hourOfDay >= 12) TimePeriod.PM else TimePeriod.AM
+
+private fun hourOfDayFor(displayHour: Int, period: TimePeriod): Int =
+    when {
+        period == TimePeriod.AM && displayHour == 12 -> 0
+        period == TimePeriod.PM && displayHour != 12 -> displayHour + 12
+        else -> displayHour
+    }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import com.kez.picker.DatePickerItems
 import com.kez.picker.util.currentDate
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.number
@@ -133,6 +134,15 @@ class DatePickerState(
             month = date.month.number,
             day = date.day
         )
+    }
+
+    /**
+     * Programmatically selects the closest date to [date] that is allowed by [items].
+     *
+     * Use this overload when app-owned state can contain values outside custom picker lists.
+     */
+    fun selectDate(date: LocalDate, items: DatePickerItems) {
+        selectDate(items.coerceDate(date))
     }
 
     /**

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPickerState.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import com.kez.picker.YearMonthPickerItems
 import com.kez.picker.util.currentDate
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.number
@@ -120,6 +121,22 @@ class YearMonthPickerState(
         updateYearMonth(yearMonth.year, yearMonth.month)
     }
 
+    /**
+     * Programmatically selects the closest year/month to [yearMonth] that is allowed by [items].
+     *
+     * Use this overload when app-owned state can contain values outside custom picker lists.
+     */
+    fun selectYearMonth(yearMonth: YearMonth, items: YearMonthPickerItems) {
+        selectYearMonth(items.coerceYearMonth(yearMonth))
+    }
+
+    /**
+     * Programmatically selects the closest year/month to [year] and [month] that is allowed by [items].
+     */
+    fun selectYearMonth(year: Int, month: Int, items: YearMonthPickerItems) {
+        selectYearMonth(YearMonth(year, month), items)
+    }
+
     internal fun selectYear(year: Int) {
         updateYearMonth(year, selectedMonth)
     }
@@ -148,6 +165,15 @@ class YearMonthPickerState(
      */
     fun selectDate(date: LocalDate) {
         selectYearMonth(YearMonth.from(date))
+    }
+
+    /**
+     * Programmatically selects the closest year/month to [date] that is allowed by [items].
+     *
+     * The day value is ignored because [YearMonthPicker] only selects year and month.
+     */
+    fun selectDate(date: LocalDate, items: YearMonthPickerItems) {
+        selectYearMonth(YearMonth.from(date), items)
     }
 
     companion object {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import com.kez.picker.TimePickerItems
 import com.kez.picker.util.TimeFormat
 import com.kez.picker.util.TimePeriod
 import com.kez.picker.util.currentDateTime
@@ -185,6 +186,15 @@ class TimePickerState(
         mutableSelectedHour = initialHourForTimeFormat(time.hour, timeFormat)
         mutableSelectedMinute = time.minute
         mutableSelectedPeriod = if (time.hour >= 12) TimePeriod.PM else TimePeriod.AM
+    }
+
+    /**
+     * Programmatically selects the closest time to [time] that is allowed by [items].
+     *
+     * Use this overload when app-owned state can contain values outside custom picker lists.
+     */
+    fun selectTime(time: LocalTime, items: TimePickerItems) {
+        selectTime(items.coerceTime(time = time, timeFormat = timeFormat))
     }
 
     internal fun selectHour(hour: Int) {

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -697,6 +697,50 @@ class TimePickerStateTest {
     }
 
     @Test
+    fun timePickerItems_coerceTime_usesClosest24HourItems() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = listOf(9, 17),
+            hour12Items = emptyList(),
+            periodItems = emptyList()
+        )
+
+        assertEquals(LocalTime(17, 30), items.coerceTime(LocalTime(14, 20), TimeFormat.HOUR_24))
+    }
+
+    @Test
+    fun timePickerItems_coerceTime_usesClosest12HourDisplayItems() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = emptyList(),
+            hour12Items = listOf(9, 11),
+            periodItems = listOf(TimePeriod.AM)
+        )
+
+        assertEquals(LocalTime(9, 30), items.coerceTime(LocalTime(22, 45), TimeFormat.HOUR_12))
+    }
+
+    @Test
+    fun timePickerState_selectTimeWithItems_coercesSelection() {
+        val state = TimePickerState(
+            initialHour = 8,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = listOf(9, 17),
+            hour12Items = emptyList(),
+            periodItems = emptyList()
+        )
+
+        state.selectTime(LocalTime(14, 20), items)
+
+        assertEquals(LocalTime(17, 30), state.selectedTime)
+    }
+
+    @Test
     fun initialHourForTimeFormat_converts24HourInputFor12HourMode() {
         assertEquals(12, initialHourForTimeFormat(0, TimeFormat.HOUR_12))
         assertEquals(12, initialHourForTimeFormat(12, TimeFormat.HOUR_12))

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -253,6 +253,32 @@ class YearMonthPickerStateTest {
     }
 
     @Test
+    fun yearMonthPickerItems_coerceYearMonth_usesClosestItems() {
+        val items = YearMonthPickerItems(
+            yearItems = listOf(2024, 2026),
+            monthItems = listOf(3, 9)
+        )
+
+        assertEquals(
+            YearMonth(year = 2024, month = 3),
+            items.coerceYearMonth(YearMonth(year = 2025, month = 6))
+        )
+    }
+
+    @Test
+    fun yearMonthPickerState_selectYearMonthWithItems_coercesSelection() {
+        val state = YearMonthPickerState(initialYear = 2024, initialMonth = 3)
+        val items = YearMonthPickerItems(
+            yearItems = listOf(2024, 2026),
+            monthItems = listOf(3, 9)
+        )
+
+        state.selectYearMonth(year = 2025, month = 6, items = items)
+
+        assertEquals(YearMonth(year = 2024, month = 3), state.selectedYearMonth)
+    }
+
+    @Test
     fun validateYearMonthPickerItems_allowsCurrentSelection() {
         val state = YearMonthPickerState(
             initialYear = 2024,

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -3,6 +3,7 @@ package com.kez.picker.date
 import androidx.compose.runtime.saveable.SaverScope
 import com.kez.picker.DatePickerItems
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -297,6 +298,51 @@ class DatePickerStateTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun datePickerItems_coerceDate_usesClosestItems() {
+        val items = DatePickerItems(
+            yearItems = listOf(2024, 2026),
+            monthItems = listOf(2, 12),
+            dayItems = listOf(1, 15, 31)
+        )
+
+        assertEquals(
+            LocalDate(year = 2024, month = Month.DECEMBER, day = 31),
+            items.coerceDate(LocalDate(year = 2025, month = Month.NOVEMBER, day = 30))
+        )
+    }
+
+    @Test
+    fun datePickerItems_coerceDate_filtersDayItemsByCoercedYearMonth() {
+        val items = DatePickerItems(
+            yearItems = listOf(2025),
+            monthItems = listOf(2),
+            dayItems = listOf(15, 31)
+        )
+
+        assertEquals(
+            LocalDate(year = 2025, month = Month.FEBRUARY, day = 15),
+            items.coerceDate(LocalDate(year = 2025, month = Month.FEBRUARY, day = 28))
+        )
+    }
+
+    @Test
+    fun datePickerState_selectDateWithItems_coercesSelection() {
+        val state = DatePickerState(initialYear = 2024, initialMonth = 2, initialDay = 1)
+        val items = DatePickerItems(
+            yearItems = listOf(2024, 2026),
+            monthItems = listOf(2, 12),
+            dayItems = listOf(1, 15, 31)
+        )
+
+        state.selectDate(
+            date = LocalDate(year = 2025, month = Month.NOVEMBER, day = 30),
+            items = items
+        )
+
+        assertEquals(LocalDate(year = 2024, month = Month.DECEMBER, day = 31), state.selectedDate)
     }
 
     @Test

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -72,6 +72,12 @@ fun DatePickerSampleScreen(
             val allowedDays = remember(today.day, leapDate.day) {
                 listOf(1, 15, today.day, leapDate.day).distinct().sorted()
             }
+            val pickerItems = remember(allowedYears, allowedDays) {
+                PickerDefaults.datePickerItems(
+                    yearItems = allowedYears,
+                    dayItems = allowedDays
+                )
+            }
             val state = rememberDatePickerState(initialDate = today)
             var selectedDateText by rememberSaveable { mutableStateOf(today.toString()) }
 
@@ -87,8 +93,8 @@ fun DatePickerSampleScreen(
             SampleActionRow {
                 Button(
                     onClick = {
-                        state.selectDate(today)
-                        selectedDateText = today.toString()
+                        state.selectDate(today, pickerItems)
+                        selectedDateText = state.selectedDate.toString()
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -102,8 +108,8 @@ fun DatePickerSampleScreen(
 
                 OutlinedButton(
                     onClick = {
-                        state.selectDate(leapDate)
-                        selectedDateText = leapDate.toString()
+                        state.selectDate(leapDate, pickerItems)
+                        selectedDateText = state.selectedDate.toString()
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -117,10 +123,7 @@ fun DatePickerSampleScreen(
                 DatePicker(
                     state = state,
                     onSelectedDateChange = { selectedDateText = it.toString() },
-                    items = PickerDefaults.datePickerItems(
-                        yearItems = allowedYears,
-                        dayItems = allowedDays
-                    ),
+                    items = pickerItems,
                     style = PickerDefaults.style(
                         visibleItemsCount = 3,
                         textStyles = PickerDefaults.textStyles(


### PR DESCRIPTION
## Summary
- Add `coerceTime`, `coerceDate`, and `coerceYearMonth` helpers to component item option objects.
- Add matching `state.select*(value, items)` overloads so apps can safely apply restored or preset values with custom item lists.
- Update tests, sample date preset flow, README/README_KO, CHANGELOG, AGENTS.md, and ABI dumps.

## Self-review
- Must-fix: Added unit coverage for time/date/year-month coercion and state overloads.
- Should-fix: Reused the same strict item validation rules before coercion so broken item configs still fail fast.
- Nit: Date sample now keeps a single `pickerItems` object and uses it for both rendering and preset actions.
- Residual risk: The coercion policy intentionally chooses the nearest numeric value and resolves ties to the lower value; apps needing domain-specific rounding can still pre-normalize before calling the state API.

## Validation
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon`
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:checkLegacyAbi :sample:compileDebugKotlinAndroid --no-daemon`
- `./gradlew :datetimepicker:check :sample:compileKotlinDesktop --no-daemon`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coercion utilities to automatically map date/time values to the closest selectable option when using custom item lists.
  * Introduced new state selection overloads that accept item constraints and apply automatic coercion during selection.

* **Documentation**
  * Updated guides to recommend coercion and constrained selection methods for handling values outside custom item lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->