### PR TITLE
Make picker validation errors actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 - Clarified the state and callback usage pattern in README and picker KDoc so apps can distinguish
   user-driven `onSelected*Change` callbacks from programmatic `state.select*` changes.
+- Made custom item-list and constraint validation errors for date, time, and year/month pickers
+  include the matching `remember*State(items = ...)`, `items.coerce*`, and `state.select*(..., items)`
+  recovery paths.
 - Ensured `DateRangePicker` dispatches `onSelectedDateRangeChange` when a child date picker changes
   the start or end date.
 - Clarified `DateRangePicker` callback and spacing parameter documentation in both READMEs.

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -217,10 +217,12 @@ internal fun validateDatePickerItems(
                 "Invalid values: $invalidDays"
     }
     require(state.selectedYear in yearItems) {
-        "DatePicker yearItems must contain state.selectedYear=${state.selectedYear}."
+        "DatePicker yearItems must contain state.selectedYear=${state.selectedYear}. " +
+                datePickerStateItemsAdvice()
     }
     require(state.selectedMonth in monthItems) {
-        "DatePicker monthItems must contain state.selectedMonth=${state.selectedMonth}."
+        "DatePicker monthItems must contain state.selectedMonth=${state.selectedMonth}. " +
+                datePickerStateItemsAdvice()
     }
     if (items.constraints.isUnbounded) {
         val minimumMaxDay = minimumMaxDayFor(yearItems, monthItems)
@@ -231,12 +233,14 @@ internal fun validateDatePickerItems(
     }
     val availableYearItems = items.selectableYearItems()
     require(state.selectedYear in availableYearItems) {
-        "DatePicker constraints must allow state.selectedYear=${state.selectedYear}."
+        "DatePicker constraints must allow state.selectedYear=${state.selectedYear}. " +
+                datePickerStateItemsAdvice()
     }
     val availableMonthItems = items.selectableMonthItemsFor(state.selectedYear)
     require(state.selectedMonth in availableMonthItems) {
         "DatePicker constraints must allow state.selectedMonth=${state.selectedMonth} " +
-                "for selectedYear=${state.selectedYear}."
+                "for selectedYear=${state.selectedYear}. " +
+                datePickerStateItemsAdvice()
     }
     val availableDayItems = items.selectableDayItemsFor(
         year = state.selectedYear,
@@ -244,9 +248,15 @@ internal fun validateDatePickerItems(
     )
     require(state.selectedDay in availableDayItems) {
         "DatePicker dayItems and constraints must allow state.selectedDay=${state.selectedDay} " +
-                "for selectedYear=${state.selectedYear} and selectedMonth=${state.selectedMonth}."
+                "for selectedYear=${state.selectedYear} and selectedMonth=${state.selectedMonth}. " +
+                datePickerStateItemsAdvice()
     }
 }
+
+private fun datePickerStateItemsAdvice(): String =
+    "Use rememberDatePickerState(items = items, initialDate = ...) for initial values. For later " +
+            "programmatic changes, coerce app values with items.coerceDate(...) and call " +
+            "state.selectDate(date, items) before composing DatePicker."
 
 private fun List<Int>.invalidValuesFor(range: IntRange): List<Int> =
     filterNot { it in range }.distinct()

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/YearMonthPicker.kt
@@ -175,21 +175,30 @@ internal fun validateYearMonthPickerItems(
                 "Invalid values: $invalidMonths"
     }
     require(state.selectedYear in yearItems) {
-        "YearMonthPicker yearItems must contain state.selectedYear=${state.selectedYear}."
+        "YearMonthPicker yearItems must contain state.selectedYear=${state.selectedYear}. " +
+                yearMonthPickerStateItemsAdvice()
     }
     require(state.selectedMonth in monthItems) {
-        "YearMonthPicker monthItems must contain state.selectedMonth=${state.selectedMonth}."
+        "YearMonthPicker monthItems must contain state.selectedMonth=${state.selectedMonth}. " +
+                yearMonthPickerStateItemsAdvice()
     }
     val availableYearItems = items.selectableYearItems()
     require(state.selectedYear in availableYearItems) {
-        "YearMonthPicker constraints must allow state.selectedYear=${state.selectedYear}."
+        "YearMonthPicker constraints must allow state.selectedYear=${state.selectedYear}. " +
+                yearMonthPickerStateItemsAdvice()
     }
     val availableMonthItems = items.selectableMonthItemsFor(state.selectedYear)
     require(state.selectedMonth in availableMonthItems) {
         "YearMonthPicker constraints must allow state.selectedMonth=${state.selectedMonth} " +
-                "for selectedYear=${state.selectedYear}."
+                "for selectedYear=${state.selectedYear}. " +
+                yearMonthPickerStateItemsAdvice()
     }
 }
