### PR TITLE
Clarify DateRangePicker callbacks and spacing docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 - Ensured `DateRangePicker` dispatches `onSelectedDateRangeChange` when a child date picker changes
   the start or end date.
+- Clarified `DateRangePicker` callback and spacing parameter documentation in both READMEs.
 - Updated the sample app to show programmatic selection buttons, a `DatePicker` example that derives
   selectable years from the current year and a nearby leap-day target, and Korean localized picker
   accessibility labels across the `TimePicker`, `BackgroundStyle`, `Integrated`, and `BottomSheet`

--- a/README.md
+++ b/README.md
@@ -545,9 +545,10 @@ to the closest selectable value before rendering the picker.
 For first composition, use `remember*State(items = items, initial... = value)` to apply the same coercion
 before the picker is rendered.
 
-`onSelectedTimeChange`, `onSelectedDateChange`, and `onSelectedYearMonthChange` are called for
-user-driven picker changes. Programmatic `state.select*` calls update the state directly; update your
-app-owned value in the same event handler when you trigger programmatic changes.
+`onSelectedTimeChange`, `onSelectedDateChange`, `onSelectedDateRangeChange`, and
+`onSelectedYearMonthChange` are called for user-driven picker changes. Programmatic `state.select*`
+calls update the state directly; update your app-owned value in the same event handler when you
+trigger programmatic changes.
 
 Use `PickerDefaults.timePickerLayout(...)`, `datePickerLayout(...)`, or `yearMonthPickerLayout(...)`
 when a composite picker needs different column proportions. Pass `null` for a column weight to let
@@ -646,6 +647,8 @@ Invalid custom item values, duplicate items, empty lists, or current selected ye
 | `display` | Visible item text formatters for each picker column. | `PickerDefaults.datePickerDisplay()` |
 | `style` | Visual and layout styling for each picker column. | `PickerDefaults.style()` |
 | `layout` | Column weights and visual order for each child `DatePicker`. | `PickerDefaults.datePickerLayout()` |
+| `spacingBetweenPickers` | Horizontal spacing between columns inside each child `DatePicker`. | `0.dp` |
+| `spacingBetweenDatePickers` | Vertical spacing between the start and end child pickers. | `16.dp` |
 | `startLabel` / `endLabel` | Optional visible labels above each child picker. | `"Start date"` / `"End date"` |
 | `accessibility` | Accessibility labels for the start and end child pickers. | `PickerDefaults.dateRangePickerAccessibility()` |
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -542,9 +542,10 @@ column을 필터링합니다. `DatePicker`는 `dayItems`를 선택된 연/월의
 첫 composition의 초기값에도 같은 보정이 필요하면 `remember*State(items = items, initial... = value)`를
 사용하세요.
 
-`onSelectedTimeChange`, `onSelectedDateChange`, `onSelectedYearMonthChange`는 사용자가 picker를
-조작해서 값이 바뀔 때 호출됩니다. 프로그래밍 방식의 `state.select*` 호출은 state를 직접 변경하므로,
-그 이벤트 핸들러 안에서 앱이 소유한 값도 함께 갱신하세요.
+`onSelectedTimeChange`, `onSelectedDateChange`, `onSelectedDateRangeChange`,
+`onSelectedYearMonthChange`는 사용자가 picker를 조작해서 값이 바뀔 때 호출됩니다. 프로그래밍 방식의
+`state.select*` 호출은 state를 직접 변경하므로, 그 이벤트 핸들러 안에서 앱이 소유한 값도 함께
+갱신하세요.
 
 composite picker의 column 비율을 조정해야 한다면 `PickerDefaults.timePickerLayout(...)`,
 `datePickerLayout(...)`, `yearMonthPickerLayout(...)`을 사용하세요. 특정 column의 weight를
@@ -643,6 +644,8 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 | `display` | 각 picker column의 화면 표시 텍스트 formatter입니다. | `PickerDefaults.datePickerDisplay()` |
 | `style` | 각 picker column의 시각/레이아웃 스타일입니다. | `PickerDefaults.style()` |
 | `layout` | 각 child `DatePicker`의 column weight와 표시 순서입니다. | `PickerDefaults.datePickerLayout()` |
+| `spacingBetweenPickers` | 각 child `DatePicker` 내부 column 사이의 가로 간격입니다. | `0.dp` |
+| `spacingBetweenDatePickers` | 시작/종료 child picker 사이의 세로 간격입니다. | `16.dp` |
 | `startLabel` / `endLabel` | 각 child picker 위에 표시할 선택적 label입니다. | `"Start date"` / `"End date"` |
 | `accessibility` | 시작/종료 child picker의 접근성 label입니다. | `PickerDefaults.dateRangePickerAccessibility()` |
 


### PR DESCRIPTION
## Summary
- include onSelectedDateRangeChange in the general callback semantics section
- document DateRangePicker horizontal and vertical spacing parameters in both READMEs
- record the documentation clarification in CHANGELOG

## Verification
- git diff --check