### PR TITLE
Make year-month contains tolerate invalid parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 ### Changed
 
+- Made `YearMonthPickerItems.contains(year, month)` return `false` for raw year/month values outside
+  the supported ranges instead of constructing an invalid `YearMonth`.
 - Clarified the state and callback usage pattern in README and picker KDoc so apps can distinguish
   user-driven `onSelected*Change` callbacks from programmatic `state.select*` changes.
 - Made custom item-list and constraint validation errors for date, time, and year/month pickers

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
@@ -397,11 +397,15 @@ data class YearMonthPickerItems(
 
     /**
      * Returns whether [year] and [month] are directly selectable.
+     *
+     * Values outside the supported year or month ranges return false.
      */
-    fun contains(year: Int, month: Int): Boolean =
-        year in yearItems &&
+    fun contains(year: Int, month: Int): Boolean {
+        if (year !in 1000..9999 || month !in 1..12) return false
+        return year in yearItems &&
                 month in monthItems &&
                 constraints.contains(YearMonth(year = year, month = month))
+    }
 
     /**
      * Returns whether the year/month portion of [date] is directly selectable.

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/YearMonthPickerStateTest.kt
@@ -334,6 +334,17 @@ class YearMonthPickerStateTest {
     }
 
     @Test
+    fun yearMonthPickerItems_containsParts_returnsFalseForInvalidRawValues() {
+        val items = YearMonthPickerItems(
+            yearItems = listOf(2024, 2026),
+            monthItems = listOf(3, 12, 13)
+        )
+
+        assertEquals(false, items.contains(year = 999, month = 3))
+        assertEquals(false, items.contains(year = 2024, month = 13))
+    }
+
+    @Test
     fun yearMonthPickerItems_coerceYearMonth_respectsConstraints() {
         val items = YearMonthPickerItems(
             yearItems = listOf(2024, 2025, 2026),


### PR DESCRIPTION
## Summary
- Return false from YearMonthPickerItems.contains(year, month) when raw year or month values are outside supported ranges
- Document the false-return behavior in KDoc
- Add unit coverage for invalid raw primitive values, including invalid custom list content that would previously construct an invalid YearMonth

## Review focus
- Whether primitive contains now matches TimePickerItems and DatePickerItems safe predicate behavior
- Whether this behavior change is appropriate for app-owned form field validation

## Verification
- git diff --check
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon