### PR TITLE
feat: add date range day count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   values.
 - Added `DateRange.ordered(...)` factories so apps can normalize unordered start/end inputs from
   forms, presets, or restored state before passing them to `DateRangePickerState`.
+- Added `DateRange.dayCount` so apps can display the inclusive number of calendar days in the
+  selected range without recalculating epoch-day differences.
 - Added `DateRangePickerState` and `rememberDateRangePickerState` overloads that accept a `DateRange`
   value directly.
 - Added value-first state constructors: `TimePickerState(LocalTime, ...)`,

--- a/README.md
+++ b/README.md
@@ -748,7 +748,8 @@ or `state.selectEndDate(...)` with `DateRange`, `LocalDate`, or explicit year/mo
 `DateRange` can also be created from explicit start/end year, month, and day parts. If app-owned
 start/end fields may be entered in either order, use `DateRange.ordered(startDate, endDate)` or the
 matching year/month/day overload before passing the value to state. Use `range.contains(year, month,
-day)` when app-owned form fields need an inclusive range check before creating a `LocalDate`.
+day)` when app-owned form fields need an inclusive range check before creating a `LocalDate`. Use
+`range.dayCount` to display the inclusive number of calendar days in the selected range.
 
 ### YearMonthPicker
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -740,6 +740,7 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 어느 순서로든 입력될 수 있다면 state에 전달하기 전에 `DateRange.ordered(startDate, endDate)` 또는
 대응되는 year/month/day overload를 사용하세요. 앱이 form field 값을 `LocalDate`로 만들기 전에
 inclusive range 포함 여부를 확인해야 한다면 `range.contains(year, month, day)`를 사용하세요.
+선택된 범위의 inclusive calendar day 수를 표시하려면 `range.dayCount`를 사용하세요.
 
 ### YearMonthPicker
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -600,6 +600,7 @@ public final class com/kez/picker/date/DateRange {
 	public final fun copy (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
 	public static synthetic fun copy$default (Lcom/kez/picker/date/DateRange;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;ILjava/lang/Object;)Lcom/kez/picker/date/DateRange;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDayCount ()I
 	public final fun getEndDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getStartDate ()Lkotlinx/datetime/LocalDate;
 	public fun hashCode ()I

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -160,6 +160,8 @@ final class com.kez.picker.date/DateRange { // com.kez.picker.date/DateRange|nul
     constructor <init>(kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int = ..., kotlin/Int = ..., kotlin/Int = ...) // com.kez.picker.date/DateRange.<init>|<init>(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
     constructor <init>(kotlinx.datetime/LocalDate, kotlinx.datetime/LocalDate) // com.kez.picker.date/DateRange.<init>|<init>(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate){}[0]
 
+    final val dayCount // com.kez.picker.date/DateRange.dayCount|{}dayCount[0]
+        final fun <get-dayCount>(): kotlin/Int // com.kez.picker.date/DateRange.dayCount.<get-dayCount>|<get-dayCount>(){}[0]
     final val endDate // com.kez.picker.date/DateRange.endDate|{}endDate[0]
         final fun <get-endDate>(): kotlinx.datetime/LocalDate // com.kez.picker.date/DateRange.endDate.<get-endDate>|<get-endDate>(){}[0]
     final val startDate // com.kez.picker.date/DateRange.startDate|{}startDate[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -600,6 +600,7 @@ public final class com/kez/picker/date/DateRange {
 	public final fun copy (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
 	public static synthetic fun copy$default (Lcom/kez/picker/date/DateRange;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;ILjava/lang/Object;)Lcom/kez/picker/date/DateRange;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDayCount ()I
 	public final fun getEndDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getStartDate ()Lkotlinx/datetime/LocalDate;
 	public fun hashCode ()I

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
@@ -57,6 +57,14 @@ data class DateRange(
     }
 
     /**
+     * Number of calendar days in this inclusive range.
+     *
+     * A range whose [startDate] and [endDate] are the same has a [dayCount] of 1.
+     */
+    val dayCount: Int
+        get() = (endDate.toEpochDays() - startDate.toEpochDays() + 1).toInt()
+
+    /**
      * Returns whether [date] is inside this inclusive range.
      */
     operator fun contains(date: LocalDate): Boolean =

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
@@ -37,6 +37,31 @@ class DateRangePickerStateTest {
     }
 
     @Test
+    fun dateRange_dayCountReturnsInclusiveCalendarDayCount() {
+        assertEquals(
+            1,
+            DateRange(
+                startDate = LocalDate(2026, 5, 1),
+                endDate = LocalDate(2026, 5, 1)
+            ).dayCount
+        )
+        assertEquals(
+            3,
+            DateRange(
+                startDate = LocalDate(2026, 5, 1),
+                endDate = LocalDate(2026, 5, 3)
+            ).dayCount
+        )
+        assertEquals(
+            2,
+            DateRange(
+                startDate = LocalDate(2026, 1, 31),
+                endDate = LocalDate(2026, 2, 1)
+            ).dayCount
+        )
+    }
+
+    @Test
     fun dateRange_initializesFromDateParts() {
         val range = DateRange(
             startYear = 2026,


### PR DESCRIPTION
## Summary
- add DateRange.dayCount for inclusive calendar-day range summaries
- document the helper in README.md, README_KO.md, and CHANGELOG.md
- update committed legacy ABI dumps for the new public getter

## Validation
- git diff --check
- ./gradlew :datetimepicker:testDebugUnitTest --tests "com.kez.picker.date.DateRangePickerStateTest.dateRange_dayCountReturnsInclusiveCalendarDayCount" --no-daemon
- ./gradlew :datetimepicker:updateLegacyAbi --no-daemon
- ./gradlew :datetimepicker:test :datetimepicker:checkLegacyAbi --no-daemon
- ./gradlew :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution :sample:assembleDebugAndroidTest --no-daemon

## Notes
- Hosted PR checks are manual-only; local verification is the merge gate for this slice.