### PR TITLE
feat: add date range item coercion helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   values.
 - Added `DateRange.ordered(...)` factories so apps can normalize unordered start/end inputs from
   forms, presets, or restored state before passing them to `DateRangePickerState`.
+- Added `DatePickerItems.coerceDateRange(...)` so apps can normalize app-owned date range presets
+  with the same custom item lists and `minDate`/`maxDate` bounds used by `DateRangePicker`.
 - Added `DateRange.dayCount` so apps can display the inclusive number of calendar days in the
   selected range without recalculating epoch-day differences.
 - Added `DateRange.isSingleDay`, `DateRange.contains(DateRange)`, and `DateRange.overlaps(...)` so

--- a/README.md
+++ b/README.md
@@ -772,7 +772,10 @@ the selection after state creation, call `state.selectDateRange(...)`, `state.se
 or `state.selectEndDate(...)` with `DateRange`, `LocalDate`, or explicit year/month/day values.
 `DateRange` can also be created from explicit start/end year, month, and day parts. If app-owned
 start/end fields may be entered in either order, use `DateRange.ordered(startDate, endDate)` or the
-matching year/month/day overload before passing the value to state. Use `range.contains(year, month,
+matching year/month/day overload before passing the value to state. When custom `items` or
+`minDate`/`maxDate` bounds should normalize app-owned presets before state creation, use
+`items.coerceDateRange(...)`; it coerces both boundaries to the closest selectable dates and returns
+an ordered `DateRange`. Use `range.contains(year, month,
 day)` when app-owned form fields need an inclusive range check before creating a `LocalDate`. Use
 `date in range`, `childRange in range`, and `range.overlaps(blockedRange)` for inclusive date and
 range checks. Use `range.intersection(blockedRange)` when apps need the shared sub-range itself.

--- a/README_KO.md
+++ b/README_KO.md
@@ -763,8 +763,11 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 호출합니다.
 `DateRange`도 명시적인 시작/종료 year, month, day 값으로 만들 수 있습니다. 앱의 시작/종료 field가
 어느 순서로든 입력될 수 있다면 state에 전달하기 전에 `DateRange.ordered(startDate, endDate)` 또는
-대응되는 year/month/day overload를 사용하세요. 앱이 form field 값을 `LocalDate`로 만들기 전에
-inclusive range 포함 여부를 확인해야 한다면 `range.contains(year, month, day)`를 사용하세요.
+대응되는 year/month/day overload를 사용하세요. custom `items` 또는 `minDate`/`maxDate` 범위로
+앱이 소유한 preset 값을 state 생성 전에 정규화해야 한다면 `items.coerceDateRange(...)`를 사용하세요.
+이 helper는 양쪽 경계를 가장 가까운 선택 가능 날짜로 보정하고 정렬된 `DateRange`를 반환합니다. 앱이
+form field 값을 `LocalDate`로 만들기 전에 inclusive range 포함 여부를 확인해야 한다면
+`range.contains(year, month, day)`를 사용하세요.
 inclusive date와 range 확인에는 `date in range`, `childRange in range`,
 `range.overlaps(blockedRange)`를 사용할 수 있습니다. 앱이 공유되는 하위 범위 자체가 필요하다면
 `range.intersection(blockedRange)`를 사용하세요. 하루만 선택된 범위는 `range.isSingleDay`로 확인하고,

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -46,6 +46,9 @@ public final class com/kez/picker/DatePickerItems {
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/DatePickerConstraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun coerceDate (III)Lkotlinx/datetime/LocalDate;
 	public final fun coerceDate (Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/LocalDate;
+	public final fun coerceDateRange (IIIIII)Lcom/kez/picker/date/DateRange;
+	public final fun coerceDateRange (Lcom/kez/picker/date/DateRange;)Lcom/kez/picker/date/DateRange;
+	public final fun coerceDateRange (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -347,6 +347,9 @@ final class com.kez.picker/DatePickerItems { // com.kez.picker/DatePickerItems|n
 
     final fun coerceDate(kotlin/Int, kotlin/Int, kotlin/Int): kotlinx.datetime/LocalDate // com.kez.picker/DatePickerItems.coerceDate|coerceDate(kotlin.Int;kotlin.Int;kotlin.Int){}[0]
     final fun coerceDate(kotlinx.datetime/LocalDate): kotlinx.datetime/LocalDate // com.kez.picker/DatePickerItems.coerceDate|coerceDate(kotlinx.datetime.LocalDate){}[0]
+    final fun coerceDateRange(com.kez.picker.date/DateRange): com.kez.picker.date/DateRange // com.kez.picker/DatePickerItems.coerceDateRange|coerceDateRange(com.kez.picker.date.DateRange){}[0]
+    final fun coerceDateRange(kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int, kotlin/Int): com.kez.picker.date/DateRange // com.kez.picker/DatePickerItems.coerceDateRange|coerceDateRange(kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int;kotlin.Int){}[0]
+    final fun coerceDateRange(kotlinx.datetime/LocalDate, kotlinx.datetime/LocalDate): com.kez.picker.date/DateRange // com.kez.picker/DatePickerItems.coerceDateRange|coerceDateRange(kotlinx.datetime.LocalDate;kotlinx.datetime.LocalDate){}[0]
     final fun component1(): kotlin.collections/List<kotlin/Int> // com.kez.picker/DatePickerItems.component1|component1(){}[0]
     final fun component2(): kotlin.collections/List<kotlin/Int> // com.kez.picker/DatePickerItems.component2|component2(){}[0]
     final fun component3(): kotlin.collections/List<kotlin/Int> // com.kez.picker/DatePickerItems.component3|component3(){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -46,6 +46,9 @@ public final class com/kez/picker/DatePickerItems {
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/DatePickerConstraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun coerceDate (III)Lkotlinx/datetime/LocalDate;
 	public final fun coerceDate (Lkotlinx/datetime/LocalDate;)Lkotlinx/datetime/LocalDate;
+	public final fun coerceDateRange (IIIIII)Lcom/kez/picker/date/DateRange;
+	public final fun coerceDateRange (Lcom/kez/picker/date/DateRange;)Lcom/kez/picker/date/DateRange;
+	public final fun coerceDateRange (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lcom/kez/picker/date/DateRange;
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
@@ -1,5 +1,6 @@
 package com.kez.picker
 
+import com.kez.picker.date.DateRange
 import com.kez.picker.date.YearMonth
 import com.kez.picker.date.daysInMonth
 import com.kez.picker.util.TimeFormat
@@ -311,6 +312,58 @@ data class DatePickerItems(
      */
     fun coerceDate(year: Int, month: Int, day: Int): LocalDate =
         coerceDate(dateFromParts(year = year, month = month, day = day))
+
+    /**
+     * Returns the closest selectable ordered date range for [dateRange].
+     *
+     * Start and end dates are coerced independently using [coerceDate], then ordered so the returned
+     * [DateRange] always has `startDate <= endDate`. This is useful before creating
+     * [com.kez.picker.date.DateRangePickerState] or applying app-owned range presets with custom
+     * picker items.
+     *
+     * @throws IllegalArgumentException if the configured item lists are invalid.
+     */
+    fun coerceDateRange(dateRange: DateRange): DateRange =
+        coerceDateRange(
+            startDate = dateRange.startDate,
+            endDate = dateRange.endDate
+        )
+
+    /**
+     * Returns the closest selectable ordered date range for [startDate] and [endDate].
+     *
+     * Unlike [DateRange], this overload accepts unordered inputs so apps can normalize form,
+     * restored, or preset values in one step.
+     *
+     * @throws IllegalArgumentException if the configured item lists are invalid.
+     */
+    fun coerceDateRange(startDate: LocalDate, endDate: LocalDate): DateRange =
+        DateRange.ordered(
+            startDate = coerceDate(startDate),
+            endDate = coerceDate(endDate)
+        )
+
+    /**
+     * Returns the closest selectable ordered date range for explicit start and end date parts.
+     *
+     * If a day is greater than the maximum day for its year/month, it is clamped before applying this
+     * item's selectable values and date bounds.
+     *
+     * @throws IllegalArgumentException if any year/month/day value is outside its supported range, or
+     * if the configured item lists are invalid.
+     */
+    fun coerceDateRange(
+        startYear: Int,
+        startMonth: Int,
+        startDay: Int,
+        endYear: Int,
+        endMonth: Int,
+        endDay: Int
+    ): DateRange =
+        coerceDateRange(
+            startDate = dateFromParts(year = startYear, month = startMonth, day = startDay),
+            endDate = dateFromParts(year = endYear, month = endMonth, day = endDay)
+        )
 
     internal fun selectableYearItems(): List<Int> =
         yearItems.filter { year ->

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
@@ -486,10 +486,7 @@ class DateRangePickerState(
             "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate. " +
                     dateRangeOrderedAdvice()
         }
-        val coercedRange = orderedDateRange(
-            startDate = items.coerceDate(startDate),
-            endDate = items.coerceDate(endDate)
-        )
+        val coercedRange = items.coerceDateRange(startDate = startDate, endDate = endDate)
         selectDateRange(
             startDate = coercedRange.startDate,
             endDate = coercedRange.endDate

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DatePickerStateTest.kt
@@ -447,6 +447,76 @@ class DatePickerStateTest {
     }
 
     @Test
+    fun datePickerItems_coerceDateRangeValue_respectsDateConstraints() {
+        val items = DatePickerItems(
+            yearItems = listOf(2026),
+            monthItems = (1..12).toList(),
+            dayItems = (1..31).toList(),
+            constraints = DatePickerConstraints(
+                minDate = LocalDate(year = 2026, month = Month.MAY, day = 10),
+                maxDate = LocalDate(year = 2026, month = Month.JUNE, day = 20)
+            )
+        )
+
+        assertEquals(
+            DateRange(
+                startDate = LocalDate(year = 2026, month = Month.MAY, day = 10),
+                endDate = LocalDate(year = 2026, month = Month.JUNE, day = 20)
+            ),
+            items.coerceDateRange(
+                DateRange(
+                    startDate = LocalDate(year = 2026, month = Month.JANUARY, day = 1),
+                    endDate = LocalDate(year = 2026, month = Month.DECEMBER, day = 31)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun datePickerItems_coerceDateRangeDates_ordersCoercedBoundaries() {
+        val items = DatePickerItems(
+            yearItems = listOf(2026),
+            monthItems = listOf(5),
+            dayItems = listOf(1, 10, 20)
+        )
+
+        assertEquals(
+            DateRange(
+                startDate = LocalDate(year = 2026, month = Month.MAY, day = 1),
+                endDate = LocalDate(year = 2026, month = Month.MAY, day = 20)
+            ),
+            items.coerceDateRange(
+                startDate = LocalDate(year = 2026, month = Month.MAY, day = 20),
+                endDate = LocalDate(year = 2026, month = Month.MAY, day = 1)
+            )
+        )
+    }
+
+    @Test
+    fun datePickerItems_coerceDateRangeParts_clampsInvalidDaysBeforeCoercing() {
+        val items = DatePickerItems(
+            yearItems = listOf(2026),
+            monthItems = listOf(2, 3),
+            dayItems = listOf(28, 31)
+        )
+
+        assertEquals(
+            DateRange(
+                startDate = LocalDate(year = 2026, month = Month.FEBRUARY, day = 28),
+                endDate = LocalDate(year = 2026, month = Month.MARCH, day = 31)
+            ),
+            items.coerceDateRange(
+                startYear = 2026,
+                startMonth = 3,
+                startDay = 31,
+                endYear = 2026,
+                endMonth = 2,
+                endDay = 31
+            )
+        )
+    }
+
+    @Test
     fun datePickerItems_coerceDate_throwsActionableMessageWhenConstraintsFilterEveryDate() {
         val items = DatePickerItems(
             yearItems = listOf(2026),


### PR DESCRIPTION
## Summary
- Add `DatePickerItems.coerceDateRange(...)` overloads for `DateRange`, `LocalDate` boundaries, and primitive date parts.
- Reuse the helper from `DateRangePickerState.selectDateRange(..., items)` so state and app code share the same custom item / min-max coercion behavior.
- Document the helper in README/README_KO/CHANGELOG and update ABI dumps.

## Verification
- `./gradlew :datetimepicker:test --no-daemon`
- `./gradlew :datetimepicker:updateLegacyAbi --no-daemon`
- `./gradlew :datetimepicker:checkLegacyAbi --no-daemon`
- `git diff --check origin/main...HEAD`

## ABI
- Adds three public `DatePickerItems.coerceDateRange(...)` overloads.
- No preview/generated resource churn observed in ABI dumps.