### PR TITLE
Add date range primitive helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   overloads for apps that store primitive form values.
 - Added `DateRange`, `DateRangePickerState`, `rememberDateRangePickerState`, and `DateRangePicker`
   for ordered start/end date selection without manually wiring two `DatePicker` instances. Date
-  range state also supports year/month/day overloads for apps that store primitive form values.
+  range values and state also support year/month/day overloads for apps that store primitive form
+  values.
 - Added `DateRangePickerState` and `rememberDateRangePickerState` overloads that accept a `DateRange`
   value directly.
 - Added value-first state constructors: `TimePickerState(LocalTime, ...)`,

--- a/README.md
+++ b/README.md
@@ -674,6 +674,9 @@ For initial values, use `rememberDateRangePickerState(initialDateRange = DateRan
 `initialStartYear`/`initialStartMonth`/`initialStartDay` and matching end-date parameters. To change
 the selection after state creation, call `state.selectDateRange(...)`, `state.selectStartDate(...)`,
 or `state.selectEndDate(...)` with `DateRange`, `LocalDate`, or explicit year/month/day values.
+`DateRange` can also be created from explicit start/end year, month, and day parts. Use
+`range.contains(year, month, day)` when app-owned form fields need an inclusive range check before
+creating a `LocalDate`.
 
 ### YearMonthPicker
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -671,6 +671,9 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 상태 생성 이후 선택값을 바꾸려면 `DateRange`, `LocalDate`, 또는 명시적인 year/month/day 값을
 사용해 `state.selectDateRange(...)`, `state.selectStartDate(...)`, `state.selectEndDate(...)`를
 호출합니다.
+`DateRange`도 명시적인 시작/종료 year, month, day 값으로 만들 수 있습니다. 앱이 form field 값을
+`LocalDate`로 만들기 전에 inclusive range 포함 여부를 확인해야 한다면 `range.contains(year, month, day)`를
+사용하세요.
 
 ### YearMonthPicker
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -526,9 +526,12 @@ public final class com/kez/picker/date/DatePickerStateKt {
 
 public final class com/kez/picker/date/DateRange {
 	public static final field $stable I
+	public fun <init> (IIIIII)V
+	public synthetic fun <init> (IIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)V
 	public final fun component1 ()Lkotlinx/datetime/LocalDate;
 	public final fun component2 ()Lkotlinx/datetime/LocalDate;
+	public final fun contains (III)Z
 	public final fun contains (Lkotlinx/datetime/LocalDate;)Z
 	public final fun copy (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
 	public static synthetic fun copy$default (Lcom/kez/picker/date/DateRange;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;ILjava/lang/Object;)Lcom/kez/picker/date/DateRange;

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -142,6 +142,7 @@ final class com.kez.picker.date/DatePickerState { // com.kez.picker.date/DatePic
 }
 
 final class com.kez.picker.date/DateRange { // com.kez.picker.date/DateRange|null[0]
+    constructor <init>(kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ...) // com.kez.picker.date/DateRange.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
     constructor <init>(kotlinx.datetime/LocalDate, kotlinx.datetime/LocalDate) // com.kez.picker.date/DateRange.<init>|<init>(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate){}[0]
 
     final val endDate // com.kez.picker.date/DateRange.endDate|{}endDate[0]
@@ -151,6 +152,7 @@ final class com.kez.picker.date/DateRange { // com.kez.picker.date/DateRange|nul
 
     final fun component1(): kotlinx.datetime/LocalDate // com.kez.picker.date/DateRange.component1|component1(){}[0]
     final fun component2(): kotlinx.datetime/LocalDate // com.kez.picker.date/DateRange.component2|component2(){}[0]
+    final fun contains(kotlin/Int, kotlin/Int, kotlin/Int): kotlin/Boolean // com.kez.picker.date/DateRange.contains|contains(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
     final fun contains(kotlinx.datetime/LocalDate): kotlin/Boolean // com.kez.picker.date/DateRange.contains|contains(kotlinx.datetime.LocalDate){}[0]
     final fun copy(kotlinx.datetime/LocalDate = ..., kotlinx.datetime/LocalDate = ...): com.kez.picker.date/DateRange // com.kez.picker.date/DateRange.copy|copy(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.kez.picker.date/DateRange.equals|equals(kotlin.Any?){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -526,9 +526,12 @@ public final class com/kez/picker/date/DatePickerStateKt {
 
 public final class com/kez/picker/date/DateRange {
 	public static final field $stable I
+	public fun <init> (IIIIII)V
+	public synthetic fun <init> (IIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)V
 	public final fun component1 ()Lkotlinx/datetime/LocalDate;
 	public final fun component2 ()Lkotlinx/datetime/LocalDate;
+	public final fun contains (III)Z
 	public final fun contains (Lkotlinx/datetime/LocalDate;)Z
 	public final fun copy (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
 	public static synthetic fun copy$default (Lcom/kez/picker/date/DateRange;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;ILjava/lang/Object;)Lcom/kez/picker/date/DateRange;

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
@@ -22,6 +22,32 @@ data class DateRange(
     val startDate: LocalDate,
     val endDate: LocalDate
 ) {
+    /**
+     * Creates a [DateRange] with explicit start and end date parts.
+     *
+     * If a day is greater than the maximum day for its year/month, it is clamped to that maximum.
+     *
+     * @param startYear The range start year. Must be in 1000..9999.
+     * @param startMonth The range start month. Must be in 1..12.
+     * @param startDay The range start day. Must be at least 1.
+     * @param endYear The range end year. Must be in 1000..9999.
+     * @param endMonth The range end month. Must be in 1..12.
+     * @param endDay The range end day. Must be at least 1.
+     * @throws IllegalArgumentException if any date part is outside its supported range, or if the
+     * resulting start date is after the resulting end date.
+     */
+    constructor(
+        startYear: Int,
+        startMonth: Int,
+        startDay: Int,
+        endYear: Int = startYear,
+        endMonth: Int = startMonth,
+        endDay: Int = startDay
+    ) : this(
+        startDate = dateFromParts(year = startYear, month = startMonth, day = startDay),
+        endDate = dateFromParts(year = endYear, month = endMonth, day = endDay)
+    )
+
     init {
         require(startDate <= endDate) {
             "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate"
@@ -33,6 +59,18 @@ data class DateRange(
      */
     operator fun contains(date: LocalDate): Boolean =
         date in startDate..endDate
+
+    /**
+     * Returns whether [year], [month], and [day] are inside this inclusive range.
+     *
+     * Values outside the supported year, month, or day ranges return false. A [day] greater than the
+     * maximum valid day for [year] and [month] also returns false.
+     */
+    fun contains(year: Int, month: Int, day: Int): Boolean {
+        if (year !in 1000..9999 || month !in 1..12 || day < 1) return false
+        if (day > daysInMonth(year, month)) return false
+        return LocalDate(year = year, month = month, day = day) in this
+    }
 }
 
 /**

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
@@ -35,6 +35,55 @@ class DateRangePickerStateTest {
     }
 
     @Test
+    fun dateRange_initializesFromDateParts() {
+        val range = DateRange(
+            startYear = 2026,
+            startMonth = 5,
+            startDay = 1,
+            endYear = 2026,
+            endMonth = 5,
+            endDay = 3
+        )
+
+        assertEquals(LocalDate(2026, 5, 1), range.startDate)
+        assertEquals(LocalDate(2026, 5, 3), range.endDate)
+    }
+
+    @Test
+    fun dateRange_datePartsClampInvalidDayForMonth() {
+        val range = DateRange(
+            startYear = 2026,
+            startMonth = 2,
+            startDay = 31,
+            endYear = 2026,
+            endMonth = 3,
+            endDay = 31
+        )
+
+        assertEquals(LocalDate(2026, 2, 28), range.startDate)
+        assertEquals(LocalDate(2026, 3, 31), range.endDate)
+    }
+
+    @Test
+    fun dateRange_containsPartsChecksInclusiveDatesAndInvalidParts() {
+        val range = DateRange(
+            startYear = 2026,
+            startMonth = 5,
+            startDay = 1,
+            endYear = 2026,
+            endMonth = 5,
+            endDay = 3
+        )
+
+        assertEquals(true, range.contains(year = 2026, month = 5, day = 1))
+        assertEquals(true, range.contains(year = 2026, month = 5, day = 2))
+        assertEquals(true, range.contains(year = 2026, month = 5, day = 3))
+        assertEquals(false, range.contains(year = 2026, month = 5, day = 4))
+        assertEquals(false, range.contains(year = 2026, month = 13, day = 1))
+        assertEquals(false, range.contains(year = 2026, month = 2, day = 29))
+    }
+
+    @Test
     fun dateRangePickerState_initializesSelectedRange() {
         val state = DateRangePickerState(
             initialStartDate = LocalDate(2026, 5, 1),


### PR DESCRIPTION
Summary:
- Add DateRange constructor from primitive start/end date parts.
- Add DateRange.contains(year, month, day) for primitive form-field checks.
- Update tests, docs, changelog, and ABI dumps.

Verification:
- ./gradlew :datetimepicker:testDebugUnitTest --tests "com.kez.picker.date.DateRangePickerStateTest" --no-daemon
- ./gradlew :datetimepicker:updateLegacyAbi --no-daemon
- git diff --check origin/main...HEAD

Note: merging immediately per maintainer request; CI will continue after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DateRange can now be initialized from explicit year, month, and day values
  * Added ability to check if a specific date (by year, month, and day components) falls within a date range

* **Documentation**
  * Updated API documentation with examples of the new initialization and range-checking features
  * Added Korean language documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->