### PR TITLE
test: cover date range start callback repair

### DIFF
--- a/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerSemanticsRobolectricTest.kt
+++ b/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerSemanticsRobolectricTest.kt
@@ -1125,6 +1125,56 @@ class PickerSemanticsRobolectricTest {
     }
 
     @Test
+    fun dateRangePicker_callsOnSelectedDateRangeChangeAfterStartSelectionMovesEnd() {
+        lateinit var state: DateRangePickerState
+        lateinit var changedRangeState: MutableState<DateRange?>
+
+        composeRule.setContent {
+            state = rememberDateRangePickerState(
+                initialStartDate = LocalDate(2026, 1, 12),
+                initialEndDate = LocalDate(2026, 1, 12)
+            )
+            changedRangeState = remember { mutableStateOf(null) }
+
+            DateRangePicker(
+                state = state,
+                onSelectedDateRangeChange = { changedRangeState.value = it },
+                items = PickerDefaults.datePickerItems(
+                    yearItems = listOf(2026),
+                    monthItems = listOf(1),
+                    dayItems = listOf(12, 13)
+                ),
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.datePickerFormat(
+                    dayItemContentDescription = { "${it}일" }
+                ),
+                semantics = PickerDefaults.dateRangePickerSemantics(
+                    start = PickerDefaults.datePickerSemantics(
+                        dayPickerLabel = "시작 일",
+                        nextItemActionLabel = NEXT_VALUE_ACTION_LABEL
+                    )
+                )
+            )
+        }
+
+        performCustomAccessibilityAction(
+            contentDescription = "시작 일: 12일",
+            actionLabel = NEXT_VALUE_ACTION_LABEL
+        )
+        waitUntilSelectedItem("시작 일: 13일")
+
+        composeRule.runOnIdle {
+            val expectedRange = DateRange(
+                startDate = LocalDate(2026, 1, 13),
+                endDate = LocalDate(2026, 1, 13)
+            )
+
+            assertEquals(expectedRange, changedRangeState.value)
+            assertEquals(expectedRange, state.selectedDateRange)
+        }
+    }
+
+    @Test
     fun dateRangePicker_callsOnSelectedDateRangeChangeAfterEndSelectionMovesStart() {
         lateinit var state: DateRangePickerState
         lateinit var changedRangeState: MutableState<DateRange?>


### PR DESCRIPTION
## Summary
- add the symmetric DateRangePicker start-day callback regression test
- verify user-driven start selection that passes the end date repairs the end date and reports the repaired DateRange

## Validation
- ./gradlew :datetimepicker:testDebugUnitTest --tests "com.kez.picker.PickerSemanticsRobolectricTest.dateRangePicker_callsOnSelectedDateRangeChangeAfterStartSelectionMovesEnd" --no-daemon
- ./gradlew :datetimepicker:testDebugUnitTest --no-daemon
- git diff --check origin/main...HEAD

## Notes
- Test-only slice; no public API or ABI impact.