### PR TITLE
docs: show date range day count in sample

### DIFF
--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
@@ -85,7 +85,8 @@ internal fun DateRangePickerSampleScreen(
                 icon = FeatherIcons.Calendar,
                 label = "Selected range",
                 value = state.selectedDateRange.asText(),
-                supportingText = "Selectable year: ${today.year}"
+                supportingText = "Days selected: ${state.selectedDateRange.dayCount}. " +
+                        "Selectable year: ${today.year}"
             )
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- show DateRange.dayCount in the DateRangePicker sample selected-value summary
- make the sample demonstrate the new inclusive day-count helper in real app UI

## Validation
- git diff --check
- ./gradlew :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution :sample:assembleDebugAndroidTest --no-daemon

## Notes
- Hosted PR checks are manual-only; local verification is the merge gate for this slice.