### PR TITLE
Simplify sample state ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Fixed sample picker interaction issues where long month labels were clipped, dependent date columns
   could refresh while another column was still scrolling, and the date range sample started from a
   one-day range that made end-date movement look like a reset on the first start-date change.
+- Simplified the basic date, date range, and year/month samples so the picker state is the single
+  source of truth for displayed selections.
 - Added inclusive `DatePicker` bounds through `DatePickerConstraints` and
   `PickerDefaults.datePickerItems(minDate = ..., maxDate = ...)`.
 - Added inclusive `TimePicker` bounds through `TimePickerConstraints` and

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -17,10 +17,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
@@ -84,12 +81,11 @@ fun DatePickerSampleScreen(
                 initialMonth = today.month.number,
                 initialDay = today.day
             )
-            var selectedDateText by rememberSaveable { mutableStateOf(today.toString()) }
 
             SelectedValueCard(
                 icon = FeatherIcons.Calendar,
                 label = "Selected date",
-                value = selectedDateText,
+                value = state.selectedDate.toString(),
                 supportingText = "Range: $today..$leapDate · Days: ${allowedDays.joinToString()}"
             )
 
@@ -99,7 +95,6 @@ fun DatePickerSampleScreen(
                 Button(
                     onClick = {
                         state.selectDate(today, pickerItems)
-                        selectedDateText = state.selectedDate.toString()
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -114,7 +109,6 @@ fun DatePickerSampleScreen(
                 OutlinedButton(
                     onClick = {
                         state.selectDate(leapDate, pickerItems)
-                        selectedDateText = state.selectedDate.toString()
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -127,7 +121,6 @@ fun DatePickerSampleScreen(
             PickerPanel {
                 DatePicker(
                     state = state,
-                    onSelectedDateChange = { selectedDateText = it.toString() },
                     items = pickerItems,
                     display = PickerDefaults.datePickerDisplay(
                         yearItemText = { "${it}년" },

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
@@ -16,10 +16,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -89,14 +86,11 @@ internal fun DateRangePickerSampleScreen(
                 items = items,
                 initialDateRange = monthRange
             )
-            var selectedRangeText by rememberSaveable {
-                mutableStateOf(monthRange.asText())
-            }
 
             SelectedValueCard(
                 icon = FeatherIcons.Calendar,
                 label = "Selected range",
-                value = selectedRangeText,
+                value = state.selectedDateRange.asText(),
                 supportingText = "Selectable year: ${today.year}"
             )
 
@@ -109,7 +103,6 @@ internal fun DateRangePickerSampleScreen(
                             dateRange = monthRange,
                             items = items
                         )
-                        selectedRangeText = state.selectedDateRange.asText()
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -127,7 +120,6 @@ internal fun DateRangePickerSampleScreen(
                             dateRange = todayRange,
                             items = items
                         )
-                        selectedRangeText = state.selectedDateRange.asText()
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -140,7 +132,6 @@ internal fun DateRangePickerSampleScreen(
             PickerPanel {
                 DateRangePicker(
                     state = state,
-                    onSelectedDateRangeChange = { selectedRangeText = it.asText() },
                     items = items,
                     display = PickerDefaults.datePickerDisplay(
                         yearItemText = { "${it}년" },

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/YearMonthPickerSampleScreen.kt
@@ -17,10 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -61,13 +58,11 @@ internal fun YearMonthPickerSampleScreen(
         items = items,
         initialDate = currentDate
     )
-    var selectedYear by rememberSaveable { mutableIntStateOf(state.selectedYear) }
-    var selectedMonth by rememberSaveable { mutableIntStateOf(state.selectedMonth) }
 
     // Calculate selected date text
     val selectedDateText by remember {
         derivedStateOf {
-            "${selectedYear}년 ${getMonthName(selectedMonth)}"
+            "${state.selectedYear}년 ${getMonthName(state.selectedMonth)}"
         }
     }
 
@@ -91,7 +86,7 @@ internal fun YearMonthPickerSampleScreen(
                 icon = FeatherIcons.Calendar,
                 label = "Selected month",
                 value = selectedDateText,
-                supportingText = "Stored as ${YearMonth(selectedYear, selectedMonth).atDay()}"
+                supportingText = "Stored as ${state.selectedYearMonth.atDay()}"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -101,8 +96,6 @@ internal fun YearMonthPickerSampleScreen(
                     onClick = {
                         val yearMonth = YearMonth.from(currentDate())
                         state.selectYearMonth(yearMonth, items)
-                        selectedYear = state.selectedYear
-                        selectedMonth = state.selectedMonth
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -120,8 +113,6 @@ internal fun YearMonthPickerSampleScreen(
                             month = currentDate.month.number
                         )
                         state.selectYearMonth(yearMonth, items)
-                        selectedYear = state.selectedYear
-                        selectedMonth = state.selectedMonth
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -135,10 +126,6 @@ internal fun YearMonthPickerSampleScreen(
                 YearMonthPicker(
                     modifier = Modifier.padding(horizontal = 12.dp),
                     state = state,
-                    onSelectedYearMonthChange = {
-                        selectedYear = it.year
-                        selectedMonth = it.month
-                    },
                     items = items,
                     display = PickerDefaults.yearMonthPickerDisplay(
                         yearItemText = { "${it}년" },


### PR DESCRIPTION
## Summary
- remove duplicate display state from the basic DatePicker, DateRangePicker, and YearMonthPicker sample screens
- read selected value cards directly from picker state so copied sample code keeps one source of truth
- note the sample cleanup in CHANGELOG

## Verification
- ./gradlew :datetimepicker:testDebugUnitTest :sample:compileKotlinDesktop :sample:assembleDebug --no-daemon
- ./gradlew :sample:connectedDebugAndroidTest --no-daemon
- git diff --check origin/main...HEAD
- Device smoke on Pixel_9 AVD with screenshots under artifacts/android-cli/: YearMonth button + swipe, Date preset button, DateRange Today only + start-day swipe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified date picker, date range picker, and year/month picker sample implementations by eliminating redundant state management.
  * Picker state is now the single source of truth for all displayed selections.

* **Documentation**
  * Updated changelog to reflect sample code improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->