### PR TITLE
test: cover selection indicator line colors

### DIFF
--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerSelectionBand.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerSelectionBand.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
@@ -80,12 +81,6 @@ private fun SelectionBandLines(
 ) {
     if (!indicator.isVisible) return
 
-    val color = if (enabled) {
-        indicator.color
-    } else {
-        indicator.disabledColor
-    }
-
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -94,8 +89,11 @@ private fun SelectionBandLines(
         val lineModifier = Modifier
             .fillMaxWidth()
             .height(indicator.thickness)
-            .background(color = color, shape = indicator.shape)
+            .background(color = indicator.lineColor(enabled), shape = indicator.shape)
         Box(modifier = Modifier.then(lineModifier).align(Alignment.TopCenter))
         Box(modifier = Modifier.then(lineModifier).align(Alignment.BottomCenter))
     }
 }
+
+internal fun PickerSelectionIndicator.lineColor(enabled: Boolean): Color =
+    if (enabled) color else disabledColor

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerLayoutTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/PickerLayoutTest.kt
@@ -232,4 +232,19 @@ class PickerLayoutTest {
         assertEquals(false, indicator.isVisible)
         assertEquals(Color.Yellow, indicator.disabledColor)
     }
+
+    @Test
+    fun pickerSelectionIndicator_lineColorUsesDisabledColorWhenDisabled() {
+        val indicator = PickerSelectionIndicator(
+            color = Color.Red,
+            disabledColor = Color.Blue,
+            thickness = 1.dp,
+            shape = RectangleShape,
+            horizontalInset = 0.dp,
+            isVisible = true
+        )
+
+        assertEquals(Color.Red, indicator.lineColor(enabled = true))
+        assertEquals(Color.Blue, indicator.lineColor(enabled = false))
+    }
 }


### PR DESCRIPTION
## Summary
- extract the selection indicator line color choice into an internal helper used by PickerSelectionBand
- add common test coverage that enabled bands use color and disabled bands use disabledColor
- avoid flaky Robolectric screenshot capture for this contract; the local Robolectric window capture path timed out in this environment

## Validation
- git diff --check origin/main...HEAD
- ./gradlew :datetimepicker:test :datetimepicker:checkLegacyAbi --no-daemon
- ./gradlew :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution :sample:assembleDebugAndroidTest --no-daemon
