### PR TITLE
test: cover date range state restore summary

### DIFF
--- a/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
+++ b/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.isSelected
 import com.kez.picker.date.DatePicker
 import com.kez.picker.date.DatePickerState
+import com.kez.picker.date.DateRange
 import com.kez.picker.date.DateRangePicker
 import com.kez.picker.date.DateRangePickerState
 import com.kez.picker.date.YearMonthPicker
@@ -261,6 +262,43 @@ class PickerStateRestorationRobolectricTest {
 
         composeRule.runOnIdle {
             assertEquals(LocalDate(2026, 2, 28), state.selectedDate)
+        }
+    }
+
+    @Test
+    fun rememberDateRangePickerState_restoresProgrammaticSelectionSummaryAfterSaveRestore() {
+        lateinit var state: DateRangePickerState
+        val restorationTester = StateRestorationTester(composeRule)
+
+        restorationTester.setContent {
+            state = rememberDateRangePickerState(
+                initialDateRange = DateRange(
+                    startDate = LocalDate(2024, 1, 1),
+                    endDate = LocalDate(2024, 1, 2)
+                )
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectDateRange(
+                startDate = LocalDate(2024, 2, 27),
+                endDate = LocalDate(2024, 3, 1)
+            )
+            assertEquals(4, state.selectedDateRange.dayCount)
+        }
+
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        composeRule.runOnIdle {
+            val expected = DateRange(
+                startDate = LocalDate(2024, 2, 27),
+                endDate = LocalDate(2024, 3, 1)
+            )
+
+            assertEquals(expected, state.selectedDateRange)
+            assertEquals(expected.startDate, state.selectedStartDate)
+            assertEquals(expected.endDate, state.selectedEndDate)
+            assertEquals(4, state.selectedDateRange.dayCount)
         }
     }
 


### PR DESCRIPTION
## Summary
- add a DateRangePickerState save/restore regression test for programmatic date range selections
- verify restored selectedDateRange, start/end dates, and inclusive dayCount stay in sync

## Validation
- ./gradlew :datetimepicker:testDebugUnitTest --tests "com.kez.picker.PickerStateRestorationRobolectricTest.rememberDateRangePickerState_restoresProgrammaticSelectionSummaryAfterSaveRestore" --no-daemon
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check origin/main...HEAD

## Notes
- Test-only slice; no public API or ABI impact.