### PR TITLE
test: assert date range sample callback summary

### DIFF
--- a/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
+++ b/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
@@ -76,6 +76,8 @@ class SampleAppSmokeAndroidTest {
     @Test
     fun dateRangePickerMenuAction_updatesSelectedRangeFromButtons() {
         val today = currentDate()
+        val expectedSummary = "Selected range, $today..$today, Days selected: 1. " +
+                "Last user change: No user change. Selectable year: ${today.year}"
 
         composeRule
             .onNodeWithTag("sample-menu-date-range-picker")
@@ -91,7 +93,7 @@ class SampleAppSmokeAndroidTest {
             .performClick()
 
         composeRule
-            .onNode(hasContentDescriptionStartingWith("Selected range, $today..$today"))
+            .onNode(hasContentDescriptionStartingWith(expectedSummary))
             .assertIsDisplayed()
     }
 


### PR DESCRIPTION
## Summary
- extend the DateRangePicker sample smoke assertion to include day count and user callback summary text
- verify the Today preset keeps the user-callback summary unchanged because it uses programmatic state selection

## Validation
- ./gradlew :sample:assembleDebugAndroidTest --no-daemon
- git diff --check origin/main...HEAD

## Notes
- Android instrumented-test source change only; emulator execution was not run locally.