### PR TITLE
Fix sample picker interaction regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Added `PickerDefaults.itemText(...)` plus `TimePickerDisplay`, `DatePickerDisplay`, and
   `YearMonthPickerDisplay` option objects so apps can customize visible item text separately from
   accessibility descriptions.
+- Fixed sample picker interaction issues where long month labels were clipped, dependent date columns
+  could refresh while another column was still scrolling, and the date range sample started from a
+  one-day range that made end-date movement look like a reset on the first start-date change.
 - Added inclusive `DatePicker` bounds through `DatePickerConstraints` and
   `PickerDefaults.datePickerItems(minDate = ..., maxDate = ...)`.
 - Added inclusive `TimePicker` bounds through `TimePickerConstraints` and

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -228,7 +228,7 @@ fun <T : Any> Picker(
             }
             .distinctUntilChanged()
             .collect { (item, isScrollInProgress) ->
-                if (enabled && isScrollInProgress && item != currentSelectedItem) {
+                if (enabled && !isScrollInProgress && item != currentSelectedItem) {
                     currentOnSelectedItemChange(item)
                 }
             }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -137,21 +137,19 @@ fun DatePicker(
                             }
 
                             DatePickerColumn.DAY -> {
-                                key(dayItems) {
-                                    Picker(
-                                        items = dayItems,
-                                        selectedItem = state.selectedDay,
-                                        onSelectedItemChange = { day ->
-                                            updateSelectedDate { state.selectDay(day) }
-                                        },
-                                        modifier = pickerColumnModifier(pickerModifier, layout.dayWeight),
-                                        enabled = enabled,
-                                        style = style,
-                                        isInfinity = false,
-                                        accessibility = accessibility.day,
-                                        display = display.day
-                                    )
-                                }
+                                Picker(
+                                    items = dayItems,
+                                    selectedItem = state.selectedDay,
+                                    onSelectedItemChange = { day ->
+                                        updateSelectedDate { state.selectDay(day) }
+                                    },
+                                    modifier = pickerColumnModifier(pickerModifier, layout.dayWeight),
+                                    enabled = enabled,
+                                    style = style,
+                                    isInfinity = false,
+                                    accessibility = accessibility.day,
+                                    display = display.day
+                                )
                             }
                         }
                     }

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -149,9 +149,9 @@ fun DatePickerSampleScreen(
                         )
                     ),
                     layout = PickerDefaults.datePickerLayout(
-                        yearWeight = 1.3f,
-                        monthWeight = 1f,
-                        dayWeight = 0.8f
+                        yearWeight = 1.05f,
+                        monthWeight = 1.55f,
+                        dayWeight = 0.75f
                     ),
                     spacingBetweenPickers = 8.dp,
                     accessibility = PickerDefaults.datePickerAccessibility(

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
@@ -87,10 +87,10 @@ internal fun DateRangePickerSampleScreen(
             }
             val state = rememberDateRangePickerState(
                 items = items,
-                initialDateRange = todayRange
+                initialDateRange = monthRange
             )
             var selectedRangeText by rememberSaveable {
-                mutableStateOf("${today}..${today}")
+                mutableStateOf(monthRange.asText())
             }
 
             SelectedValueCard(
@@ -146,6 +146,11 @@ internal fun DateRangePickerSampleScreen(
                         yearItemText = { "${it}년" },
                         monthItemText = { getMonthName(it) },
                         dayItemText = { "${it}일" }
+                    ),
+                    layout = PickerDefaults.datePickerLayout(
+                        yearWeight = 1.05f,
+                        monthWeight = 1.55f,
+                        dayWeight = 0.75f
                     ),
                     spacingBetweenPickers = 8.dp,
                     startLabel = { Text("시작일") },


### PR DESCRIPTION
Summary:
- Commit picker selection changes only after scroll settles, reducing dependent DatePicker column refresh while another column is still moving.
- Stop force-keying the DatePicker day column by day item list.
- Widen sample month columns for localized month labels and initialize the date range sample to the current month range so start-date edits do not look like end-date resets.

Device verification:
- Installed sample with android run --apks=sample/build/outputs/apk/debug/sample-debug.apk --activity=.MainActivity
- Captured before/after screenshots under artifacts/android-cli/ (not committed): fixed-date.png, fixed-date-during-month-swipe.png, fixed-range.png, fixed-range-after-start-day-swipe.png
- Manually swiped DatePicker month column and DateRangePicker start-day column on Pixel_9 AVD

Gradle verification:
- ./gradlew :datetimepicker:testDebugUnitTest :sample:assembleDebug --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi :datetimepicker:assembleDebugAndroidTest :sample:compileKotlinDesktop :sample:assembleDebugAndroidTest --no-daemon
- ./gradlew :sample:connectedDebugAndroidTest --no-daemon
- ./gradlew :datetimepicker:connectedDebugAndroidTest --no-daemon
- git diff --check origin/main...HEAD

Note: merging immediately after local and device verification per urgent maintainer request.