+
+private fun yearMonthPickerStateItemsAdvice(): String =
+    "Use rememberYearMonthPickerState(items = items, initialYearMonth = ...) for initial values. " +
+            "For later programmatic changes, coerce app values with items.coerceYearMonth(...) and " +
+            "call state.selectYearMonth(yearMonth, items) before composing YearMonthPicker."
 
 private fun List<Int>.invalidValuesFor(range: IntRange): List<Int> =
     filterNot { it in range }.distinct()

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -199,7 +199,8 @@ internal fun validateTimePickerItems(
                 "Invalid values: $invalidMinutes"
     }
     require(state.selectedMinute in minuteItems) {
-        "TimePicker minuteItems must contain state.selectedMinute=${state.selectedMinute}."
+        "TimePicker minuteItems must contain state.selectedMinute=${state.selectedMinute}. " +
+                timePickerStateItemsAdvice()
     }
 
     val isHour12 = state.timeFormat == TimeFormat.HOUR_12
@@ -217,7 +218,8 @@ internal fun validateTimePickerItems(
     }
     require(state.selectedHour in hourItems) {
         "TimePicker $hourItemsName must contain state.selectedHour=${state.selectedHour} " +
-                "for timeFormat=${state.timeFormat}."
+                "for timeFormat=${state.timeFormat}. " +
+                timePickerStateItemsAdvice()
     }
 
     if (isHour12) {
@@ -228,11 +230,13 @@ internal fun validateTimePickerItems(
             "TimePicker periodItems must not contain duplicate values."
         }
         require(state.selectedPeriod in periodItems) {
-            "TimePicker periodItems must contain state.selectedPeriod=${state.selectedPeriod}."
+            "TimePicker periodItems must contain state.selectedPeriod=${state.selectedPeriod}. " +
+                    timePickerStateItemsAdvice()
         }
         val availablePeriodItems = items.selectablePeriodItems()
         require(state.selectedPeriod in availablePeriodItems) {
-            "TimePicker constraints must allow state.selectedPeriod=${state.selectedPeriod}."
+            "TimePicker constraints must allow state.selectedPeriod=${state.selectedPeriod}. " +
+                    timePickerStateItemsAdvice()
         }
     }
 
@@ -242,16 +246,23 @@ internal fun validateTimePickerItems(
     )
     require(state.selectedHour in availableHourItems) {
         "TimePicker constraints must allow state.selectedHour=${state.selectedHour} " +
-                "for timeFormat=${state.timeFormat}."
+                "for timeFormat=${state.timeFormat}. " +
+                timePickerStateItemsAdvice()
     }
     val availableMinuteItems = items.selectableMinuteItemsFor(
         hourOfDay = state.selectedHourOfDay
     )
     require(state.selectedMinute in availableMinuteItems) {
         "TimePicker minuteItems and constraints must allow state.selectedMinute=${state.selectedMinute} " +
-                "for selectedHourOfDay=${state.selectedHourOfDay}."
+                "for selectedHourOfDay=${state.selectedHourOfDay}. " +
+                timePickerStateItemsAdvice()
     }
 }
