### PR TITLE
docs: show single-day range state in sample

### DIFF
--- a/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
+++ b/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
@@ -76,7 +76,7 @@ class SampleAppSmokeAndroidTest {
     @Test
     fun dateRangePickerMenuAction_updatesSelectedRangeFromButtons() {
         val today = currentDate()
-        val expectedSummary = "Selected range, $today..$today, Days selected: 1. " +
+        val expectedSummary = "Selected range, $today..$today, Single day. Days selected: 1. " +
                 "Last user change: No user change. Selectable year: ${today.year}"
 
         composeRule

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
@@ -86,12 +86,18 @@ internal fun DateRangePickerSampleScreen(
             var lastUserRangeText by rememberSaveable {
                 mutableStateOf("No user change")
             }
+            val selectedRange = state.selectedDateRange
+            val selectionKind = if (selectedRange.isSingleDay) {
+                "Single day"
+            } else {
+                "Date range"
+            }
 
             SelectedValueCard(
                 icon = FeatherIcons.Calendar,
                 label = "Selected range",
-                value = state.selectedDateRange.asText(),
-                supportingText = "Days selected: ${state.selectedDateRange.dayCount}. " +
+                value = selectedRange.asText(),
+                supportingText = "$selectionKind. Days selected: ${selectedRange.dayCount}. " +
                         "Last user change: $lastUserRangeText. Selectable year: ${today.year}"
             )
 


### PR DESCRIPTION
## Summary
- show DateRange.isSingleDay in the DateRangePicker sample summary
- update the sample smoke assertion to cover the new single-day summary text

## Validation
- ./gradlew :sample:compileKotlinDesktop --no-daemon
- ./gradlew :sample:wasmJsBrowserDistribution --no-daemon
- ./gradlew :sample:assembleDebugAndroidTest --no-daemon
- git diff --check origin/main...HEAD

## Notes
- Sample-only slice; no public API or ABI impact.