### PR TITLE
Clarify picker state callback usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 ### Changed
 
+- Clarified the state and callback usage pattern in README and picker KDoc so apps can distinguish
+  user-driven `onSelected*Change` callbacks from programmatic `state.select*` changes.
 - Ensured `DateRangePicker` dispatches `onSelectedDateRangeChange` when a child date picker changes
   the start or end date.
 - Clarified `DateRangePicker` callback and spacing parameter documentation in both READMEs.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ For release notes and upgrade-impact details, see [CHANGELOG.md](CHANGELOG.md).
 
 > The examples below target the current `main` branch API. They may require unreleased `0.6.0` APIs rather than the public `0.4.0` dependency shown above.
 
+### State and Callback Pattern
+
+For `TimePicker`, `DatePicker`, `DateRangePicker`, and `YearMonthPicker`, create the picker state
+once with `remember*State(...)` and pass that same state object to the composable. Inside the picker
+UI, that state object is the source of truth for the currently selected value.
+
+- Read the current value from `state.selectedTime`, `state.selectedDate`,
+  `state.selectedDateRange`, or `state.selectedYearMonth`.
+- Use `onSelected*Change` when you need to mirror user-driven picker changes into app state,
+  a `ViewModel`, or form data.
+- `onSelected*Change` is not called when your app calls `state.select*` programmatically. If a
+  button, preset, or external value changes the picker, call `state.select*(...)` and update your
+  app-owned value in the same handler.
+- Do not recreate `remember*State` just to reset the picker. Keep the state instance and call its
+  public `select*` method.
+
 ### TimePicker
 
 Use `TimePicker` for time selection. It supports both 12-hour and 24-hour formats.

--- a/README_KO.md
+++ b/README_KO.md
@@ -56,6 +56,21 @@ dependencies {
 
 > 아래 예제는 현재 `main` 브랜치 API를 기준으로 합니다. 위 설치 스니펫의 공개 `0.4.0` 의존성이 아니라, 아직 릴리스되지 않은 `0.6.0` API가 필요할 수 있습니다.
 
+### State와 Callback 사용 패턴
+
+`TimePicker`, `DatePicker`, `DateRangePicker`, `YearMonthPicker`는 `remember*State(...)`로 만든
+picker state 객체를 composable에 전달해서 사용합니다. Picker UI 내부에서 현재 선택값의 단일 source of
+truth는 이 state 객체입니다.
+
+- 현재 값은 `state.selectedTime`, `state.selectedDate`, `state.selectedDateRange`,
+  `state.selectedYearMonth`에서 읽습니다.
+- 사용자 조작으로 바뀐 값을 앱 state, `ViewModel`, form data에 반영해야 할 때만 `onSelected*Change`를
+  사용합니다.
+- 앱이 버튼, preset, 외부 값 변경으로 `state.select*`를 직접 호출할 때는 `onSelected*Change`가 호출되지
+  않습니다. 이 경우 같은 이벤트 핸들러 안에서 `state.select*(...)`와 앱이 소유한 값 갱신을 함께 수행하세요.
+- picker를 reset하려고 `remember*State`를 새로 만들지 마세요. 기존 state 객체를 유지하고 public
+  `select*` 메서드를 호출합니다.
+
 ### TimePicker
 
 시간 선택을 위해 `TimePicker`를 사용합니다. 12시간 및 24시간 형식을 지원합니다.

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -30,6 +30,9 @@ import kotlin.math.abs
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
  * @param onSelectedDateChange Called after user interaction changes the selected date.
+ * Programmatic [DatePickerState.selectDate] calls update [state] directly and do not invoke this
+ * callback. When app code changes the picker from a button, preset, or external value, update any
+ * app-owned state in the same handler.
  * @param enabled Whether user scroll, click, and accessibility selection actions are enabled.
  * @param items Selectable year, month, and day item lists for the picker.
  * @param display Visible item text formatters for each picker column.

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePicker.kt
@@ -30,6 +30,10 @@ import kotlinx.datetime.LocalDate
  * @param pickerModifier The modifier to be applied to each child picker column.
  * @param state The state object to control the selected date range.
  * @param onSelectedDateRangeChange Called after user interaction changes the selected range.
+ * Programmatic [DateRangePickerState.selectDateRange], [DateRangePickerState.selectStartDate], and
+ * [DateRangePickerState.selectEndDate] calls update [state] directly and do not invoke this
+ * callback. When app code changes the picker from a button, preset, or external value, update any
+ * app-owned state in the same handler.
  * @param enabled Whether user scroll, click, and accessibility selection actions are enabled.
  * @param items Selectable year/month/day item lists plus optional inclusive date bounds.
  * @param display Visible item text formatters for each picker column.

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -30,6 +30,9 @@ import com.kez.picker.pickerColumnModifier
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
  * @param onSelectedYearMonthChange Called after user interaction changes the selected year/month.
+ * Programmatic [YearMonthPickerState.selectYearMonth] and [YearMonthPickerState.selectDate] calls
+ * update [state] directly and do not invoke this callback. When app code changes the picker from a
+ * button, preset, or external value, update any app-owned state in the same handler.
  * @param enabled Whether user scroll, click, and accessibility selection actions are enabled.
  * @param items Selectable year and month item lists plus optional year/month bounds for the picker.
  * @param display Visible item text formatters for each picker column.

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -33,6 +33,9 @@ import kotlinx.datetime.LocalTime
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
  * @param onSelectedTimeChange Called after user interaction changes the selected time.
+ * Programmatic [TimePickerState.selectTime] calls update [state] directly and do not invoke this
+ * callback. When app code changes the picker from a button, preset, or external value, update any
+ * app-owned state in the same handler.
  * @param enabled Whether user scroll, click, and accessibility selection actions are enabled.
  * @param items Selectable minute, hour, and period item lists for the picker.
  * @param display Visible item text formatters for each picker column.


### PR DESCRIPTION
## Summary
- Add a first-read state/callback pattern section to README and README_KO
- Clarify in picker KDoc that user callbacks are not fired by programmatic state.select* calls
- Record the docs clarification in CHANGELOG

## Review focus
- First-time Android developers should know which value is the source of truth before reading component-specific examples
- Callback wording should distinguish user gestures from app-driven preset/reset changes

## Verification
- git diff --check
- ./gradlew :datetimepicker:compileKotlinMetadata --no-daemon