### PR TITLE
docs: clarify picker style option groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,19 @@ dividers, item padding, selected item background, and fading edge behavior with 
 Use `format.itemText` for visible text and `format.itemContentDescription` for screen-reader value
 text when those two strings should differ.
 
+`PickerStyle` groups the visual settings that can be shared across `Picker` and composite pickers:
+
+| Option | Use it for |
+| :--- | :--- |
+| `visibleItemsCount` | Number of rows visible in the wheel. |
+| `colors` | Default/selected/disabled text colors, divider colors, and selected-item background colors. |
+| `textStyles` | Default and selected text styles. |
+| `selectedItemBackgroundShape` | Shape of the selected item background. |
+| `itemPadding` | Padding applied around each rendered item. |
+| `fadingEdgeGradient` | Top/bottom fading edge mask. |
+| `horizontalAlignment` | Horizontal alignment of item content inside each column. |
+| `dividerThickness`, `dividerShape`, `dividerWidth`, `isDividerVisible` | Standalone `Picker` selection divider settings. Composite pickers use `selectionIndicator` for the shared band. |
+
 For a standalone `Picker`, control the selection divider length with `dividerWidth`. Use
 `PickerDividerWidth.Fill` (default) to span the full column width, `PickerDividerWidth.Fraction(0f..1f)`
 for a proportional length, or `PickerDividerWidth.Fixed(Dp)` for an absolute length. The divider stays
@@ -550,6 +563,17 @@ rather than the per-column `style` divider settings (which do not apply to compo
 `disabledDividerColor` / `isDividerVisible` customizations still take effect. Use `horizontalInset`
 to inset the band from the picker edges. `thickness` and `horizontalInset` must be finite,
 non-negative `Dp` values.
+
+`PickerSelectionIndicator` keeps the composite band settings separate from per-column item styling:
+
+| Option | Use it for |
+| :--- | :--- |
+| `color` | Selection band line color while the picker is enabled. |
+| `disabledColor` | Selection band line color while the picker is disabled. |
+| `thickness` | Thickness of each band line. Must be a finite, non-negative `Dp`. |
+| `shape` | Shape of each band line. |
+| `horizontalInset` | Inset applied to both horizontal edges of the band. Must be a finite, non-negative `Dp`. |
+| `isVisible` | Whether the band is drawn. |
 
 ```kotlin
 TimePicker(

--- a/README_KO.md
+++ b/README_KO.md
@@ -519,6 +519,19 @@ Picker(
 화면에 보이는 텍스트와 스크린 리더 문구가 달라야 한다면 visible text는 `format.itemText`로, 접근성
 값 설명은 `format.itemContentDescription`으로 분리하세요.
 
+`PickerStyle`은 `Picker`와 composite picker에서 공유할 수 있는 시각 설정을 묶습니다.
+
+| Option | 용도 |
+| :--- | :--- |
+| `visibleItemsCount` | wheel에 보이는 행 개수입니다. |
+| `colors` | 기본/선택/비활성 텍스트 색, divider 색, 선택 항목 배경색입니다. |
+| `textStyles` | 기본 텍스트와 선택 텍스트 스타일입니다. |
+| `selectedItemBackgroundShape` | 선택 항목 배경의 shape입니다. |
+| `itemPadding` | 각 item 주위에 적용되는 padding입니다. |
+| `fadingEdgeGradient` | 상하 fading edge mask입니다. |
+| `horizontalAlignment` | 각 column 안에서 item content를 가로 정렬하는 방식입니다. |
+| `dividerThickness`, `dividerShape`, `dividerWidth`, `isDividerVisible` | 독립 실행형 `Picker`의 selection divider 설정입니다. Composite picker는 공유 band에 `selectionIndicator`를 사용합니다. |
+
 독립 실행형 `Picker`에서는 `dividerWidth`로 선택 divider의 길이를 제어할 수 있습니다.
 `PickerDividerWidth.Fill`(기본값)은 column 전체 폭을 사용하고,
 `PickerDividerWidth.Fraction(0f..1f)`은 column 폭의 비율을 사용하며,
@@ -541,6 +554,17 @@ divider를 따로 그리지 않고 picker 전체를 가로지르는 **단일 sel
 파생되므로 기존 `dividerColor` / `dividerThickness` / `disabledDividerColor` / `isDividerVisible`
 커스터마이징은 계속 적용됩니다. `horizontalInset`으로 picker 양쪽 가장자리에서 band를 안쪽으로
 넣을 수 있습니다. `thickness`와 `horizontalInset`은 finite non-negative `Dp`여야 합니다.
+
+`PickerSelectionIndicator`는 composite band 설정을 per-column item styling과 분리합니다.
+
+| Option | 용도 |
+| :--- | :--- |
+| `color` | picker가 활성화됐을 때 selection band line 색입니다. |
+| `disabledColor` | picker가 비활성화됐을 때 selection band line 색입니다. |
+| `thickness` | 각 band line 두께입니다. finite non-negative `Dp`여야 합니다. |
+| `shape` | 각 band line의 shape입니다. |
+| `horizontalInset` | band의 양쪽 가로 가장자리에 적용되는 inset입니다. finite non-negative `Dp`여야 합니다. |
+| `isVisible` | band를 그릴지 여부입니다. |
 
 ```kotlin
 TimePicker(


### PR DESCRIPTION
## Summary
- add README/README_KO option tables for PickerStyle and PickerSelectionIndicator
- clarify standalone divider settings versus composite selectionIndicator settings

## Validation
- git diff --check origin/main...HEAD

## Notes
- Documentation-only slice; no Gradle gate needed.