### PR TITLE
chore: add autonomous improvement workflow guidance

### DIFF
--- a/.agents/skills/compose-picker-api-stabilizer/SKILL.md
+++ b/.agents/skills/compose-picker-api-stabilizer/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: compose-picker-api-stabilizer
+description: Audit and improve Compose-DateTimePicker public API ergonomics, API stability, ABI dumps, KDoc, README usage, picker state contracts, item constraints, formatting, semantics, and cross-component invariants. Use when working on Picker, TimePicker, DatePicker, YearMonthPicker, DateRangePicker, or any public API change in this repository.
+---
+
+# Compose Picker API Stabilizer
+
+## Overview
+
+Use this skill before changing supported picker APIs or reviewing a branch that changes public picker behavior.
+
+## API Principles
+
+- Prefer controlled picker APIs with one source of truth.
+- Composite pickers should expose saveable logical state plus optional `onSelected*Change` callbacks for user-driven changes.
+- Keep public state APIs colocated with their component package.
+- Prefer `YearMonth` for year/month-only values; keep `selectedMonthDate` as interop convenience only.
+- Group repeated visual options in `PickerStyle`; group semantics in `PickerSemantics` or component-specific semantics objects; group custom item lists in component-specific item option objects.
+- Keep `enabled` as a top-level interaction availability parameter.
+- Do not reintroduce `startTime`, `startLocalDate`, or generic `startIndex` component parameters.
+- Treat `remember*State` initial parameters as first-composition defaults, not recomposition reset hooks.
+
+## Cross-Component Invariants
+
+When changing one component, audit the counterpart behavior in all relevant components:
+
+- `contains`, `coerce*`, validation, rendered item filtering, and selection repair.
+- Exact inclusive min/max constraints for time, date, and year-month values.
+- Empty lists, duplicates, unsupported ranges, and current-selection presence validation.
+- Programmatic `state.select*` calls and scroll synchronization.
+- Visible format vs content description format vs structural semantics labels.
+- Disabled behavior: block scroll/click/custom semantics actions while selected values remain visible.
+
+## Required Public API Checklist
+
+For intentional public API changes:
+
+1. Update KDoc on every new or changed public symbol.
+2. Update `README.md` and `README_KO.md` with usage, failure mode, and state-clamping guidance.
+3. Update `CHANGELOG.md`.
+4. Run `./gradlew :datetimepicker:updateLegacyAbi --no-daemon`.
+5. Review `datetimepicker/api/` dumps for intended symbols only. Reject accidental `*Preview` or generated resource API churn.
+6. Run `./gradlew :datetimepicker:checkLegacyAbi --no-daemon`.
+
+## Test Targets
+
+Prefer focused tests over broad churn:
+
+- Common unit tests for pure date/time coercion, validation, item filtering, and state mutation contracts.
+- Robolectric tests for Compose semantics, state restoration, disabled behavior, and custom labels/actions.
+- Sample compile or smoke tests only when sample-facing behavior changes.
+
+Do not claim API stabilization is complete unless tests, docs, ABI dumps, and samples agree.

--- a/.agents/skills/compose-picker-api-stabilizer/agents/openai.yaml
+++ b/.agents/skills/compose-picker-api-stabilizer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Compose Picker API Stabilizer"
+  short_description: "API ergonomics and ABI hardening"
+  default_prompt: "Use $compose-picker-api-stabilizer to audit and improve Compose-DateTimePicker public APIs."