+
+private fun timePickerStateItemsAdvice(): String =
+    "Use rememberTimePickerState(items = items, initialTime = ...) for initial values. For later " +
+            "programmatic changes, coerce app values with items.coerceTime(...) and call " +
+            "state.selectTime(time, items) before composing TimePicker."
 
 private fun List<Int>.invalidValuesFor(range: IntRange): List<Int> =
     filterNot { it in range }.distinct()

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -364,7 +364,7 @@ class TimePickerStateTest {
             timeFormat = TimeFormat.HOUR_24
         )
 
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             validateTimePickerItems(
                 state = state,
                 minuteItems = listOf(0, 15, 45),
@@ -372,6 +372,11 @@ class TimePickerStateTest {
                 periodItems = emptyList()
             )
         }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("rememberTimePickerState(items = items"))
+        assertTrue(message.contains("items.coerceTime"))
+        assertTrue(message.contains("state.selectTime(time, items)"))
     }
 
     @Test
@@ -958,6 +963,9 @@ class TimePickerStateTest {
         }
 
         assertTrue(error.message.orEmpty().contains("constraints"))
+        assertTrue(error.message.orEmpty().contains("rememberTimePickerState(items = items"))
+        assertTrue(error.message.orEmpty().contains("items.coerceTime"))
+        assertTrue(error.message.orEmpty().contains("state.selectTime(time, items)"))
     }
 
     @Test

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 /**
  * Unit tests for [YearMonthPickerState] class.
@@ -430,13 +431,18 @@ class YearMonthPickerStateTest {
             initialMonth = 6
         )
 
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             validateYearMonthPickerItems(
                 state = state,
                 yearItems = (2025..2030).toList(),
                 monthItems = listOf(3, 6, 9, 12)
             )
         }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("rememberYearMonthPickerState(items = items"))
+        assertTrue(message.contains("items.coerceYearMonth"))
+        assertTrue(message.contains("state.selectYearMonth(yearMonth, items)"))
     }
 
     @Test
@@ -491,6 +497,9 @@ class YearMonthPickerStateTest {
         }
 
         assertEquals(true, error.message.orEmpty().contains("constraints"))
+        assertTrue(error.message.orEmpty().contains("rememberYearMonthPickerState(items = items"))
+        assertTrue(error.message.orEmpty().contains("items.coerceYearMonth"))
+        assertTrue(error.message.orEmpty().contains("state.selectYearMonth(yearMonth, items)"))
     }
 
     @Test

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -8,6 +8,7 @@ import kotlinx.datetime.Month
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class DatePickerStateTest {
 
@@ -192,13 +193,18 @@ class DatePickerStateTest {
     fun testValidateDatePickerItems_ThrowsWhenYearItemsMissingCurrentSelection() {
         val state = DatePickerState(initialYear = 2025, initialMonth = 6, initialDay = 15)
 
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             validateDatePickerItems(
                 state = state,
                 yearItems = (2026..2030).toList(),
                 monthItems = listOf(3, 6, 9, 12)
             )
         }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("rememberDatePickerState(items = items"))
+        assertTrue(message.contains("items.coerceDate"))
+        assertTrue(message.contains("state.selectDate(date, items)"))
     }
 
     @Test
@@ -456,12 +462,18 @@ class DatePickerStateTest {
             )
         )
 
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             validateDatePickerItems(
                 state = state,
                 items = items
             )
         }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("constraints"))
+        assertTrue(message.contains("rememberDatePickerState(items = items"))
+        assertTrue(message.contains("items.coerceDate"))
+        assertTrue(message.contains("state.selectDate(date, items)"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add recovery guidance to DatePicker, TimePicker, and YearMonthPicker validation errors when state does not match custom items or constraints
- Cover the new guidance in unit tests for missing selected values and constrained selections
- Record the user-facing validation-message improvement in the changelog

## Review focus
- Whether the recovery guidance points first-time Android developers to the right state/items APIs without changing public API shape
- Whether the covered failures are the right ones to make actionable

## Verification
- git diff --check origin/main...HEAD
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- ./gradlew :datetimepicker:compileKotlinMetadata --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon