### PR TITLE
Prevent picker text clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Fixed sample picker interaction issues where long month labels were clipped, dependent date columns
   could refresh while another column was still scrolling, and the date range sample started from a
   one-day range that made end-date movement look like a reset on the first start-date change.
+- Fixed picker row height calculation and default vertical item padding so selected text no longer
+  appears clipped against the selection dividers.
 - Simplified the basic date, date range, and year/month samples so the picker state is the single
   source of truth for displayed selections.
 - Added inclusive `DatePicker` bounds through `DatePickerConstraints` and

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -48,17 +48,19 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import kotlin.math.max
 
 /**
  * Multiplier for infinite scroll list size.
@@ -132,6 +134,7 @@ fun <T : Any> Picker(
     }
 
     val density = LocalDensity.current
+    val textMeasurer = rememberTextMeasurer(cacheSize = 16)
     val visibleItemsMiddle = remember(visibleItemsCount) { visibleItemsCount / 2 }
     val scope = rememberCoroutineScope()
     val currentOnSelectedItemChange by rememberUpdatedState(onSelectedItemChange)
@@ -202,22 +205,32 @@ fun <T : Any> Picker(
         colors.disabledSelectedTextColor
     }
 
-    val selectedLineHeight = selectedTextStyle.lineHeight.takeIf { it.isSpecified } ?: 0.sp
-    val unselectedLineHeight = textStyle.lineHeight.takeIf { it.isSpecified } ?: 0.sp
-    val largestLineHeight =
-        if (selectedLineHeight > unselectedLineHeight) selectedLineHeight else unselectedLineHeight
-
-    val selectedFontSize = selectedTextStyle.fontSize.takeIf { it.isSpecified } ?: 0.sp
-    val unselectedFontSize = textStyle.fontSize.takeIf { it.isSpecified } ?: 0.sp
-    val largestFontSize =
-        if (selectedFontSize > unselectedFontSize) selectedFontSize else unselectedFontSize
-
-    val textHeightSp = if (largestLineHeight > 0.sp) largestLineHeight else largestFontSize
+    val measuredTextHeight = remember(items, display, textStyle, selectedTextStyle, textMeasurer) {
+        items.maxOf { item ->
+            val text = AnnotatedString(display.itemText(item))
+            max(
+                textMeasurer.measure(
+                    text = text,
+                    style = textStyle,
+                    overflow = TextOverflow.Clip,
+                    softWrap = false,
+                    maxLines = 1
+                ).size.height,
+                textMeasurer.measure(
+                    text = text,
+                    style = selectedTextStyle,
+                    overflow = TextOverflow.Clip,
+                    softWrap = false,
+                    maxLines = 1
+                ).size.height
+            )
+        }
+    }
 
     val itemHeight = with(density) {
-        textHeightSp.toDp() +
-                itemPadding.calculateTopPadding() +
-                itemPadding.calculateBottomPadding()
+        measuredTextHeight.toDp() +
+            itemPadding.calculateTopPadding() +
+            itemPadding.calculateBottomPadding()
     }
     val itemHeightPx = with(density) { itemHeight.toPx() }
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerDefaults.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerDefaults.kt
@@ -46,7 +46,7 @@ object PickerDefaults {
     /**
      * Default padding around each item.
      */
-    val ItemPadding: PaddingValues = PaddingValues(8.dp)
+    val ItemPadding: PaddingValues = PaddingValues(horizontal = 8.dp, vertical = 12.dp)
 
     /**
      * Default thickness of the dividers.


### PR DESCRIPTION
## Summary
- measure picker item text with TextMeasurer instead of estimating row height from font size
- increase default vertical item padding so selected text has clear space from selection dividers
- document the clipping fix in CHANGELOG

## Verification
- ./gradlew :datetimepicker:testDebugUnitTest :datetimepicker:checkLegacyAbi :sample:connectedDebugAndroidTest --no-daemon
- git diff --check origin/main...HEAD
- Device checks on Pixel_9 AVD with original-resolution screenshots:
  - artifacts/android-cli/padded-measured-date-picker.png
  - artifacts/android-cli/padded-measured-date-picker-month-swipe.png