--- a/.agents/skills/compose-picker-autonomous-loop/SKILL.md
+++ b/.agents/skills/compose-picker-autonomous-loop/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: compose-picker-autonomous-loop
+description: Run long autonomous improvement loops for the Compose-DateTimePicker repository. Use when the maintainer asks for a Codex goal, 12-hour improvement run, autonomous API/library hardening, branch/PR planning, worktree strategy, or repo-scoped execution plan for this Kotlin Multiplatform picker library.
+---
+
+# Compose Picker Autonomous Loop
+
+## Overview
+
+Use this as the top-level workflow skill for this repo. Keep maintainer-facing updates in Korean. Keep code identifiers, paths, Gradle tasks, and API names in English.
+
+## Orientation
+
+Start each run by reading `AGENTS.md`, then inspect:
+
+```bash
+git status --short --branch
+git branch -a --sort=-committerdate
+gh pr list --state open --limit 20 --json number,title,headRefName,baseRefName,isDraft,mergeStateStatus,url
+```
+
+Also inspect `README.md`, `README_KO.md`, `CHANGELOG.md`, `gradle.properties`, `datetimepicker/api/`, and the relevant picker source/test files before making public API decisions.
+
+## Branch Strategy
+
+- Use `feature/*` branches for implementation work.
+- Treat `main` / `origin/main` as the integration branch. Do not target `develop`.
+- If the current checkout has unrelated dirty work, create a separate worktree from `origin/main` before editing.
+- Keep one PR-sized slice active at a time. Do not bundle calendar expansion, API breaking changes, docs rewrites, and CI policy changes in one product PR.
+- Do not deploy, publish, release, or trigger production credentials unless the maintainer explicitly authorizes that action.
+
+## Priority Order
+
+1. Stabilize any active dirty picker feature already present in the checkout without overwriting user changes.
+2. Improve Android developer ergonomics: state APIs, sample usage, KDoc, README/README_KO, accessibility semantics, predictable lifecycle behavior.
+3. Harden public API consistency across `Picker`, `TimePicker`, `DatePicker`, `YearMonthPicker`, and `DateRangePicker`.
+4. Add focused regression coverage for non-standard logic: custom item lists, exact min/max constraints, state restoration, programmatic selection sync, selection repair, duplicate/empty validation, non-default column/order/style options, and semantics.
+5. Design calendar-style selection only after the existing picker/state APIs are stable enough to support it. Start calendar work with a small API proposal and acceptance criteria before implementation.
+
+## Feedback Loop
+
+After each substantial implementation step:
+
+1. Run targeted local verification.
+2. Red-team the change against stale assumptions, duplicated invariants, missing tests, and source/API/docs drift.
+3. If multi-agent tools are available and the maintainer asked for autonomous improvement, run independent review passes for API ergonomics, tests, docs/sample usability, accessibility, multiplatform behavior, and release/ABI risk.
+4. Fix actionable findings, then verify again.
+
+## Completion Report
+
+End each slice with branch/status, files changed, commands run with results, public API/ABI impact, docs updated, remaining risks, and the next recommended PR-sized slice.

