### PR TITLE
Add value-first state constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   move restored or preset values to the closest selectable value before rendering custom item lists.
 - Added `remember*State(items = ..., initial... = ...)` overloads so initial picker state can be
   coerced by the same custom item lists before first composition.
+- Added value-first state constructors: `TimePickerState(LocalTime, ...)`,
+  `DatePickerState(LocalDate)`, `YearMonthPickerState(YearMonth)`, and
+  `YearMonthPickerState(LocalDate)`.
 - Added picker accessibility descriptions and localized item description hooks so Android apps can provide clearer TalkBack output.
 - Added previous/next accessibility actions for picker columns, with public labels that apps can localize.
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -225,6 +225,7 @@ public final class com/kez/picker/date/DatePickerState {
 	public static final field $stable I
 	public static final field Companion Lcom/kez/picker/date/DatePickerState$Companion;
 	public fun <init> (III)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
 	public final fun getMaxDay ()I
 	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedDay ()I
@@ -273,6 +274,8 @@ public final class com/kez/picker/date/YearMonthPickerState {
 	public static final field $stable I
 	public static final field Companion Lcom/kez/picker/date/YearMonthPickerState$Companion;
 	public fun <init> (II)V
+	public fun <init> (Lcom/kez/picker/date/YearMonth;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedMonthDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedYear ()I
@@ -344,6 +347,8 @@ public final class com/kez/picker/time/TimePickerState {
 	public static final field $stable I
 	public static final field Companion Lcom/kez/picker/time/TimePickerState$Companion;
 	public fun <init> (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/util/TimeFormat;)V
+	public fun <init> (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)V
+	public synthetic fun <init> (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getSelectedHour ()I
 	public final fun getSelectedHourOfDay ()I
 	public final fun getSelectedMinute ()I

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -52,6 +52,7 @@ final class <#A: kotlin/Any> com.kez.picker/PickerAccessibility { // com.kez.pic
 
 final class com.kez.picker.date/DatePickerState { // com.kez.picker.date/DatePickerState|null[0]
     constructor <init>(kotlin/Int, kotlin/Int, kotlin/Int) // com.kez.picker.date/DatePickerState.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    constructor <init>(kotlinx.datetime/LocalDate) // com.kez.picker.date/DatePickerState.<init>|<init>(kotlinx.datetime.LocalDate){}[0]
 
     final val maxDay // com.kez.picker.date/DatePickerState.maxDay|{}maxDay[0]
         final fun <get-maxDay>(): kotlin/Int // com.kez.picker.date/DatePickerState.maxDay.<get-maxDay>|<get-maxDay>(){}[0]
@@ -95,7 +96,9 @@ final class com.kez.picker.date/YearMonth { // com.kez.picker.date/YearMonth|nul
 }
 
 final class com.kez.picker.date/YearMonthPickerState { // com.kez.picker.date/YearMonthPickerState|null[0]
+    constructor <init>(com.kez.picker.date/YearMonth) // com.kez.picker.date/YearMonthPickerState.<init>|<init>(com.kez.picker.date.YearMonth){}[0]
     constructor <init>(kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPickerState.<init>|<init>(kotlin.Int;kotlin.Int){}[0]
+    constructor <init>(kotlinx.datetime/LocalDate) // com.kez.picker.date/YearMonthPickerState.<init>|<init>(kotlinx.datetime.LocalDate){}[0]
 
     final val selectedMonth // com.kez.picker.date/YearMonthPickerState.selectedMonth|{}selectedMonth[0]
         final fun <get-selectedMonth>(): kotlin/Int // com.kez.picker.date/YearMonthPickerState.selectedMonth.<get-selectedMonth>|<get-selectedMonth>(){}[0]
@@ -121,6 +124,7 @@ final class com.kez.picker.date/YearMonthPickerState { // com.kez.picker.date/Ye
 
 final class com.kez.picker.time/TimePickerState { // com.kez.picker.time/TimePickerState|null[0]
     constructor <init>(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod, com.kez.picker.util/TimeFormat) // com.kez.picker.time/TimePickerState.<init>|<init>(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod;com.kez.picker.util.TimeFormat){}[0]
+    constructor <init>(kotlinx.datetime/LocalTime, com.kez.picker.util/TimeFormat = ...) // com.kez.picker.time/TimePickerState.<init>|<init>(kotlinx.datetime.LocalTime;com.kez.picker.util.TimeFormat){}[0]
 
     final val selectedHour // com.kez.picker.time/TimePickerState.selectedHour|{}selectedHour[0]
         final fun <get-selectedHour>(): kotlin/Int // com.kez.picker.time/TimePickerState.selectedHour.<get-selectedHour>|<get-selectedHour>(){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -225,6 +225,7 @@ public final class com/kez/picker/date/DatePickerState {
 	public static final field $stable I
 	public static final field Companion Lcom/kez/picker/date/DatePickerState$Companion;
 	public fun <init> (III)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
 	public final fun getMaxDay ()I
 	public final fun getSelectedDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedDay ()I
@@ -273,6 +274,8 @@ public final class com/kez/picker/date/YearMonthPickerState {
 	public static final field $stable I
 	public static final field Companion Lcom/kez/picker/date/YearMonthPickerState$Companion;
 	public fun <init> (II)V
+	public fun <init> (Lcom/kez/picker/date/YearMonth;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedMonthDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getSelectedYear ()I
@@ -344,6 +347,8 @@ public final class com/kez/picker/time/TimePickerState {
 	public static final field $stable I
 	public static final field Companion Lcom/kez/picker/time/TimePickerState$Companion;
 	public fun <init> (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/util/TimeFormat;)V
+	public fun <init> (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)V
+	public synthetic fun <init> (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getSelectedHour ()I
 	public final fun getSelectedHourOfDay ()I
 	public final fun getSelectedMinute ()I

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -104,6 +104,15 @@ class DatePickerState(
     initialMonth: Int,
     initialDay: Int
 ) {
+    /**
+     * Creates a [DatePickerState] from [initialDate].
+     */
+    constructor(initialDate: LocalDate) : this(
+        initialYear = initialDate.year,
+        initialMonth = initialDate.month.number,
+        initialDay = initialDate.day
+    )
+
     init {
         require(initialYear in 1000..9999) {
             "initialYear must be in range [1000, 9999], but was $initialYear"

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPickerState.kt
@@ -125,6 +125,21 @@ class YearMonthPickerState(
     initialYear: Int,
     initialMonth: Int
 ) {
+    /**
+     * Creates a [YearMonthPickerState] from [initialYearMonth].
+     */
+    constructor(initialYearMonth: YearMonth) : this(
+        initialYear = initialYearMonth.year,
+        initialMonth = initialYearMonth.month
+    )
+
+    /**
+     * Creates a [YearMonthPickerState] from the year/month portion of [initialDate].
+     *
+     * The day value is ignored because [YearMonthPicker] only selects year and month.
+     */
+    constructor(initialDate: LocalDate) : this(YearMonth.from(initialDate))
+
     init {
         require(initialYear in 1000..9999) {
             "initialYear must be in range [1000, 9999], but was $initialYear"

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
@@ -152,6 +152,22 @@ class TimePickerState(
     initialPeriod: TimePeriod,
     val timeFormat: TimeFormat
 ) {
+    /**
+     * Creates a [TimePickerState] from a [LocalTime].
+     *
+     * When [timeFormat] is [TimeFormat.HOUR_12], the hour is converted to the display-hour range
+     * and the AM/PM period is derived from [initialTime].
+     */
+    constructor(
+        initialTime: LocalTime,
+        timeFormat: TimeFormat = TimeFormat.HOUR_24
+    ) : this(
+        initialHour = initialHourForTimeFormat(initialTime.hour, timeFormat),
+        initialMinute = initialTime.minute,
+        initialPeriod = if (initialTime.hour >= 12) TimePeriod.PM else TimePeriod.AM,
+        timeFormat = timeFormat
+    )
+
     init {
         require(initialMinute in 0..59) {
             "initialMinute must be in range [0, 59], but was $initialMinute"

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -78,6 +78,19 @@ class TimePickerStateTest {
         assertEquals(59, state.selectedMinute)
     }
 
+    @Test
+    fun timePickerState_localTimeConstructor_initializes24HourSelection() {
+        val state = TimePickerState(
+            initialTime = LocalTime(21, 45),
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        assertEquals(21, state.selectedHour)
+        assertEquals(45, state.selectedMinute)
+        assertEquals(TimePeriod.PM, state.selectedPeriod)
+        assertEquals(LocalTime(21, 45), state.selectedTime)
+    }
+
     // ==================== 12-hour Format Tests ====================
 
     @Test
@@ -151,6 +164,19 @@ class TimePickerStateTest {
 
         assertEquals(15, state.selectedHourOfDay)
         assertEquals(LocalTime(15, 45), state.selectedTime)
+    }
+
+    @Test
+    fun timePickerState_localTimeConstructor_initializes12HourSelection() {
+        val state = TimePickerState(
+            initialTime = LocalTime(13, 5),
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        assertEquals(1, state.selectedHour)
+        assertEquals(5, state.selectedMinute)
+        assertEquals(TimePeriod.PM, state.selectedPeriod)
+        assertEquals(LocalTime(13, 5), state.selectedTime)
     }
 
     // ==================== Minute Boundary Tests ====================

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -56,6 +56,25 @@ class YearMonthPickerStateTest {
         assertEquals(12, state.selectedMonth)
     }
 
+    @Test
+    fun yearMonthPickerState_yearMonthConstructor_initializesSelection() {
+        val state = YearMonthPickerState(
+            initialYearMonth = YearMonth(year = 2026, month = 5)
+        )
+
+        assertEquals(YearMonth(year = 2026, month = 5), state.selectedYearMonth)
+    }
+
+    @Test
+    fun yearMonthPickerState_localDateConstructor_ignoresDayValue() {
+        val state = YearMonthPickerState(
+            initialDate = LocalDate(2026, 5, 20)
+        )
+
+        assertEquals(YearMonth(year = 2026, month = 5), state.selectedYearMonth)
+        assertEquals(LocalDate(2026, 5, 1), state.selectedMonthDate)
+    }
+
     // ==================== Year Boundary Tests ====================
 
     @Test

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -67,6 +67,16 @@ class DatePickerStateTest {
     }
 
     @Test
+    fun datePickerState_localDateConstructor_initializesSelection() {
+        val state = DatePickerState(LocalDate(2026, 5, 20))
+
+        assertEquals(2026, state.selectedYear)
+        assertEquals(5, state.selectedMonth)
+        assertEquals(20, state.selectedDay)
+        assertEquals(LocalDate(2026, 5, 20), state.selectedDate)
+    }
+
+    @Test
     fun testInitialMonth_Throws_WhenOutOfRange() {
         assertFailsWith<IllegalArgumentException> {
             DatePickerState(initialYear = 2024, initialMonth = 13, initialDay = 1)


### PR DESCRIPTION
## Summary
- Add `TimePickerState(LocalTime, timeFormat)`, `DatePickerState(LocalDate)`, `YearMonthPickerState(YearMonth)`, and `YearMonthPickerState(LocalDate)` constructors.
- Add tests for value-first constructor behavior in 12/24-hour time, date, and year-month state.
- Update CHANGELOG and ABI dumps.

## Self-review
- Must-fix: Covered 12-hour conversion from `LocalTime` so constructor behavior matches `selectTime` and `rememberTimePickerState`.
- Should-fix: Kept constructor additions as convenience APIs only; existing explicit primitive constructors remain for low-level use.
- Nit: `YearMonthPickerState(LocalDate)` documents that the day is ignored.
- Residual risk: This PR is stacked on #70, which is stacked on #69; retarget in order after upstream PRs merge.

## Validation
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest --no-daemon`
- `./gradlew :datetimepicker:updateLegacyAbi --no-daemon`
- `./gradlew :datetimepicker:checkLegacyAbi --no-daemon`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Picker state classes now support convenient constructor overloads that accept date and time objects directly (LocalDate, LocalTime, YearMonth), simplifying state initialization without manual component extraction.

* **Tests**
  * Added unit tests verifying new constructor implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->