### PR TITLE
Add primitive state selection overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   coerced by the same custom item lists before first composition.
 - Added `rememberYearMonthPickerState(initialYearMonth = ...)` and the matching `items` overload so
   year/month-only state can be initialized without routing through `LocalDate`.
+- Added `TimePickerState.selectTime(hour, minute)` and `DatePickerState.selectDate(year, month, day)`
+  overloads for apps that store primitive form values.
 - Added value-first state constructors: `TimePickerState(LocalTime, ...)`,
   `DatePickerState(LocalDate)`, `YearMonthPickerState(YearMonth)`, and
   `YearMonthPickerState(LocalDate)`.

--- a/README.md
+++ b/README.md
@@ -465,8 +465,8 @@ selection.
 | State | Method |
 | :--- | :--- |
 | Generic `Picker<T>` | Update the app-owned `selectedItem` value |
-| `time.TimePickerState` | `selectTime(LocalTime(...))` or `selectTime(LocalTime(...), items)` |
-| `date.DatePickerState` | `selectDate(LocalDate(...))` or `selectDate(LocalDate(...), items)` |
+| `time.TimePickerState` | `selectTime(LocalTime(...))`, `selectTime(hour, minute)`, or the matching `items` overloads |
+| `date.DatePickerState` | `selectDate(LocalDate(...))`, `selectDate(year, month, day)`, or the matching `items` overloads |
 | `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, `selectDate(LocalDate(...))`, or the matching `items` overloads |
 
 ```kotlin
