### PR TITLE
feat: add date range intersection helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Added `DateRange.isSingleDay`, `DateRange.contains(DateRange)`, and `DateRange.overlaps(...)` so
   apps can check selected ranges for one-day, containment, and overlap cases without duplicating
   inclusive boundary logic.
+- Added `DateRange.intersection(...)` so apps can retrieve the shared inclusive sub-range between
+  two date ranges, or `null` when no calendar day overlaps.
 - Added `DateRangePickerState` and `rememberDateRangePickerState` overloads that accept a `DateRange`
   value directly.
 - Added value-first state constructors: `TimePickerState(LocalTime, ...)`,

--- a/README.md
+++ b/README.md
@@ -775,8 +775,9 @@ start/end fields may be entered in either order, use `DateRange.ordered(startDat
 matching year/month/day overload before passing the value to state. Use `range.contains(year, month,
 day)` when app-owned form fields need an inclusive range check before creating a `LocalDate`. Use
 `date in range`, `childRange in range`, and `range.overlaps(blockedRange)` for inclusive date and
-range checks. Use `range.isSingleDay` for one-day selections and `range.dayCount` to display the
-inclusive number of calendar days in the selected range.
+range checks. Use `range.intersection(blockedRange)` when apps need the shared sub-range itself.
+Use `range.isSingleDay` for one-day selections and `range.dayCount` to display the inclusive number
+of calendar days in the selected range.
 
 ### YearMonthPicker
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -766,8 +766,9 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 대응되는 year/month/day overload를 사용하세요. 앱이 form field 값을 `LocalDate`로 만들기 전에
 inclusive range 포함 여부를 확인해야 한다면 `range.contains(year, month, day)`를 사용하세요.
 inclusive date와 range 확인에는 `date in range`, `childRange in range`,
-`range.overlaps(blockedRange)`를 사용할 수 있습니다. 하루만 선택된 범위는 `range.isSingleDay`로
-확인하고, 선택된 범위의 inclusive calendar day 수를 표시하려면 `range.dayCount`를 사용하세요.
+`range.overlaps(blockedRange)`를 사용할 수 있습니다. 앱이 공유되는 하위 범위 자체가 필요하다면
+`range.intersection(blockedRange)`를 사용하세요. 하루만 선택된 범위는 `range.isSingleDay`로 확인하고,
+선택된 범위의 inclusive calendar day 수를 표시하려면 `range.dayCount`를 사용하세요.
 
 ### YearMonthPicker
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -605,6 +605,7 @@ public final class com/kez/picker/date/DateRange {
 	public final fun getEndDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getStartDate ()Lkotlinx/datetime/LocalDate;
 	public fun hashCode ()I
+	public final fun intersection (Lcom/kez/picker/date/DateRange;)Lcom/kez/picker/date/DateRange;
 	public final fun isSingleDay ()Z
 	public final fun overlaps (Lcom/kez/picker/date/DateRange;)Z
 	public fun toString ()Ljava/lang/String;

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -177,6 +177,7 @@ final class com.kez.picker.date/DateRange { // com.kez.picker.date/DateRange|nul
     final fun copy(kotlinx.datetime/LocalDate = ..., kotlinx.datetime/LocalDate = ...): com.kez.picker.date/DateRange // com.kez.picker.date/DateRange.copy|copy(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.kez.picker.date/DateRange.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.kez.picker.date/DateRange.hashCode|hashCode(){}[0]
+    final fun intersection(com.kez.picker.date/DateRange): com.kez.picker.date/DateRange? // com.kez.picker.date/DateRange.intersection|intersection(com.kez.picker.date.DateRange){}[0]
     final fun overlaps(com.kez.picker.date/DateRange): kotlin/Boolean // com.kez.picker.date/DateRange.overlaps|overlaps(com.kez.picker.date.DateRange){}[0]
     final fun toString(): kotlin/String // com.kez.picker.date/DateRange.toString|toString(){}[0]
 

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -605,6 +605,7 @@ public final class com/kez/picker/date/DateRange {
 	public final fun getEndDate ()Lkotlinx/datetime/LocalDate;
 	public final fun getStartDate ()Lkotlinx/datetime/LocalDate;
 	public fun hashCode ()I
+	public final fun intersection (Lcom/kez/picker/date/DateRange;)Lcom/kez/picker/date/DateRange;
 	public final fun isSingleDay ()Z
 	public final fun overlaps (Lcom/kez/picker/date/DateRange;)Z
 	public fun toString ()Ljava/lang/String;

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
@@ -100,6 +100,20 @@ data class DateRange(
     fun overlaps(range: DateRange): Boolean =
         startDate <= range.endDate && range.startDate <= endDate
 
+    /**
+     * Returns the inclusive overlap between this range and [range], or `null` when they do not
+     * share any calendar day.
+     */
+    fun intersection(range: DateRange): DateRange? {
+        val intersectionStart = maxOf(startDate, range.startDate)
+        val intersectionEnd = minOf(endDate, range.endDate)
+        return if (intersectionStart <= intersectionEnd) {
+            DateRange(startDate = intersectionStart, endDate = intersectionEnd)
+        } else {
+            null
+        }
+    }
+
     companion object {
         /**
          * Creates a [DateRange] from two dates, ordering them if [startDate] is after [endDate].

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
@@ -119,6 +119,60 @@ class DateRangePickerStateTest {
     }
 
     @Test
+    fun dateRange_intersectionReturnsInclusiveSharedDateRange() {
+        val range = DateRange(
+            startDate = LocalDate(2026, 5, 10),
+            endDate = LocalDate(2026, 5, 20)
+        )
+
+        assertEquals(
+            DateRange(
+                startDate = LocalDate(2026, 5, 10),
+                endDate = LocalDate(2026, 5, 10)
+            ),
+            range.intersection(
+                DateRange(
+                    startDate = LocalDate(2026, 5, 1),
+                    endDate = LocalDate(2026, 5, 10)
+                )
+            )
+        )
+        assertEquals(
+            DateRange(
+                startDate = LocalDate(2026, 5, 12),
+                endDate = LocalDate(2026, 5, 15)
+            ),
+            range.intersection(
+                DateRange(
+                    startDate = LocalDate(2026, 5, 12),
+                    endDate = LocalDate(2026, 5, 15)
+                )
+            )
+        )
+        assertEquals(
+            DateRange(
+                startDate = LocalDate(2026, 5, 18),
+                endDate = LocalDate(2026, 5, 20)
+            ),
+            range.intersection(
+                DateRange(
+                    startDate = LocalDate(2026, 5, 18),
+                    endDate = LocalDate(2026, 5, 25)
+                )
+            )
+        )
+        assertEquals(
+            null,
+            range.intersection(
+                DateRange(
+                    startDate = LocalDate(2026, 5, 21),
+                    endDate = LocalDate(2026, 5, 25)
+                )
+            )
+        )
+    }
+
+    @Test
     fun dateRange_dayCountReturnsInclusiveCalendarDayCount() {
         assertEquals(
             1,


### PR DESCRIPTION
## Summary
- add DateRange.intersection(...) for retrieving the shared inclusive sub-range between two ranges
- cover boundary, contained, partial, and disjoint intersection behavior in common tests
- update README/README_KO, CHANGELOG, and ABI dumps for the new public API

## Validation
- ./gradlew :datetimepicker:test --no-daemon
- ./gradlew :datetimepicker:updateLegacyAbi --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon
- git diff --check origin/main...HEAD

## Notes
- Public API addition only; no breaking API change intended.