--- a/.agents/skills/compose-picker-autonomous-loop/SKILL.md
+++ b/.agents/skills/compose-picker-autonomous-loop/SKILL.md
@@ -27,6 +27,7 @@ Also inspect `README.md`, `README_KO.md`, `CHANGELOG.md`, `gradle.properties`, `
 - Treat `main` / `origin/main` as the integration branch. Do not target `develop`.
 - If the current checkout has unrelated dirty work, create a separate worktree from `origin/main` before editing.
 - Keep one PR-sized slice active at a time. Do not bundle calendar expansion, API breaking changes, docs rewrites, and CI policy changes in one product PR.
+- Treat push, PR creation, and merge as part of each slice's completion path. After local verification passes, push the branch, open or update the PR, and merge it when the maintainer has authorized ongoing autonomous merges. If merge is blocked, capture the exact blocker before moving on.
 - Do not deploy, publish, release, or trigger production credentials unless the maintainer explicitly authorizes that action.
 
 ## Priority Order
@@ -48,4 +49,4 @@ After each substantial implementation step:
 
 ## Completion Report
 
-End each slice with branch/status, files changed, commands run with results, public API/ABI impact, docs updated, remaining risks, and the next recommended PR-sized slice.
+End each slice with branch/status, commit(s), pushed branch, PR URL, merge result or blocker, files changed, commands run with results, public API/ABI impact, docs updated, remaining risks, and the next recommended PR-sized slice.

--- a/.agents/skills/compose-picker-autonomous-loop/agents/openai.yaml
+++ b/.agents/skills/compose-picker-autonomous-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Compose Picker Autonomous Loop"
+  short_description: "12-hour repo improvement loop"
+  default_prompt: "Use $compose-picker-autonomous-loop to run a scoped autonomous improvement loop for Compose-DateTimePicker."

--- a/.agents/skills/compose-picker-local-verifier/SKILL.md
+++ b/.agents/skills/compose-picker-local-verifier/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: compose-picker-local-verifier
+description: Select and run fast local verification gates for Compose-DateTimePicker changes while hosted GitHub Actions PR automation is disabled. Use before handoff, PR creation, merging, or after modifying Kotlin source, public APIs, README/CHANGELOG docs, sample app code, or workflow files.
+---
+
+# Compose Picker Local Verifier
+
+## Overview
+
+Use local verification as the primary gate. Hosted PR CI is manual-only and should not be treated as required unless the maintainer explicitly asks for hosted evidence.
+
+## Always Run
+
+```bash
+git status --short --branch
+git diff --check origin/main...HEAD
+```
+
+## Choose Gates by Change Type
+
+Docs or workflow-only changes:
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Common Kotlin logic or picker state changes:
+
+```bash
+./gradlew :datetimepicker:test --no-daemon
+```
+
+Android Compose semantics, state restoration, or component UI behavior:
+
+```bash
+./gradlew :datetimepicker:testDebugUnitTest --no-daemon
+```
+
+Public API changes:
+
+```bash
+./gradlew :datetimepicker:updateLegacyAbi --no-daemon
+./gradlew :datetimepicker:checkLegacyAbi --no-daemon
+```
+
+Sample app changes:
+
+```bash
+./gradlew :sample:compileKotlinDesktop --no-daemon
+./gradlew :sample:wasmJsBrowserDistribution --no-daemon
+./gradlew :sample:assembleDebugAndroidTest --no-daemon
+```
+
+Broad release readiness:
+
+```bash
+./gradlew :datetimepicker:check --no-daemon
+./gradlew :datetimepicker:checkLegacyAbi --no-daemon
+```
+
+## Slow or Environment-Dependent Gates
+
+Run these only when the environment supports them or the maintainer asks:
+
+```bash
+./gradlew :sample:pixel2Api35DebugAndroidTest \
+  -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+  --no-daemon
+./gradlew :sample:connectedDebugAndroidTest --no-daemon
+```
+
+If managed-device prerequisites are missing, run `:sample:assembleDebugAndroidTest` or a Gradle `--dry-run`, then state clearly that emulator execution was not locally proven.
+
+## Reporting
+
+Report exact commands and pass/fail results. If a gate is skipped, state why. Never imply hosted GitHub Actions passed when only local checks ran.

--- a/.agents/skills/compose-picker-local-verifier/SKILL.md
+++ b/.agents/skills/compose-picker-local-verifier/SKILL.md
@@ -86,4 +86,4 @@ If managed-device prerequisites are missing, run `:sample:assembleDebugAndroidTe
 
 ## Reporting
 
-Report exact commands and pass/fail results. If a gate is skipped, state why. Never imply hosted GitHub Actions passed when only local checks ran.
+Report exact commands and pass/fail results. If a gate is skipped, state why. Before handoff or moving to the next slice, also report whether the branch was pushed, which PR was opened or updated, and whether it was merged or why merge is blocked. Never imply hosted GitHub Actions passed when only local checks ran.

--- a/.agents/skills/compose-picker-local-verifier/SKILL.md
+++ b/.agents/skills/compose-picker-local-verifier/SKILL.md
@@ -24,6 +24,13 @@ Docs or workflow-only changes:
 git diff --check origin/main...HEAD
 ```
 
+For workflow changes, validate YAML and run `actionlint` when it is available:
+
+```bash
+ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "ok #{f}" }'
+command -v actionlint >/dev/null && actionlint .github/workflows/*.yml
+```
+
 Common Kotlin logic or picker state changes:
 
 ```bash
@@ -37,6 +44,12 @@ Android Compose semantics, state restoration, or component UI behavior:
 ```
 
 Public API changes:
+
+```bash
+./gradlew :datetimepicker:checkLegacyAbi --no-daemon
+```
+
+If `checkLegacyAbi` fails because the public API change is intentional, run:
 
 ```bash
 ./gradlew :datetimepicker:updateLegacyAbi --no-daemon

--- a/.agents/skills/compose-picker-local-verifier/agents/openai.yaml
+++ b/.agents/skills/compose-picker-local-verifier/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Compose Picker Local Verifier"
+  short_description: "Fast local verification gates"
+  default_prompt: "Use $compose-picker-local-verifier to choose and run local verification gates before a PR."

--- a/.github/workflows/integration-build-test.yml
+++ b/.github/workflows/integration-build-test.yml
@@ -1,8 +1,12 @@
 name: CI - Compose Multiplatform TimePicker (Build & Test)
 
 on:
-  pull_request:
-    branches: [ main ]
+  # Hosted PR CI is intentionally disabled for now because the full
+  # multiplatform/emulator matrix is slow. Run the same gates locally and use
+  # this workflow manually only when hosted evidence is explicitly needed.
+  # pull_request:
+  #   branches: [ main ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration-build-test.yml
+++ b/.github/workflows/integration-build-test.yml
@@ -7,6 +7,12 @@ on:
   # pull_request:
   #   branches: [ main ]
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base branch or ref used for manual diff hygiene checks.
+        required: false
+        default: main
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +24,7 @@ permissions:
 env:
   LIBRARY_MODULE: ":datetimepicker"
   SAMPLE_MODULE: ":sample"
+  BASE_REF: ${{ inputs.base_ref || github.base_ref || 'main' }}
 jobs:
   repository-hygiene:
     name: Linux • Repository hygiene
@@ -28,8 +35,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check PR diff whitespace
-        run: git diff --check "origin/${{ github.base_ref }}...HEAD"
+      - name: Check diff whitespace
+        run: |
+          git fetch origin "${BASE_REF}"
+          git diff --check "origin/${BASE_REF}...HEAD"
 
   abi-check:
     name: macOS • Kotlin ABI Check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,9 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 
 - Use `feature/*` branch names for new implementation work in this repository.
 - Treat `main` as the integration branch. There is currently no `develop` branch on the remote.
+- For long autonomous improvement runs, keep one PR-sized slice active at a time. Prefer a separate worktree from `origin/main` when the current checkout has dirty feature work, and do not mix agent workflow assets with picker product changes unless the maintainer explicitly asks for workflow assets.
 - After a substantial implementation step, run a six-agent feedback loop when the maintainer asks for autonomous improvement work: collect feedback, fix actionable issues, verify again, then open or update the PR.
-- Merge PRs only after relevant local verification and GitHub Actions checks pass.
+- Hosted GitHub Actions PR automation is intentionally disabled while the matrix is too slow. Merge PRs only after relevant local verification passes; run the manual `workflow_dispatch` CI only when hosted evidence is explicitly requested.
 - Keep improving toward Android developer ergonomics first: state APIs, sample usability, documentation clarity, accessibility, and predictable behavior in real app lifecycles.
 - Before adding custom performance machinery, verify that the standard Compose/runtime primitives are insufficient. Prefer `remember`, `derivedStateOf`, `snapshotFlow`, stable object ownership, and domain helpers before introducing bespoke caches or dirty-check classes. If the reason is performance, record the measured or directly inspected evidence in the PR.
 - Treat bespoke caching, manual invalidation, synchronization, and equality-key logic as high-risk code. If such code remains, add focused regression coverage for stale data, source identity changes, non-default column orders, and state changes that should invalidate derived values. Private code still needs tests when it replaces framework guarantees.
@@ -278,7 +279,7 @@ Follow **Semantic Versioning**: MAJOR.MINOR.PATCH
 ## CI/CD
 
 GitHub Actions workflows:
-- **`integration-build-test.yml`**: Runs repository hygiene and multiplatform library checks on pull requests to `main`; the hygiene job runs `git diff --check` on the PR diff, the dedicated macOS ABI job runs `checkLegacyAbi`, and the Android matrix runs the Gradle Managed Device `pixel2Api35DebugAndroidTest` gate for library and sample instrumented tests.
+- **`integration-build-test.yml`**: Manual-only (`workflow_dispatch`) hosted verification. PR automation is commented out because the full multiplatform/emulator matrix is slow. Prefer local gates first: `git diff --check origin/main...HEAD`, targeted Gradle tests, `checkLegacyAbi` for public API changes, and sample compilation. Trigger the hosted workflow only when explicit hosted evidence is needed.
 - **`maven-central-deploy.yml`**: Publishes releases to Maven Central
 
 Build matrix: Ubuntu latest for Android/Desktop/Wasm and macOS 14 for iOS, using JDK 17 (Temurin)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Most logic lives in `commonMain`. Platform-specific code is minimal.
 - Use `feature/*` branch names for new implementation work in this repository.
 - Treat `main` as the integration branch. There is currently no `develop` branch on the remote.
 - For long autonomous improvement runs, keep one PR-sized slice active at a time. Prefer a separate worktree from `origin/main` when the current checkout has dirty feature work, and do not mix agent workflow assets with picker product changes unless the maintainer explicitly asks for workflow assets.
+- In autonomous improvement runs, a PR-sized slice is not complete until it has its own commit(s), pushed `feature/*` branch, opened PR, and merge attempt after local verification. If merge is blocked, record the blocker and continue with the next actionable slice only after the blocker is explicit.
 - After a substantial implementation step, run a six-agent feedback loop when the maintainer asks for autonomous improvement work: collect feedback, fix actionable issues, verify again, then open or update the PR.
 - Hosted GitHub Actions PR automation is intentionally disabled while the matrix is too slow. Merge PRs only after relevant local verification passes; run the manual `workflow_dispatch` CI only when hosted evidence is explicitly requested.
 - Keep improving toward Android developer ergonomics first: state APIs, sample usability, documentation clarity, accessibility, and predictable behavior in real app lifecycles.

--- a/docs/agent-goals/autonomous-improvement-goal.md
+++ b/docs/agent-goals/autonomous-improvement-goal.md
@@ -1,0 +1,24 @@
+# Compose-DateTimePicker Autonomous Improvement Goal
+
+Use this prompt when starting a long Codex goal for this repository.
+
+```text
+Goal: For the next autonomous improvement run, improve Compose-DateTimePicker as a Kotlin Multiplatform date/time picker library for real Android app ergonomics. Work in Korean for maintainer communication. Start by reading AGENTS.md, checking git status, branch topology, open PRs, current dirty files, README/CHANGELOG/API dumps, and the repo-local skills under .agents/skills.
+
+Operate in PR-sized slices. If the current checkout has unrelated dirty work, create a separate worktree from origin/main with a feature/* branch before editing. Do not use develop. Do not deploy or release unless explicitly authorized.
+
+Priority order:
+1. Finish or stabilize any active picker API/UI work already present in the checkout without overwriting user changes.
+2. Improve public API ergonomics and stabilization for Picker, TimePicker, DatePicker, YearMonthPicker, and DateRangePicker: single source of truth, saveable state, item constraints, exact min/max behavior, semantics, formatting, KDoc, README/README_KO, CHANGELOG, and ABI dumps.
+3. Add focused regression tests for state restoration, programmatic selection sync, custom item lists, invalid ranges, selection repair, semantics, and non-default column/order/style options.
+4. Improve sample usability and developer-facing examples, especially Android-first app lifecycle usage.
+5. Only after the above is stable, design the next feature slice for calendar-style selection. Start with a small spec and API proposal before implementing calendar UI.
+
+Avoid speculative rewrites. Prefer Compose/runtime primitives over custom caches unless measured or directly inspected evidence justifies custom machinery. When changing public APIs, update KDoc, README.md, README_KO.md, CHANGELOG.md, and datetimepicker/api/ dumps in the same slice.
+
+Verification policy: hosted PR GitHub Actions are disabled because the full matrix is slow. Use local verification as the main gate. Always run git diff --check origin/main...HEAD. Run the smallest sufficient Gradle gates for the change, and run :datetimepicker:checkLegacyAbi for public API changes. Use the manual workflow_dispatch CI only when hosted evidence is explicitly requested.
+
+Every substantial implementation step should end with: current branch/status, files changed, tests run with results, remaining risks, and the next PR-sized slice.
+```
+
+Recommended first slice for June 2026: finish the current `feature/picker-selection-indicator` work if it is still dirty. After that, use separate branches for API stabilization, sample/documentation improvements, and calendar feature design.

--- a/docs/agent-goals/autonomous-improvement-goal.md
+++ b/docs/agent-goals/autonomous-improvement-goal.md
@@ -21,4 +21,4 @@ Verification policy: hosted PR GitHub Actions are disabled because the full matr
 Every substantial implementation step should end with: current branch/status, files changed, tests run with results, remaining risks, and the next PR-sized slice.
 ```
 
-Recommended first slice for June 2026: finish the current `feature/picker-selection-indicator` work if it is still dirty. After that, use separate branches for API stabilization, sample/documentation improvements, and calendar feature design.
+Recommended slice order: finish any active dirty picker feature first, then use separate branches for API stabilization, sample/documentation improvements, workflow guidance, and calendar feature design.

--- a/docs/agent-goals/autonomous-improvement-goal.md
+++ b/docs/agent-goals/autonomous-improvement-goal.md
@@ -5,7 +5,7 @@ Use this prompt when starting a long Codex goal for this repository.
 ```text
 Goal: For the next autonomous improvement run, improve Compose-DateTimePicker as a Kotlin Multiplatform date/time picker library for real Android app ergonomics. Work in Korean for maintainer communication. Start by reading AGENTS.md, checking git status, branch topology, open PRs, current dirty files, README/CHANGELOG/API dumps, and the repo-local skills under .agents/skills.
 
-Operate in PR-sized slices. If the current checkout has unrelated dirty work, create a separate worktree from origin/main with a feature/* branch before editing. Do not use develop. Do not deploy or release unless explicitly authorized.
+Operate in PR-sized slices. If the current checkout has unrelated dirty work, create a separate worktree from origin/main with a feature/* branch before editing. Do not use develop. Each slice should end with its own commit(s), pushed feature/* branch, opened PR, and merge attempt after local verification; if merge is blocked, record the exact blocker before moving to the next slice. Do not deploy or release unless explicitly authorized.
 
 Priority order:
 1. Finish or stabilize any active picker API/UI work already present in the checkout without overwriting user changes.
@@ -18,7 +18,7 @@ Avoid speculative rewrites. Prefer Compose/runtime primitives over custom caches
 
 Verification policy: hosted PR GitHub Actions are disabled because the full matrix is slow. Use local verification as the main gate. Always run git diff --check origin/main...HEAD. Run the smallest sufficient Gradle gates for the change, and run :datetimepicker:checkLegacyAbi for public API changes. Use the manual workflow_dispatch CI only when hosted evidence is explicitly requested.
 
-Every substantial implementation step should end with: current branch/status, files changed, tests run with results, remaining risks, and the next PR-sized slice.
+Every substantial implementation step should end with: current branch/status, commit(s), pushed branch, PR URL, merge result or blocker, files changed, tests run with results, remaining risks, and the next PR-sized slice.
 ```
 
 Recommended slice order: finish any active dirty picker feature first, then use separate branches for API stabilization, sample/documentation improvements, workflow guidance, and calendar feature design.


### PR DESCRIPTION
## Summary
- add repo-local autonomous improvement skills for API stabilization, long-run slicing, and local verification
- keep hosted PR CI manual-only while preserving workflow_dispatch and local verification guidance
- document that each autonomous slice must be committed, pushed, opened as a PR, and merged or explicitly blocked

## Validation
- git diff --check origin/main...HEAD
- ruby YAML parse for .github/workflows/*.yml and .agents/skills/*/agents/*.yaml
- actionlint skipped: not installed locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for API stabilization, verification procedures, and autonomous improvement workflows
  * New local testing and validation guidelines for development processes

* **Chores**
  * Updated development workflow configurations and tooling setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->