### PR TITLE
Add ordered DateRange factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   for ordered start/end date selection without manually wiring two `DatePicker` instances. Date
   range values and state also support year/month/day overloads for apps that store primitive form
   values.
+- Added `DateRange.ordered(...)` factories so apps can normalize unordered start/end inputs from
+  forms, presets, or restored state before passing them to `DateRangePickerState`.
 - Added `DateRangePickerState` and `rememberDateRangePickerState` overloads that accept a `DateRange`
   value directly.
 - Added value-first state constructors: `TimePickerState(LocalTime, ...)`,

--- a/README.md
+++ b/README.md
@@ -690,9 +690,10 @@ For initial values, use `rememberDateRangePickerState(initialDateRange = DateRan
 `initialStartYear`/`initialStartMonth`/`initialStartDay` and matching end-date parameters. To change
 the selection after state creation, call `state.selectDateRange(...)`, `state.selectStartDate(...)`,
 or `state.selectEndDate(...)` with `DateRange`, `LocalDate`, or explicit year/month/day values.
-`DateRange` can also be created from explicit start/end year, month, and day parts. Use
-`range.contains(year, month, day)` when app-owned form fields need an inclusive range check before
-creating a `LocalDate`.
+`DateRange` can also be created from explicit start/end year, month, and day parts. If app-owned
+start/end fields may be entered in either order, use `DateRange.ordered(startDate, endDate)` or the
+matching year/month/day overload before passing the value to state. Use `range.contains(year, month,
+day)` when app-owned form fields need an inclusive range check before creating a `LocalDate`.
 
 ### YearMonthPicker
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -686,9 +686,10 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 상태 생성 이후 선택값을 바꾸려면 `DateRange`, `LocalDate`, 또는 명시적인 year/month/day 값을
 사용해 `state.selectDateRange(...)`, `state.selectStartDate(...)`, `state.selectEndDate(...)`를
 호출합니다.
-`DateRange`도 명시적인 시작/종료 year, month, day 값으로 만들 수 있습니다. 앱이 form field 값을
-`LocalDate`로 만들기 전에 inclusive range 포함 여부를 확인해야 한다면 `range.contains(year, month, day)`를
-사용하세요.
+`DateRange`도 명시적인 시작/종료 year, month, day 값으로 만들 수 있습니다. 앱의 시작/종료 field가
+어느 순서로든 입력될 수 있다면 state에 전달하기 전에 `DateRange.ordered(startDate, endDate)` 또는
+대응되는 year/month/day overload를 사용하세요. 앱이 form field 값을 `LocalDate`로 만들기 전에
+inclusive range 포함 여부를 확인해야 한다면 `range.contains(year, month, day)`를 사용하세요.
 
 ### YearMonthPicker
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -526,6 +526,7 @@ public final class com/kez/picker/date/DatePickerStateKt {
 
 public final class com/kez/picker/date/DateRange {
 	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/date/DateRange$Companion;
 	public fun <init> (IIIIII)V
 	public synthetic fun <init> (IIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)V
@@ -540,6 +541,12 @@ public final class com/kez/picker/date/DateRange {
 	public final fun getStartDate ()Lkotlinx/datetime/LocalDate;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/date/DateRange$Companion {
+	public final fun ordered (IIIIII)Lcom/kez/picker/date/DateRange;
+	public final fun ordered (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
+	public static synthetic fun ordered$default (Lcom/kez/picker/date/DateRange$Companion;IIIIIIILjava/lang/Object;)Lcom/kez/picker/date/DateRange;
 }
 
 public final class com/kez/picker/date/DateRangePickerKt {

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -158,6 +158,11 @@ final class com.kez.picker.date/DateRange { // com.kez.picker.date/DateRange|nul
     final fun equals(kotlin/Any?): kotlin/Boolean // com.kez.picker.date/DateRange.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.kez.picker.date/DateRange.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // com.kez.picker.date/DateRange.toString|toString(){}[0]
+
+    final object Companion { // com.kez.picker.date/DateRange.Companion|null[0]
+        final fun ordered(kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ...): com.kez.picker.date/DateRange // com.kez.picker.date/DateRange.Companion.ordered|ordered(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+        final fun ordered(kotlinx.datetime/LocalDate, kotlinx.datetime/LocalDate): com.kez.picker.date/DateRange // com.kez.picker.date/DateRange.Companion.ordered|ordered(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate){}[0]
+    }
 }
 
 final class com.kez.picker.date/DateRangePickerState { // com.kez.picker.date/DateRangePickerState|null[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -526,6 +526,7 @@ public final class com/kez/picker/date/DatePickerStateKt {
 
 public final class com/kez/picker/date/DateRange {
 	public static final field $stable I
+	public static final field Companion Lcom/kez/picker/date/DateRange$Companion;
 	public fun <init> (IIIIII)V
 	public synthetic fun <init> (IIIIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)V
@@ -540,6 +541,12 @@ public final class com/kez/picker/date/DateRange {
 	public final fun getStartDate ()Lkotlinx/datetime/LocalDate;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/kez/picker/date/DateRange$Companion {
+	public final fun ordered (IIIIII)Lcom/kez/picker/date/DateRange;
+	public final fun ordered (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
+	public static synthetic fun ordered$default (Lcom/kez/picker/date/DateRange$Companion;IIIIIIILjava/lang/Object;)Lcom/kez/picker/date/DateRange;
 }
 
 public final class com/kez/picker/date/DateRangePickerKt {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
@@ -13,6 +13,7 @@ import kotlinx.datetime.number
 
 /**
  * Inclusive date range selected by [DateRangePicker].
+ * Use [ordered] when app-owned start/end inputs may arrive in either order.
  *
  * @param startDate The first selected date.
  * @param endDate The last selected date.
@@ -50,7 +51,8 @@ data class DateRange(
 
     init {
         require(startDate <= endDate) {
-            "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate"
+            "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate. " +
+                    dateRangeOrderedAdvice()
         }
     }
 
@@ -70,6 +72,40 @@ data class DateRange(
         if (year !in 1000..9999 || month !in 1..12 || day < 1) return false
         if (day > daysInMonth(year, month)) return false
         return LocalDate(year = year, month = month, day = day) in this
+    }
+
+    companion object {
+        /**
+         * Creates a [DateRange] from two dates, ordering them if [startDate] is after [endDate].
+         *
+         * This is useful when a form, preset, or restored value supplies two dates without a
+         * guaranteed start/end order.
+         */
+        fun ordered(startDate: LocalDate, endDate: LocalDate): DateRange =
+            if (startDate <= endDate) {
+                DateRange(startDate = startDate, endDate = endDate)
+            } else {
+                DateRange(startDate = endDate, endDate = startDate)
+            }
+
+        /**
+         * Creates a [DateRange] from explicit date parts, ordering the resulting dates if needed.
+         *
+         * If a day is greater than the maximum day for its year/month, it is clamped before the
+         * dates are ordered.
+         */
+        fun ordered(
+            startYear: Int,
+            startMonth: Int,
+            startDay: Int,
+            endYear: Int = startYear,
+            endMonth: Int = startMonth,
+            endDay: Int = startDay
+        ): DateRange =
+            ordered(
+                startDate = dateFromParts(year = startYear, month = startMonth, day = startDay),
+                endDate = dateFromParts(year = endYear, month = endMonth, day = endDay)
+            )
     }
 }
 
@@ -183,7 +219,8 @@ fun rememberDateRangePickerState(
         require(rememberedInitialStartDate <= rememberedInitialEndDate) {
             "initialStartDate must be on or before initialEndDate. " +
                     "initialStartDate=$rememberedInitialStartDate, " +
-                    "initialEndDate=$rememberedInitialEndDate"
+                    "initialEndDate=$rememberedInitialEndDate. " +
+                    dateRangeOrderedAdvice()
         }
         orderedDateRange(
             startDate = rememberedItems.coerceDate(rememberedInitialStartDate),
@@ -330,7 +367,8 @@ class DateRangePickerState(
     init {
         require(initialStartDate <= initialEndDate) {
             "initialStartDate must be on or before initialEndDate. " +
-                    "initialStartDate=$initialStartDate, initialEndDate=$initialEndDate"
+                    "initialStartDate=$initialStartDate, initialEndDate=$initialEndDate. " +
+                    dateRangeOrderedAdvice()
         }
     }
 
@@ -362,7 +400,8 @@ class DateRangePickerState(
      */
     fun selectDateRange(startDate: LocalDate, endDate: LocalDate) {
         require(startDate <= endDate) {
-            "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate"
+            "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate. " +
+                    dateRangeOrderedAdvice()
         }
         startDatePickerState.selectDate(startDate)
         endDatePickerState.selectDate(endDate)
@@ -404,7 +443,8 @@ class DateRangePickerState(
      */
     fun selectDateRange(startDate: LocalDate, endDate: LocalDate, items: DatePickerItems) {
         require(startDate <= endDate) {
-            "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate"
+            "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate. " +
+                    dateRangeOrderedAdvice()
         }
         val coercedRange = orderedDateRange(
             startDate = items.coerceDate(startDate),
@@ -570,8 +610,8 @@ private fun dateFromParts(year: Int, month: Int, day: Int): LocalDate {
 }
 
 private fun orderedDateRange(startDate: LocalDate, endDate: LocalDate): DateRange =
-    if (startDate <= endDate) {
-        DateRange(startDate = startDate, endDate = endDate)
-    } else {
-        DateRange(startDate = endDate, endDate = startDate)
-    }
+    DateRange.ordered(startDate = startDate, endDate = endDate)
+
+private fun dateRangeOrderedAdvice(): String =
+    "If app-owned start/end inputs may arrive in either order, use DateRange.ordered(...) before " +
+            "creating or selecting a DateRange."

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
@@ -14,12 +14,14 @@ class DateRangePickerStateTest {
 
     @Test
     fun dateRange_requiresOrderedDates() {
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             DateRange(
                 startDate = LocalDate(2026, 5, 2),
                 endDate = LocalDate(2026, 5, 1)
             )
         }
+
+        assertTrue(error.message.orEmpty().contains("DateRange.ordered"))
     }
 
     @Test
@@ -57,6 +59,32 @@ class DateRangePickerStateTest {
             startDay = 31,
             endYear = 2026,
             endMonth = 3,
+            endDay = 31
+        )
+
+        assertEquals(LocalDate(2026, 2, 28), range.startDate)
+        assertEquals(LocalDate(2026, 3, 31), range.endDate)
+    }
+
+    @Test
+    fun dateRange_ordered_ordersReversedDates() {
+        val range = DateRange.ordered(
+            startDate = LocalDate(2026, 5, 3),
+            endDate = LocalDate(2026, 5, 1)
+        )
+
+        assertEquals(LocalDate(2026, 5, 1), range.startDate)
+        assertEquals(LocalDate(2026, 5, 3), range.endDate)
+    }
+
+    @Test
+    fun dateRange_orderedDateParts_clampsInvalidDaysBeforeOrdering() {
+        val range = DateRange.ordered(
+            startYear = 2026,
+            startMonth = 3,
+            startDay = 31,
+            endYear = 2026,
+            endMonth = 2,
             endDay = 31
         )
 
@@ -146,12 +174,31 @@ class DateRangePickerStateTest {
 
     @Test
     fun dateRangePickerState_rejectsInitialStartAfterEnd() {
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             DateRangePickerState(
                 initialStartDate = LocalDate(2026, 5, 3),
                 initialEndDate = LocalDate(2026, 5, 1)
             )
         }
+
+        assertTrue(error.message.orEmpty().contains("DateRange.ordered"))
+    }
+
+    @Test
+    fun dateRangePickerState_selectDateRangeRejectsReversedRangeWithOrderedAdvice() {
+        val state = DateRangePickerState(
+            initialStartDate = LocalDate(2026, 5, 1),
+            initialEndDate = LocalDate(2026, 5, 3)
+        )
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            state.selectDateRange(
+                startDate = LocalDate(2026, 5, 3),
+                endDate = LocalDate(2026, 5, 1)
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("DateRange.ordered"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add DateRange.ordered(...) factories for LocalDate and explicit year/month/day inputs
- Point reversed range validation errors at DateRange.ordered(...) so failures have a recovery path
- Document the factory in README and README_KO for unordered form/restored start-end values
- Add DateRange ordered factory and validation-message coverage, and update ABI dumps

## Review focus
- Whether DateRange.ordered is the right explicit API for normalizing unordered app-owned date range inputs
- Whether the public ABI additions are limited to the intended DateRange companion factories
- Whether existing ordered-only constructors still fail clearly while directing developers to the new factory

## Verification
- git diff --check origin/main...HEAD
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- ./gradlew :datetimepicker:updateLegacyAbi --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon