### PR TITLE
Clarify picker item constraint errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 ### Changed
 
+- Made picker item-list and constraint construction errors explain which min/max bounds or custom
+  item lists to adjust when no selectable value remains.
 - Clarified the state and callback usage pattern in README and picker KDoc so apps can distinguish
   user-driven `onSelected*Change` callbacks from programmatic `state.select*` changes.
 - Made custom item-list and constraint validation errors for date, time, and year/month pickers

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
@@ -23,7 +23,9 @@ data class TimePickerConstraints(
     init {
         if (minTime != null && maxTime != null) {
             require(minTime <= maxTime) {
-                "TimePicker minTime must be on or before maxTime. minTime=$minTime, maxTime=$maxTime"
+                "TimePicker minTime must be on or before maxTime. minTime=$minTime, " +
+                        "maxTime=$maxTime. If app input can arrive in either order, sort it " +
+                        "before creating TimePickerConstraints."
             }
         }
     }
@@ -198,7 +200,9 @@ data class TimePickerItems(
             TimeFormat.HOUR_12 -> selectablePeriodItems().isNotEmpty()
         }
         require(hasSelectableTime) {
-            "TimePicker items must contain at least one time allowed by constraints."
+            "TimePicker items must contain at least one time allowed by constraints. Adjust " +
+                    "minTime/maxTime or include at least one hour/minute/period combination " +
+                    "inside the allowed range."
         }
     }
 }
@@ -216,7 +220,9 @@ data class DatePickerConstraints(
     init {
         if (minDate != null && maxDate != null) {
             require(minDate <= maxDate) {
-                "DatePicker minDate must be on or before maxDate. minDate=$minDate, maxDate=$maxDate"
+                "DatePicker minDate must be on or before maxDate. minDate=$minDate, " +
+                        "maxDate=$maxDate. If app input can arrive in either order, sort it " +
+                        "before creating DatePickerConstraints."
             }
         }
     }
@@ -341,7 +347,9 @@ data class DatePickerItems(
             }
         }
         require(selectableYearItems().isNotEmpty()) {
-            "DatePicker items must contain at least one date allowed by constraints."
+            "DatePicker items must contain at least one date allowed by constraints. Adjust " +
+                    "minDate/maxDate or include at least one matching year/month/day item " +
+                    "inside the allowed range."
         }
     }
 }
@@ -360,7 +368,9 @@ data class YearMonthPickerConstraints(
         if (minYearMonth != null && maxYearMonth != null) {
             require(minYearMonth <= maxYearMonth) {
                 "YearMonthPicker minYearMonth must be on or before maxYearMonth. " +
-                        "minYearMonth=$minYearMonth, maxYearMonth=$maxYearMonth"
+                        "minYearMonth=$minYearMonth, maxYearMonth=$maxYearMonth. If app input " +
+                        "can arrive in either order, sort it before creating " +
+                        "YearMonthPickerConstraints."
             }
         }
     }
@@ -464,7 +474,9 @@ data class YearMonthPickerItems(
         yearItems.requireIntItems(name = "YearMonthPicker yearItems", range = 1000..9999)
         monthItems.requireIntItems(name = "YearMonthPicker monthItems", range = 1..12)
         require(selectableYearItems().isNotEmpty()) {
-            "YearMonthPicker items must contain at least one year/month allowed by constraints."
+            "YearMonthPicker items must contain at least one year/month allowed by constraints. " +
+                    "Adjust minYearMonth/maxYearMonth or include at least one matching " +
+                    "year/month item pair inside the allowed range."
         }
     }
 }

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -763,12 +763,14 @@ class TimePickerStateTest {
 
     @Test
     fun timePickerConstraints_throwsWhenMinimumIsAfterMaximum() {
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             TimePickerConstraints(
                 minTime = LocalTime(18, 0),
                 maxTime = LocalTime(9, 0)
             )
         }
+
+        assertTrue(error.message.orEmpty().contains("sort it before creating TimePickerConstraints"))
     }
 
     @Test
@@ -817,6 +819,28 @@ class TimePickerStateTest {
             LocalTime(9, 30),
             items.coerceTime(hour = 8, minute = 0, timeFormat = TimeFormat.HOUR_24)
         )
+    }
+
+    @Test
+    fun timePickerItems_coerceTime_throwsActionableMessageWhenConstraintsFilterEveryTime() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0),
+            hour24Items = listOf(9),
+            hour12Items = emptyList(),
+            periodItems = emptyList(),
+            constraints = TimePickerConstraints(
+                minTime = LocalTime(10, 0),
+                maxTime = LocalTime(11, 0)
+            )
+        )
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            items.coerceTime(LocalTime(9, 0), TimeFormat.HOUR_24)
+        }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("minTime/maxTime"))
+        assertTrue(message.contains("hour/minute/period"))
     }
 
     @Test

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -295,12 +295,36 @@ class YearMonthPickerStateTest {
 
     @Test
     fun yearMonthPickerConstraints_throwsWhenMinimumIsAfterMaximum() {
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             YearMonthPickerConstraints(
                 minYearMonth = YearMonth(year = 2025, month = 1),
                 maxYearMonth = YearMonth(year = 2024, month = 12)
             )
         }
+
+        assertTrue(
+            error.message.orEmpty().contains("sort it before creating YearMonthPickerConstraints")
+        )
+    }
+
+    @Test
+    fun yearMonthPickerItems_coerceYearMonth_throwsActionableMessageWhenConstraintsFilterEveryMonth() {
+        val items = YearMonthPickerItems(
+            yearItems = listOf(2024),
+            monthItems = listOf(1),
+            constraints = YearMonthPickerConstraints(
+                minYearMonth = YearMonth(year = 2025, month = 1),
+                maxYearMonth = YearMonth(year = 2025, month = 12)
+            )
+        )
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            items.coerceYearMonth(YearMonth(year = 2024, month = 1))
+        }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("minYearMonth/maxYearMonth"))
+        assertTrue(message.contains("year/month item pair"))
     }
 
     @Test

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -382,12 +382,14 @@ class DatePickerStateTest {
 
     @Test
     fun datePickerConstraints_throwsWhenMinimumIsAfterMaximum() {
-        assertFailsWith<IllegalArgumentException> {
+        val error = assertFailsWith<IllegalArgumentException> {
             DatePickerConstraints(
                 minDate = LocalDate(year = 2026, month = Month.JUNE, day = 20),
                 maxDate = LocalDate(year = 2026, month = Month.MAY, day = 10)
             )
         }
+
+        assertTrue(error.message.orEmpty().contains("sort it before creating DatePickerConstraints"))
     }
 
     @Test
@@ -428,6 +430,27 @@ class DatePickerStateTest {
             LocalDate(year = 2026, month = Month.JUNE, day = 20),
             items.coerceDate(LocalDate(year = 2026, month = Month.DECEMBER, day = 31))
         )
+    }
+
+    @Test
+    fun datePickerItems_coerceDate_throwsActionableMessageWhenConstraintsFilterEveryDate() {
+        val items = DatePickerItems(
+            yearItems = listOf(2026),
+            monthItems = listOf(1),
+            dayItems = listOf(1),
+            constraints = DatePickerConstraints(
+                minDate = LocalDate(year = 2026, month = Month.MAY, day = 10),
+                maxDate = LocalDate(year = 2026, month = Month.JUNE, day = 20)
+            )
+        )
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            items.coerceDate(LocalDate(year = 2026, month = Month.JANUARY, day = 1))
+        }
+
+        val message = error.message.orEmpty()
+        assertTrue(message.contains("minDate/maxDate"))
+        assertTrue(message.contains("year/month/day"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Make min/max constraint ordering errors explain that unordered app input should be sorted first
- Make no-selectable-value item/constraint errors point to the specific bounds or custom item lists to adjust
- Add unit coverage for time, date, and year-month item constraint failure messages

## Review focus
- Whether the messages give first-time Android developers enough information to fix invalid custom items or constraints
- Whether this stays limited to diagnostics without public ABI changes

## Verification
- git diff --check
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for date and time picker configuration to provide actionable guidance. When validation fails due to min/max bounds being reversed or constraints filtering all valid values, messages now specify which settings require adjustment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kez-lab/Compose-DateTimePicker/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->