### PR TITLE
Add picker item content scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   can show a selected value while preventing user scroll, click, and accessibility selection actions.
 - Added disabled color slots to `PickerColors` / `PickerDefaults.colors(...)` so disabled pickers can
   keep selected values visible while clearly communicating their disabled state.
+- Added `PickerItemScope` for generic `Picker` custom content so row UI can read the formatted text,
+  selected state, enabled state, distance fraction, text style, and content color.
 - Added picker accessibility descriptions and localized item description hooks so Android apps can provide clearer TalkBack output.
 - Added previous/next accessibility actions for picker columns, with public labels that apps can localize.
 
@@ -116,6 +118,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   arguments when configuring `items`, `display`, `style`, `spacingBetweenPickers`, or `accessibility`.
   Named-argument call sites are straightforward to migrate; positional call sites may need argument
   reordering.
+- Generic `Picker.content` now receives `PickerItemScope<T>` instead of `T`. Replace direct item usage
+  with `scope.item`, and use `scope.text`, `scope.textStyle`, or `scope.contentColor` when rendering
+  custom rows.
 - `DatePickerItems` now includes `dayItems`. Direct `DatePickerItems(...)` construction must pass
   day values; `PickerDefaults.datePickerItems(...)` remains the preferred factory.
 - `DatePickerItems` now includes `constraints`. Kotlin callers can omit it because it has a default

--- a/README.md
+++ b/README.md
@@ -429,8 +429,25 @@ distinct, and `selectedItem` must exist in `items`. If `T` is not saveable, stor
 your app state and map that key back to an item before rendering the picker.
 Pass `enabled = false` to prevent user scroll, click, and accessibility selection actions while still
 showing the current value. Disabled pickers use the disabled slots from `PickerDefaults.colors(...)`
-for default text, dividers, and selected-item backgrounds; custom `content` composables should render
-their own disabled appearance.
+for default text, dividers, and selected-item backgrounds.
+
+Custom `content` receives `PickerItemScope<T>` so custom rows can reuse the default formatted text,
+selected/enabled state, distance fraction, text style, and content color:
+
+```kotlin
+Picker(
+    items = items,
+    selectedItem = selectedSize,
+    onSelectedItemChange = { selectedSize = it },
+    content = { item ->
+        Text(
+            text = if (item.isSelected) "[${item.text}]" else item.text,
+            style = item.textStyle,
+            color = item.contentColor
+        )
+    }
+)
+```
 
 Use `style = PickerDefaults.style(...)` to customize visible item count, colors, text styles,
 dividers, item padding, selected item background, and fading edge behavior with one reusable object.

--- a/README_KO.md
+++ b/README_KO.md
@@ -426,8 +426,25 @@ fun SizePickerExample() {
 saveable한 key를 저장한 뒤 렌더링 전에 그 key를 item으로 매핑하세요.
 현재 값을 표시하되 사용자의 scroll, click, accessibility 선택 action을 막아야 한다면 `enabled = false`를
 전달하세요. Disabled picker는 기본 텍스트, divider, 선택 영역 배경에 `PickerDefaults.colors(...)`의
-disabled 색상 슬롯을 사용합니다. custom `content` composable을 전달한 경우 disabled 표현도 앱이 직접
-그려야 합니다.
+disabled 색상 슬롯을 사용합니다.
+
+custom `content`는 `PickerItemScope<T>`를 받습니다. 따라서 custom row에서도 기본 formatted text,
+selected/enabled 상태, distance fraction, text style, content color를 그대로 재사용할 수 있습니다.
+
+```kotlin
+Picker(
+    items = items,
+    selectedItem = selectedSize,
+    onSelectedItemChange = { selectedSize = it },
+    content = { item ->
+        Text(
+            text = if (item.isSelected) "[${item.text}]" else item.text,
+            style = item.textStyle,
+            color = item.contentColor
+        )
+    }
+)
+```
 
 `style = PickerDefaults.style(...)`로 visible item count, 색상, 텍스트 스타일, divider, item padding,
 선택 영역 배경, fading edge 동작을 하나의 재사용 가능한 객체로 커스터마이즈하세요.

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -160,6 +160,17 @@ public final class com/kez/picker/PickerDefaults {
 	public static synthetic fun yearMonthPickerItems$default (Lcom/kez/picker/PickerDefaults;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/date/YearMonth;Lcom/kez/picker/date/YearMonth;ILjava/lang/Object;)Lcom/kez/picker/YearMonthPickerItems;
 }
 
+public final class com/kez/picker/PickerItemScope {
+	public static final field $stable I
+	public final fun getContentColor-0d7_KjU ()J
+	public final fun getDistanceFraction ()F
+	public final fun getItem ()Ljava/lang/Object;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public final fun isEnabled ()Z
+	public final fun isSelected ()Z
+}
+
 public final class com/kez/picker/PickerItemText {
 	public static final field $stable I
 	public fun <init> ()V

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -50,6 +50,23 @@ final class <#A: kotlin/Any> com.kez.picker/PickerAccessibility { // com.kez.pic
     final fun toString(): kotlin/String // com.kez.picker/PickerAccessibility.toString|toString(){}[0]
 }
 
+final class <#A: kotlin/Any> com.kez.picker/PickerItemScope { // com.kez.picker/PickerItemScope|null[0]
+    final val contentColor // com.kez.picker/PickerItemScope.contentColor|{}contentColor[0]
+        final fun <get-contentColor>(): androidx.compose.ui.graphics/Color // com.kez.picker/PickerItemScope.contentColor.<get-contentColor>|<get-contentColor>(){}[0]
+    final val distanceFraction // com.kez.picker/PickerItemScope.distanceFraction|{}distanceFraction[0]
+        final fun <get-distanceFraction>(): kotlin/Float // com.kez.picker/PickerItemScope.distanceFraction.<get-distanceFraction>|<get-distanceFraction>(){}[0]
+    final val isEnabled // com.kez.picker/PickerItemScope.isEnabled|{}isEnabled[0]
+        final fun <get-isEnabled>(): kotlin/Boolean // com.kez.picker/PickerItemScope.isEnabled.<get-isEnabled>|<get-isEnabled>(){}[0]
+    final val isSelected // com.kez.picker/PickerItemScope.isSelected|{}isSelected[0]
+        final fun <get-isSelected>(): kotlin/Boolean // com.kez.picker/PickerItemScope.isSelected.<get-isSelected>|<get-isSelected>(){}[0]
+    final val item // com.kez.picker/PickerItemScope.item|{}item[0]
+        final fun <get-item>(): #A // com.kez.picker/PickerItemScope.item.<get-item>|<get-item>(){}[0]
+    final val text // com.kez.picker/PickerItemScope.text|{}text[0]
+        final fun <get-text>(): kotlin/String // com.kez.picker/PickerItemScope.text.<get-text>|<get-text>(){}[0]
+    final val textStyle // com.kez.picker/PickerItemScope.textStyle|{}textStyle[0]
+        final fun <get-textStyle>(): androidx.compose.ui.text/TextStyle // com.kez.picker/PickerItemScope.textStyle.<get-textStyle>|<get-textStyle>(){}[0]
+}
+
 final class <#A: kotlin/Any> com.kez.picker/PickerItemText { // com.kez.picker/PickerItemText|null[0]
     constructor <init>(kotlin/Function1<#A, kotlin/String> = ...) // com.kez.picker/PickerItemText.<init>|<init>(kotlin.Function1<1:0,kotlin.String>){}[0]
 
@@ -583,6 +600,7 @@ final val com.kez.picker/com_kez_picker_DatePickerItems$stableprop // com.kez.pi
 final val com.kez.picker/com_kez_picker_PickerAccessibility$stableprop // com.kez.picker/com_kez_picker_PickerAccessibility$stableprop|#static{}com_kez_picker_PickerAccessibility$stableprop[0]
 final val com.kez.picker/com_kez_picker_PickerColors$stableprop // com.kez.picker/com_kez_picker_PickerColors$stableprop|#static{}com_kez_picker_PickerColors$stableprop[0]
 final val com.kez.picker/com_kez_picker_PickerDefaults$stableprop // com.kez.picker/com_kez_picker_PickerDefaults$stableprop|#static{}com_kez_picker_PickerDefaults$stableprop[0]
+final val com.kez.picker/com_kez_picker_PickerItemScope$stableprop // com.kez.picker/com_kez_picker_PickerItemScope$stableprop|#static{}com_kez_picker_PickerItemScope$stableprop[0]
 final val com.kez.picker/com_kez_picker_PickerItemText$stableprop // com.kez.picker/com_kez_picker_PickerItemText$stableprop|#static{}com_kez_picker_PickerItemText$stableprop[0]
 final val com.kez.picker/com_kez_picker_PickerStyle$stableprop // com.kez.picker/com_kez_picker_PickerStyle$stableprop|#static{}com_kez_picker_PickerStyle$stableprop[0]
 final val com.kez.picker/com_kez_picker_PickerTextStyles$stableprop // com.kez.picker/com_kez_picker_PickerTextStyles$stableprop|#static{}com_kez_picker_PickerTextStyles$stableprop[0]
@@ -595,7 +613,7 @@ final val com.kez.picker/com_kez_picker_YearMonthPickerConstraints$stableprop //
 final val com.kez.picker/com_kez_picker_YearMonthPickerDisplay$stableprop // com.kez.picker/com_kez_picker_YearMonthPickerDisplay$stableprop|#static{}com_kez_picker_YearMonthPickerDisplay$stableprop[0]
 final val com.kez.picker/com_kez_picker_YearMonthPickerItems$stableprop // com.kez.picker/com_kez_picker_YearMonthPickerItems$stableprop|#static{}com_kez_picker_YearMonthPickerItems$stableprop[0]
 
-final fun <#A: kotlin/Any> com.kez.picker/Picker(kotlin.collections/List<#A>, #A, kotlin/Function1<#A, kotlin/Unit>, androidx.compose.ui/Modifier?, kotlin/Boolean, com.kez.picker/PickerStyle?, com.kez.picker/PickerAccessibility<#A>?, kotlin/Boolean, kotlin/Function1<#A, kotlin/String>?, kotlin/Function3<#A, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker/Picker|Picker(kotlin.collections.List<0:0>;0:0;kotlin.Function1<0:0,kotlin.Unit>;androidx.compose.ui.Modifier?;kotlin.Boolean;com.kez.picker.PickerStyle?;com.kez.picker.PickerAccessibility<0:0>?;kotlin.Boolean;kotlin.Function1<0:0,kotlin.String>?;kotlin.Function3<0:0,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<kotlin.Any>}[0]
+final fun <#A: kotlin/Any> com.kez.picker/Picker(kotlin.collections/List<#A>, #A, kotlin/Function1<#A, kotlin/Unit>, androidx.compose.ui/Modifier?, kotlin/Boolean, com.kez.picker/PickerStyle?, com.kez.picker/PickerAccessibility<#A>?, kotlin/Boolean, kotlin/Function1<#A, kotlin/String>?, kotlin/Function3<com.kez.picker/PickerItemScope<#A>, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker/Picker|Picker(kotlin.collections.List<0:0>;0:0;kotlin.Function1<0:0,kotlin.Unit>;androidx.compose.ui.Modifier?;kotlin.Boolean;com.kez.picker.PickerStyle?;com.kez.picker.PickerAccessibility<0:0>?;kotlin.Boolean;kotlin.Function1<0:0,kotlin.String>?;kotlin.Function3<com.kez.picker.PickerItemScope<0:0>,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<kotlin.Any>}[0]
 final fun com.kez.picker.date/DatePicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.date/DatePickerState?, kotlin/Function1<kotlinx.datetime/LocalDate, kotlin/Unit>?, kotlin/Boolean, com.kez.picker/DatePickerItems?, com.kez.picker/DatePickerDisplay?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/DatePickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.date/DatePicker|DatePicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.date.DatePickerState?;kotlin.Function1<kotlinx.datetime.LocalDate,kotlin.Unit>?;kotlin.Boolean;com.kez.picker.DatePickerItems?;com.kez.picker.DatePickerDisplay?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.DatePickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.kez.picker.date/YearMonthPicker(androidx.compose.ui/Modifier?, androidx.compose.ui/Modifier?, com.kez.picker.date/YearMonthPickerState?, kotlin/Function1<com.kez.picker.date/YearMonth, kotlin/Unit>?, kotlin/Boolean, com.kez.picker/YearMonthPickerItems?, com.kez.picker/YearMonthPickerDisplay?, com.kez.picker/PickerStyle?, androidx.compose.ui.unit/Dp, com.kez.picker/YearMonthPickerAccessibility?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // com.kez.picker.date/YearMonthPicker|YearMonthPicker(androidx.compose.ui.Modifier?;androidx.compose.ui.Modifier?;com.kez.picker.date.YearMonthPickerState?;kotlin.Function1<com.kez.picker.date.YearMonth,kotlin.Unit>?;kotlin.Boolean;com.kez.picker.YearMonthPickerItems?;com.kez.picker.YearMonthPickerDisplay?;com.kez.picker.PickerStyle?;androidx.compose.ui.unit.Dp;com.kez.picker.YearMonthPickerAccessibility?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop_getter(): kotlin/Int // com.kez.picker.date/com_kez_picker_date_DatePickerState$stableprop_getter|com_kez_picker_date_DatePickerState$stableprop_getter(){}[0]
@@ -633,6 +651,7 @@ final fun com.kez.picker/com_kez_picker_DatePickerItems$stableprop_getter(): kot
 final fun com.kez.picker/com_kez_picker_PickerAccessibility$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerAccessibility$stableprop_getter|com_kez_picker_PickerAccessibility$stableprop_getter(){}[0]
 final fun com.kez.picker/com_kez_picker_PickerColors$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerColors$stableprop_getter|com_kez_picker_PickerColors$stableprop_getter(){}[0]
 final fun com.kez.picker/com_kez_picker_PickerDefaults$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerDefaults$stableprop_getter|com_kez_picker_PickerDefaults$stableprop_getter(){}[0]
+final fun com.kez.picker/com_kez_picker_PickerItemScope$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerItemScope$stableprop_getter|com_kez_picker_PickerItemScope$stableprop_getter(){}[0]
 final fun com.kez.picker/com_kez_picker_PickerItemText$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerItemText$stableprop_getter|com_kez_picker_PickerItemText$stableprop_getter(){}[0]
 final fun com.kez.picker/com_kez_picker_PickerStyle$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerStyle$stableprop_getter|com_kez_picker_PickerStyle$stableprop_getter(){}[0]
 final fun com.kez.picker/com_kez_picker_PickerTextStyles$stableprop_getter(): kotlin/Int // com.kez.picker/com_kez_picker_PickerTextStyles$stableprop_getter|com_kez_picker_PickerTextStyles$stableprop_getter(){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -160,6 +160,17 @@ public final class com/kez/picker/PickerDefaults {
 	public static synthetic fun yearMonthPickerItems$default (Lcom/kez/picker/PickerDefaults;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/date/YearMonth;Lcom/kez/picker/date/YearMonth;ILjava/lang/Object;)Lcom/kez/picker/YearMonthPickerItems;
 }
 
+public final class com/kez/picker/PickerItemScope {
+	public static final field $stable I
+	public final fun getContentColor-0d7_KjU ()J
+	public final fun getDistanceFraction ()F
+	public final fun getItem ()Ljava/lang/Object;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public final fun isEnabled ()Z
+	public final fun isSelected ()Z
+}
+
 public final class com/kez/picker/PickerItemText {
 	public static final field $stable I
 	public fun <init> ()V

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
@@ -48,6 +49,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -67,6 +69,29 @@ import kotlin.math.abs
 private const val INFINITE_SCROLL_MULTIPLIER = 1000
 
 /**
+ * Information passed to custom [Picker] item content.
+ *
+ * @param T The picker item type.
+ * @property item The item value represented by this row.
+ * @property text The visible text produced by `itemText` for this item.
+ * @property isSelected Whether this item is the currently selected item.
+ * @property isEnabled Whether the picker currently allows user interaction.
+ * @property distanceFraction A value from `0f` to `1f` where `0f` is the centered selected row and
+ * `1f` is the outer visible edge.
+ * @property textStyle The default interpolated text style for this item.
+ * @property contentColor The default interpolated content color for this item.
+ */
+class PickerItemScope<T : Any> internal constructor(
+    val item: T,
+    val text: String,
+    val isSelected: Boolean,
+    val isEnabled: Boolean,
+    val distanceFraction: Float,
+    val textStyle: TextStyle,
+    val contentColor: Color
+)
+
+/**
  * A generic picker component that displays a list of items and allows the user to select one.
  * Follows Material3 component design patterns.
  *
@@ -78,9 +103,9 @@ private const val INFINITE_SCROLL_MULTIPLIER = 1000
  * @param style Visual and layout styling for the picker.
  * @param accessibility Accessibility labels, item descriptions, and custom action labels for the picker.
  * @param isInfinity Whether the picker should loop infinitely.
- * @param itemText Text displayed for each item when [content] is not provided.
- * @param content Optional custom content composable for rendering each item. When provided, the custom content
- * is responsible for its own enabled/disabled visual treatment.
+ * @param itemText Text displayed for each item when [content] is not provided. When [content] is provided,
+ * this text is still exposed through [PickerItemScope.text].
+ * @param content Optional custom content composable for rendering each item.
  */
 @Composable
 fun <T : Any> Picker(
@@ -93,7 +118,7 @@ fun <T : Any> Picker(
     accessibility: PickerAccessibility<T> = PickerDefaults.accessibility(),
     isInfinity: Boolean = true,
     itemText: (T) -> String = { it.toString() },
-    content: @Composable ((T) -> Unit)? = null
+    content: @Composable ((PickerItemScope<T>) -> Unit)? = null
 ) {
     require(items.isNotEmpty()) { "Items list must not be empty" }
     require(items.distinct().size == items.size) {
@@ -388,6 +413,19 @@ fun <T : Any> Picker(
                 val isSelected = item == selectedItem
                 val itemText = item?.let(itemText) ?: ""
                 val itemDescription = item?.let(accessibility.itemContentDescription) ?: ""
+                val itemContentColor = lerp(
+                    start = selectedTextColor,
+                    stop = textColor,
+                    fraction = fraction
+                )
+                val itemTextStyle = textStyle.copy(
+                    fontSize = lerp(
+                        start = selectedTextStyle.fontSize,
+                        stop = textStyle.fontSize,
+                        fraction
+                    ),
+                    color = itemContentColor,
+                )
                 val itemIndex = if (isInfinity) {
                     index % items.size
                 } else {
@@ -435,24 +473,23 @@ fun <T : Any> Picker(
                 ) {
                     if (item != null) {
                         if (content != null) {
-                            content(item)
+                            content(
+                                PickerItemScope(
+                                    item = item,
+                                    text = itemText,
+                                    isSelected = isSelected,
+                                    isEnabled = enabled,
+                                    distanceFraction = fraction,
+                                    textStyle = itemTextStyle,
+                                    contentColor = itemContentColor
+                                )
+                            )
                         } else {
                             Text(
                                 text = itemText,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
-                                style = textStyle.copy(
-                                    fontSize = lerp(
-                                        start = selectedTextStyle.fontSize,
-                                        stop = textStyle.fontSize,
-                                        fraction
-                                    ),
-                                    color = lerp(
-                                        start = selectedTextColor,
-                                        stop = textColor,
-                                        fraction = fraction
-                                    ),
-                                ),
+                                style = itemTextStyle,
                                 textAlign = TextAlign.Center
                             )
                         }


### PR DESCRIPTION
## Summary
- replace generic Picker custom content input with PickerItemScope<T>
- expose item, formatted text, selected/enabled state, distance fraction, interpolated text style, and content color to custom row UI
- document the 0.x content migration and update ABI dumps

## Review
- Must-fix: none found after local diff review
- Should-fix: documented the breaking content lambda migration in CHANGELOG and README examples
- Residual risk: this intentionally changes the generic Picker.content lambda type; apps using custom content must migrate from the raw item parameter to scope.item

## Verification
- ./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:assembleDebugAndroidTest :sample:compileDebugKotlinAndroid :sample:compileKotlinDesktop --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon
- git diff --check origin/feature/picker-disabled-colors...HEAD