### PR TITLE
fix: use date range clamping in sample month preset

### DIFF
--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
@@ -56,24 +56,18 @@ internal fun DateRangePickerSampleScreen(
             val today = remember { currentDate() }
             val yearStart = remember(today.year) { LocalDate(today.year, 1, 1) }
             val yearEnd = remember(today.year) { LocalDate(today.year, 12, 31) }
-            val monthEndDay = remember(today) {
-                when (today.month.number) {
-                    2 -> 28
-                    4, 6, 9, 11 -> 30
-                    else -> 31
-                }
-            }
-            val monthStart = remember(today) {
-                LocalDate(today.year, today.month, 1)
-            }
-            val monthEnd = remember(today, monthEndDay) {
-                LocalDate(today.year, today.month, monthEndDay)
-            }
             val todayRange = remember(today) {
                 DateRange(startDate = today, endDate = today)
             }
-            val monthRange = remember(monthStart, monthEnd) {
-                DateRange(startDate = monthStart, endDate = monthEnd)
+            val monthRange = remember(today) {
+                DateRange(
+                    startYear = today.year,
+                    startMonth = today.month.number,
+                    startDay = 1,
+                    endYear = today.year,
+                    endMonth = today.month.number,
+                    endDay = 31
+                )
             }
             val items = remember(today.year, yearStart, yearEnd) {
                 PickerDefaults.datePickerItems(


### PR DESCRIPTION
## Summary
- remove manual month-end calculation from the DateRangePicker sample
- build the “This month” preset through DateRange date-part construction so month-end clamping handles leap-year February
- keep the sample focused on the public API apps should use for date-part presets

## Validation
- git diff --check
- ./gradlew :datetimepicker:test :datetimepicker:checkLegacyAbi --no-daemon
- ./gradlew :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution :sample:assembleDebugAndroidTest --no-daemon

## Notes
- Hosted PR checks are manual-only; local verification is the merge gate for this slice.