### PR TITLE
Clarify generic picker validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 ### Changed
 
+- Made generic `Picker<T>` validation errors explain how to recover from empty lists, duplicate
+  values, invalid `selectedItem`, and invalid `visibleItemsCount` configuration.
 - Clarified the state and callback usage pattern in README and picker KDoc so apps can distinguish
   user-driven `onSelected*Change` callbacks from programmatic `state.select*` changes.
 - Made custom item-list and constraint validation errors for date, time, and year/month pickers

--- a/README.md
+++ b/README.md
@@ -491,8 +491,10 @@ fun SizePickerExample() {
 
 `Picker<T>` is a controlled component. Keep the selected value in app state, pass it through
 `selectedItem`, and update that state from `onSelectedItemChange`. `items` must be non-empty and
-distinct, and `selectedItem` must exist in `items`. If `T` is not saveable, store a saveable key in
-your app state and map that key back to an item before rendering the picker.
+distinct, and `selectedItem` must exist in `items`. If `items` can change, update or coerce the
+app-owned `selectedItem` to one of the new values before rendering the picker. If `T` is not
+saveable, store a saveable key in your app state and map that key back to an item before rendering
+the picker.
 Pass `enabled = false` to prevent user scroll, click, and accessibility selection actions while still
 showing the current value. Disabled pickers use the disabled slots from `PickerDefaults.colors(...)`
 for default text, dividers, and selected-item backgrounds.

--- a/README_KO.md
+++ b/README_KO.md
@@ -487,8 +487,9 @@ fun SizePickerExample() {
 
 `Picker<T>`는 controlled component입니다. 선택값은 앱 state에 보관하고, 그 값을 `selectedItem`으로
 전달하며, `onSelectedItemChange`에서 앱 state를 갱신하세요. `items`는 비어 있으면 안 되고 중복값이
-없어야 하며, `selectedItem`은 반드시 `items` 안에 있어야 합니다. `T`가 saveable하지 않다면 앱 state에는
-saveable한 key를 저장한 뒤 렌더링 전에 그 key를 item으로 매핑하세요.
+없어야 하며, `selectedItem`은 반드시 `items` 안에 있어야 합니다. `items`가 바뀔 수 있다면 렌더링 전에
+앱이 소유한 `selectedItem`을 새 목록의 값으로 갱신하거나 보정하세요. `T`가 saveable하지 않다면 앱
+state에는 saveable한 key를 저장한 뒤 렌더링 전에 그 key를 item으로 매핑하세요.
 현재 값을 표시하되 사용자의 scroll, click, accessibility 선택 action을 막아야 한다면 `enabled = false`를
 전달하세요. Disabled picker는 기본 텍스트, divider, 선택 영역 배경에 `PickerDefaults.colors(...)`의
 disabled 색상 슬롯을 사용합니다.

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/Picker.kt
@@ -131,17 +131,12 @@ fun <T : Any> Picker(
     isInfinity: Boolean = true,
     content: @Composable ((PickerItemScope<T>) -> Unit)? = null
 ) {
-    require(items.isNotEmpty()) { "Items list must not be empty" }
-    require(items.distinct().size == items.size) {
-        "Items list must not contain duplicate values because Picker uses item equality as its selection key."
-    }
-    require(selectedItem in items) {
-        "selectedItem must exist in items. selectedItem=$selectedItem, items=$items"
-    }
     val visibleItemsCount = style.visibleItemsCount
-    require(visibleItemsCount > 0 && visibleItemsCount % 2 == 1) {
-        "visibleItemsCount must be a positive odd number, but was $visibleItemsCount"
-    }
+    validatePickerInput(
+        items = items,
+        selectedItem = selectedItem,
+        visibleItemsCount = visibleItemsCount
+    )
 
     val density = LocalDensity.current
     val textMeasurer = rememberTextMeasurer(cacheSize = 16)
@@ -535,6 +530,30 @@ fun <T : Any> Picker(
                 }
             }
         }
+    }
+}
+
+internal fun <T : Any> validatePickerInput(
+    items: List<T>,
+    selectedItem: T,
+    visibleItemsCount: Int
+) {
+    require(items.isNotEmpty()) {
+        "Picker items must not be empty. Provide at least one item and keep selectedItem from that list."
+    }
+    require(items.distinct().size == items.size) {
+        "Picker items must not contain duplicate values because Picker uses item equality as its " +
+                "selection key. Use stable unique item values or pass unique IDs as items when " +
+                "display labels repeat."
+    }
+    require(selectedItem in items) {
+        "selectedItem must exist in items. Picker<T> is controlled, so update the app-owned " +
+                "selectedItem when items change or coerce it to one of items before composing " +
+                "Picker. selectedItem=$selectedItem, items=$items"
+    }
+    require(visibleItemsCount > 0 && visibleItemsCount % 2 == 1) {
+        "PickerDefaults.style(visibleItemsCount = ...) must use a positive odd number, but was " +
+                "$visibleItemsCount."
     }
 }
 

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerUtilsTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerUtilsTest.kt
@@ -2,6 +2,7 @@ package com.kez.picker
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
@@ -66,6 +67,65 @@ class PickerUtilsTest {
         for (count in invalidCounts) {
             assertTrue(count % 2 == 0, "Count $count should be an even number")
         }
+    }
+
+    @Test
+    fun validatePickerInput_throwsActionableMessageWhenItemsEmpty() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            validatePickerInput(
+                items = emptyList(),
+                selectedItem = "Small",
+                visibleItemsCount = 3
+            )
+        }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("Picker items must not be empty"))
+        assertTrue(message.contains("keep selectedItem from that list"))
+    }
+
+    @Test
+    fun validatePickerInput_throwsActionableMessageWhenItemsContainDuplicates() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            validatePickerInput(
+                items = listOf("Small", "Small"),
+                selectedItem = "Small",
+                visibleItemsCount = 3
+            )
+        }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("item equality"))
+        assertTrue(message.contains("stable unique item values"))
+    }
+
+    @Test
+    fun validatePickerInput_throwsActionableMessageWhenSelectedItemMissing() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            validatePickerInput(
+                items = listOf("Small", "Medium", "Large"),
+                selectedItem = "Extra Large",
+                visibleItemsCount = 3
+            )
+        }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("Picker<T> is controlled"))
+        assertTrue(message.contains("update the app-owned selectedItem when items change"))
+        assertTrue(message.contains("coerce it to one of items"))
+    }
+
+    @Test
+    fun validatePickerInput_throwsActionableMessageWhenVisibleItemsCountInvalid() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            validatePickerInput(
+                items = listOf("Small", "Medium", "Large"),
+                selectedItem = "Medium",
+                visibleItemsCount = 4
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("PickerDefaults.style(visibleItemsCount = ...)"))
     }
 
     // ==================== List Middle Calculation Tests ====================


### PR DESCRIPTION
## Summary
- Move generic Picker input validation into an internal helper covered by unit tests
- Make empty items, duplicate items, missing selectedItem, and invalid visibleItemsCount errors actionable
- Document that dynamic generic Picker items require updating or coercing app-owned selectedItem before rendering

## Review focus
- Whether the validation messages are precise enough for first-time generic Picker users
- Whether the internal helper remains outside the public ABI surface

## Verification
- git diff --check
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon