### PR TITLE
test: cover date range remember items coercion

### DIFF
--- a/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
+++ b/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
@@ -266,6 +266,40 @@ class PickerStateRestorationRobolectricTest {
     }
 
     @Test
+    fun rememberDateRangePickerState_withItemsAndRangeCoercesInitialSelection() {
+        lateinit var state: DateRangePickerState
+        val items = PickerDefaults.datePickerItems(
+            yearItems = listOf(2026),
+            monthItems = (1..12).toList(),
+            dayItems = (1..31).toList(),
+            minDate = LocalDate(2026, 5, 10),
+            maxDate = LocalDate(2026, 6, 20)
+        )
+
+        composeRule.setContent {
+            state = rememberDateRangePickerState(
+                items = items,
+                initialDateRange = DateRange(
+                    startDate = LocalDate(2026, 1, 1),
+                    endDate = LocalDate(2026, 12, 31)
+                )
+            )
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(LocalDate(2026, 5, 10), state.selectedStartDate)
+            assertEquals(LocalDate(2026, 6, 20), state.selectedEndDate)
+            assertEquals(
+                DateRange(
+                    startDate = LocalDate(2026, 5, 10),
+                    endDate = LocalDate(2026, 6, 20)
+                ),
+                state.selectedDateRange
+            )
+        }
+    }
+
+    @Test
     fun rememberDateRangePickerState_restoresProgrammaticSelectionSummaryAfterSaveRestore() {
         lateinit var state: DateRangePickerState
         val restorationTester = StateRestorationTester(composeRule)


### PR DESCRIPTION
## Summary
- add a Robolectric regression test for rememberDateRangePickerState(items, initialDateRange)
- verify out-of-range initial date ranges are coerced before the picker state is used by app UI

## Validation
- ./gradlew :datetimepicker:testDebugUnitTest --tests "com.kez.picker.PickerStateRestorationRobolectricTest.rememberDateRangePickerState_withItemsAndRangeCoercesInitialSelection" --no-daemon
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check origin/main...HEAD

## Notes
- Test-only slice; no public API or ABI impact.