@@ -483,7 +483,7 @@ fun ProgrammaticTimePickerExample() {
     val state = rememberTimePickerState(initialTime = LocalTime(8, 0))
 
     Column {
-        Button(onClick = { state.selectTime(LocalTime(9, 30)) }) {
+        Button(onClick = { state.selectTime(hour = 9, minute = 30) }) {
             Text("Set 09:30")
         }
 
@@ -553,7 +553,8 @@ is rendered only in 12-hour mode and ignored in 24-hour mode.
 
 For initial values, use either `rememberTimePickerState(initialTime = LocalTime(...))` or the explicit `initialHour`/`initialMinute` parameters.
 
-To change the selection after state creation, call `state.selectTime(LocalTime(...))`.
+To change the selection after state creation, call `state.selectTime(LocalTime(...))` or
+`state.selectTime(hour, minute)`. The integer hour is interpreted as hour-of-day in `0..23`.
 
 Invalid custom item values, duplicate items, empty required lists, or current selections missing from custom lists or time bounds throw `IllegalArgumentException` during composition. In 12-hour mode, `PickerDefaults.timePickerItems(hour12Items = ...)` uses display-hour values (`1..12`): `initialHour = 13` becomes `state.selectedHour == 1` with `PM`.
 
@@ -586,7 +587,8 @@ explicit `initialYear`/`initialMonth`/`initialDay` parameters. Initial years mus
 `1000..9999`, months in `1..12`, and days must be at least `1`. If `initialDay` is greater than
 the maximum valid day for the initial year/month, it is clamped to that maximum.
 
-To change the selection after state creation, call `state.selectDate(LocalDate(...))`.
+To change the selection after state creation, call `state.selectDate(LocalDate(...))` or
+`state.selectDate(year, month, day)`.
 
 Invalid custom item values, duplicate items, empty lists, or current selected year/month/day values missing from custom lists or date bounds throw `IllegalArgumentException` during composition. If a year/month change makes the selected month or day unavailable, the picker selects the closest available value for the configured constraints.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -462,8 +462,8 @@ state를 새로 만들 필요는 없습니다.
 | State | Method |
 | :--- | :--- |
 | Generic `Picker<T>` | 앱이 소유한 `selectedItem` 값을 갱신 |
-| `time.TimePickerState` | `selectTime(LocalTime(...))` 또는 `selectTime(LocalTime(...), items)` |
-| `date.DatePickerState` | `selectDate(LocalDate(...))` 또는 `selectDate(LocalDate(...), items)` |
+| `time.TimePickerState` | `selectTime(LocalTime(...))`, `selectTime(hour, minute)` 또는 대응되는 `items` overload |
+| `date.DatePickerState` | `selectDate(LocalDate(...))`, `selectDate(year, month, day)` 또는 대응되는 `items` overload |
 | `date.YearMonthPickerState` | `selectYearMonth(YearMonth(...))`, `selectYearMonth(year, month)`, `selectDate(LocalDate(...))`, 또는 대응되는 `items` overload |
 
 ```kotlin
@@ -480,7 +480,7 @@ fun ProgrammaticTimePickerExample() {
     val state = rememberTimePickerState(initialTime = LocalTime(8, 0))
 
     Column {
-        Button(onClick = { state.selectTime(LocalTime(9, 30)) }) {
+        Button(onClick = { state.selectTime(hour = 9, minute = 30) }) {
             Text("Set 09:30")
         }
 
@@ -550,7 +550,8 @@ DatePicker(
 
 초기값은 `rememberTimePickerState(initialTime = LocalTime(...))` 또는 `initialHour`/`initialMinute` 파라미터로 설정합니다.
 
-상태 생성 이후 선택값을 바꾸려면 `state.selectTime(LocalTime(...))`을 호출합니다.
+상태 생성 이후 선택값을 바꾸려면 `state.selectTime(LocalTime(...))` 또는
+`state.selectTime(hour, minute)`을 호출합니다. 정수 `hour`는 `0..23` 범위의 hour-of-day로 해석됩니다.
 
 custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 필수 목록이 비어 있거나, 현재 선택값이 custom 목록 또는 시간 범위 밖이면 composition 중 `IllegalArgumentException`이 발생합니다. 12시간 형식의 `PickerDefaults.timePickerItems(hour12Items = ...)`는 표시 시간 기준(`1..12`)입니다. 예를 들어 `initialHour = 13`은 `state.selectedHour == 1`, `PM`으로 변환됩니다.
 
@@ -583,7 +584,8 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 필수
 월은 `1..12` 범위여야 하고 일은 최소 `1`이어야 합니다. `initialDay`가 초기 연/월의 최대 일수보다
 크면 그 최대 일수로 보정됩니다.
 
-상태 생성 이후 선택값을 바꾸려면 `state.selectDate(LocalDate(...))`를 호출합니다.
+상태 생성 이후 선택값을 바꾸려면 `state.selectDate(LocalDate(...))` 또는
+`state.selectDate(year, month, day)`를 호출합니다.
 
 custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록이 비어 있거나, 현재 선택된 연도/월/일이 custom 목록 또는 날짜 범위 밖이면 composition 중 `IllegalArgumentException`이 발생합니다. 연/월 변경으로 현재 월 또는 일이 선택 불가능해지면 설정된 제약 안에서 가장 가까운 선택 가능 값으로 이동합니다.
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -478,6 +478,8 @@ public final class com/kez/picker/date/DatePickerState {
 	public final fun getSelectedDay ()I
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedYear ()I
+	public final fun selectDate (III)V
+	public final fun selectDate (IIILcom/kez/picker/DatePickerItems;)V
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;Lcom/kez/picker/DatePickerItems;)V
 }
@@ -606,6 +608,8 @@ public final class com/kez/picker/time/TimePickerState {
 	public final fun getSelectedPeriod ()Lcom/kez/picker/util/TimePeriod;
 	public final fun getSelectedTime ()Lkotlinx/datetime/LocalTime;
 	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
+	public final fun selectTime (II)V
+	public final fun selectTime (IILcom/kez/picker/TimePickerItems;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/TimePickerItems;)V
 }

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -130,6 +130,8 @@ final class com.kez.picker.date/DatePickerState { // com.kez.picker.date/DatePic
     final val selectedYear // com.kez.picker.date/DatePickerState.selectedYear|{}selectedYear[0]
         final fun <get-selectedYear>(): kotlin/Int // com.kez.picker.date/DatePickerState.selectedYear.<get-selectedYear>|<get-selectedYear>(){}[0]
 
+    final fun selectDate(kotlin/Int, kotlin/Int, kotlin/Int) // com.kez.picker.date/DatePickerState.selectDate|selectDate(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    final fun selectDate(kotlin/Int, kotlin/Int, kotlin/Int, com.kez.picker/DatePickerItems) // com.kez.picker.date/DatePickerState.selectDate|selectDate(kotlin.Int;kotlin.Int;kotlin.Int;com.kez.picker.DatePickerItems){}[0]
     final fun selectDate(kotlinx.datetime/LocalDate) // com.kez.picker.date/DatePickerState.selectDate|selectDate(kotlinx.datetime.LocalDate){}[0]
     final fun selectDate(kotlinx.datetime/LocalDate, com.kez.picker/DatePickerItems) // com.kez.picker.date/DatePickerState.selectDate|selectDate(kotlinx.datetime.LocalDate;com.kez.picker.DatePickerItems){}[0]
 
@@ -205,6 +207,8 @@ final class com.kez.picker.time/TimePickerState { // com.kez.picker.time/TimePic
     final val timeFormat // com.kez.picker.time/TimePickerState.timeFormat|{}timeFormat[0]
         final fun <get-timeFormat>(): com.kez.picker.util/TimeFormat // com.kez.picker.time/TimePickerState.timeFormat.<get-timeFormat>|<get-timeFormat>(){}[0]
 
+    final fun selectTime(kotlin/Int, kotlin/Int) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlin.Int;kotlin.Int){}[0]
+    final fun selectTime(kotlin/Int, kotlin/Int, com.kez.picker/TimePickerItems) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlin.Int;kotlin.Int;com.kez.picker.TimePickerItems){}[0]
     final fun selectTime(kotlinx.datetime/LocalTime) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlinx.datetime.LocalTime){}[0]
     final fun selectTime(kotlinx.datetime/LocalTime, com.kez.picker/TimePickerItems) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlinx.datetime.LocalTime;com.kez.picker.TimePickerItems){}[0]
 

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -478,6 +478,8 @@ public final class com/kez/picker/date/DatePickerState {
 	public final fun getSelectedDay ()I
 	public final fun getSelectedMonth ()I
 	public final fun getSelectedYear ()I
+	public final fun selectDate (III)V
+	public final fun selectDate (IIILcom/kez/picker/DatePickerItems;)V
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;)V
 	public final fun selectDate (Lkotlinx/datetime/LocalDate;Lcom/kez/picker/DatePickerItems;)V
 }
@@ -606,6 +608,8 @@ public final class com/kez/picker/time/TimePickerState {
 	public final fun getSelectedPeriod ()Lcom/kez/picker/util/TimePeriod;
 	public final fun getSelectedTime ()Lkotlinx/datetime/LocalTime;
 	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
+	public final fun selectTime (II)V
+	public final fun selectTime (IILcom/kez/picker/TimePickerItems;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/TimePickerItems;)V
 }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -170,12 +170,36 @@ class DatePickerState(
     }
 
     /**
+     * Programmatically selects [year], [month], and [day].
+     *
+     * If [day] is greater than the maximum day for [year] and [month], it is clamped to that
+     * maximum, matching [DatePickerState] initialization behavior.
+     *
+     * @throws IllegalArgumentException if [year] or [month] is outside the supported range, or if
+     * [day] is less than 1.
+     */
+    fun selectDate(year: Int, month: Int, day: Int) {
+        updateDate(year = year, month = month, day = day)
+    }
+
+    /**
      * Programmatically selects the closest date to [date] that is allowed by [items].
      *
      * Use this overload when app-owned state can contain values outside custom picker lists or date bounds.
      */
     fun selectDate(date: LocalDate, items: DatePickerItems) {
         selectDate(items.coerceDate(date))
+    }
+
+    /**
+     * Programmatically selects the closest date to [year], [month], and [day] that is allowed by [items].
+     *
+     * If [day] is greater than the maximum day for [year] and [month], it is clamped before applying
+     * [items].
+     */
+    fun selectDate(year: Int, month: Int, day: Int, items: DatePickerItems) {
+        val clampedDate = dateFromParts(year = year, month = month, day = day)
+        selectDate(items.coerceDate(clampedDate))
     }
 
     /**
@@ -210,6 +234,13 @@ class DatePickerState(
     }
 
     private fun updateDate(year: Int, month: Int, day: Int) {
+        val date = dateFromParts(year = year, month = month, day = day)
+        mutableSelectedYear = date.year
+        mutableSelectedMonth = date.month.number
+        mutableSelectedDay = date.day
+    }
+
+    private fun dateFromParts(year: Int, month: Int, day: Int): LocalDate {
         require(year in 1000..9999) {
             "year must be in range [1000, 9999], but was $year"
         }
@@ -219,9 +250,11 @@ class DatePickerState(
         require(day >= 1) {
             "day must be greater than or equal to 1, but was $day"
         }
-        mutableSelectedYear = year
-        mutableSelectedMonth = month
-        mutableSelectedDay = day.coerceAtMost(daysInMonth(year, month))
+        return LocalDate(
+            year = year,
+            month = month,
+            day = day.coerceAtMost(daysInMonth(year, month))
+        )
     }
 
     companion object {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
@@ -237,6 +237,18 @@ class TimePickerState(
     }
 
     /**
+     * Programmatically selects a time from 24-hour clock parts.
+     *
+     * [hour] is interpreted as hour-of-day in `0..23`. In 12-hour mode, the display hour and AM/PM
+     * period are derived from [hour].
+     *
+     * @throws IllegalArgumentException if [hour] or [minute] is outside the supported range.
+     */
+    fun selectTime(hour: Int, minute: Int) {
+        selectTime(LocalTime(hour = hour, minute = minute))
+    }
+
+    /**
      * Programmatically selects the closest time to [time] that is allowed by [items].
      *
      * Use this overload when app-owned state can contain values outside custom picker lists or
@@ -244,6 +256,15 @@ class TimePickerState(
      */
     fun selectTime(time: LocalTime, items: TimePickerItems) {
         selectTime(items.coerceTime(time = time, timeFormat = timeFormat))
+    }
+
+    /**
+     * Programmatically selects the closest time to [hour] and [minute] that is allowed by [items].
+     *
+     * [hour] is interpreted as hour-of-day in `0..23`.
+     */
+    fun selectTime(hour: Int, minute: Int, items: TimePickerItems) {
+        selectTime(LocalTime(hour = hour, minute = minute), items)
     }
 
     internal fun selectHour(hour: Int) {

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -634,6 +634,23 @@ class TimePickerStateTest {
     }
 
     @Test
+    fun timePickerState_selectTimeParts_updates24HourSelection() {
+        val state = TimePickerState(
+            initialHour = 8,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+
+        state.selectTime(hour = 21, minute = 45)
+
+        assertEquals(21, state.selectedHour)
+        assertEquals(45, state.selectedMinute)
+        assertEquals(TimePeriod.PM, state.selectedPeriod)
+        assertEquals(LocalTime(21, 45), state.selectedTime)
+    }
+
+    @Test
     fun timePickerState_selectTime_updates12HourSelection() {
         val state = TimePickerState(
             initialHour = 8,
@@ -650,6 +667,23 @@ class TimePickerStateTest {
         assertEquals(LocalTime(0, 30), state.selectedTime)
 
         state.selectTime(LocalTime(13, 5))
+
+        assertEquals(1, state.selectedHour)
+        assertEquals(5, state.selectedMinute)
+        assertEquals(TimePeriod.PM, state.selectedPeriod)
+        assertEquals(LocalTime(13, 5), state.selectedTime)
+    }
+
+    @Test
+    fun timePickerState_selectTimeParts_updates12HourSelection() {
+        val state = TimePickerState(
+            initialHour = 8,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        state.selectTime(hour = 13, minute = 5)
 
         assertEquals(1, state.selectedHour)
         assertEquals(5, state.selectedMinute)
@@ -879,6 +913,26 @@ class TimePickerStateTest {
         )
 
         state.selectTime(LocalTime(14, 20), items)
+
+        assertEquals(LocalTime(17, 0), state.selectedTime)
+    }
+
+    @Test
+    fun timePickerState_selectTimePartsWithItems_coercesSelection() {
+        val state = TimePickerState(
+            initialHour = 8,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_24
+        )
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = listOf(9, 17),
+            hour12Items = emptyList(),
+            periodItems = emptyList()
+        )
+
+        state.selectTime(hour = 14, minute = 20, items = items)
 
         assertEquals(LocalTime(17, 0), state.selectedTime)
     }

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -132,6 +132,27 @@ class DatePickerStateTest {
     }
 
     @Test
+    fun datePickerState_selectDateParts_updatesSelection() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
+
+        state.selectDate(year = 2026, month = 5, day = 20)
+
+        assertEquals(2026, state.selectedYear)
+        assertEquals(5, state.selectedMonth)
+        assertEquals(20, state.selectedDay)
+        assertEquals(LocalDate(2026, 5, 20), state.selectedDate)
+    }
+
+    @Test
+    fun datePickerState_selectDateParts_clampsInvalidDayForMonth() {
+        val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
+
+        state.selectDate(year = 2026, month = 2, day = 31)
+
+        assertEquals(LocalDate(2026, 2, 28), state.selectedDate)
+    }
+
+    @Test
     fun datePickerState_selectDate_throwsWhenYearOutOfRange() {
         val state = DatePickerState(initialYear = 2025, initialMonth = 1, initialDay = 1)
 
@@ -453,6 +474,25 @@ class DatePickerStateTest {
 
         state.selectDate(
             date = LocalDate(year = 2025, month = Month.NOVEMBER, day = 30),
+            items = items
+        )
+
+        assertEquals(LocalDate(year = 2024, month = Month.DECEMBER, day = 31), state.selectedDate)
+    }
+
+    @Test
+    fun datePickerState_selectDatePartsWithItems_coercesSelection() {
+        val state = DatePickerState(initialYear = 2024, initialMonth = 2, initialDay = 1)
+        val items = DatePickerItems(
+            yearItems = listOf(2024, 2026),
+            monthItems = listOf(2, 12),
+            dayItems = listOf(1, 15, 31)
+        )
+
+        state.selectDate(
+            year = 2025,
+            month = 11,
+            day = 30,
             items = items
         )
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -146,8 +146,12 @@ internal fun TimePickerSampleScreen(
                 }
                 OutlinedButton(
                     onClick = {
-                        timeState12.selectTime(demoTime)
-                        timeState24.selectTime(demoTime, businessHoursItems)
+                        timeState12.selectTime(hour = demoTime.hour, minute = demoTime.minute)
+                        timeState24.selectTime(
+                            hour = demoTime.hour,
+                            minute = demoTime.minute,
+                            items = businessHoursItems
+                        )
                         val selectedTime = if (selectedFormat == 0) {
                             timeState12.selectedTime
                         } else {


### PR DESCRIPTION
## Summary
- add `TimePickerState.selectTime(hour, minute)` and matching `items` overload
- add `DatePickerState.selectDate(year, month, day)` and matching `items` overload
- update tests, sample usage, docs, changelog, and ABI dumps

## Verification
- `./gradlew :datetimepicker:updateLegacyAbi --no-daemon`
- `./gradlew :datetimepicker:compileKotlinMetadata :datetimepicker:testDebugUnitTest :datetimepicker:assembleDebugAndroidTest :sample:compileDebugKotlinAndroid :sample:compileKotlinDesktop --no-daemon`
- `./gradlew :datetimepicker:checkLegacyAbi --no-daemon`
- `git diff --check origin/feature/picker-column-order-options...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date and time pickers now support selection using individual numeric components (year, month, day for dates; hour, minute for times) as an alternative to LocalDate/LocalTime objects.
  * Both methods support optional item filtering and coercion to ensure selected values remain valid.

* **Documentation**
  * Updated documentation, examples, and changelogs to document the new selection methods and their behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->