### PR TITLE
fix: coerce unordered date range initial items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Fixed sample picker interaction issues where long month labels were clipped, dependent date columns
   could refresh while another column was still scrolling, and the date range sample started from a
   one-day range that made end-date movement look like a reset on the first start-date change.
+- `rememberDateRangePickerState(items = ..., initialStartDate = ..., initialEndDate = ...)` now
+  accepts unordered initial boundaries, coerces each boundary with the provided date picker items,
+  and creates an ordered initial range.
 - Fixed picker row height calculation and default vertical item padding so selected text no longer
   appears clipped against the selection dividers.
 - Fixed picker row height consistency across mixed Korean, numeric, and Latin font fallback so

--- a/README.md
+++ b/README.md
@@ -774,8 +774,9 @@ or `state.selectEndDate(...)` with `DateRange`, `LocalDate`, or explicit year/mo
 start/end fields may be entered in either order, use `DateRange.ordered(startDate, endDate)` or the
 matching year/month/day overload before passing the value to state. When custom `items` or
 `minDate`/`maxDate` bounds should normalize app-owned presets before state creation, use
-`items.coerceDateRange(...)`; it coerces both boundaries to the closest selectable dates and returns
-an ordered `DateRange`. Use `range.contains(year, month,
+`items.coerceDateRange(...)` or `rememberDateRangePickerState(items = ..., initialStartDate = ...,
+initialEndDate = ...)`; they coerce both boundaries to the closest selectable dates and return or
+create an ordered `DateRange`. Use `range.contains(year, month,
 day)` when app-owned form fields need an inclusive range check before creating a `LocalDate`. Use
 `date in range`, `childRange in range`, and `range.overlaps(blockedRange)` for inclusive date and
 range checks. Use `range.intersection(blockedRange)` when apps need the shared sub-range itself.

--- a/README_KO.md
+++ b/README_KO.md
@@ -765,9 +765,10 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 어느 순서로든 입력될 수 있다면 state에 전달하기 전에 `DateRange.ordered(startDate, endDate)` 또는
 대응되는 year/month/day overload를 사용하세요. custom `items` 또는 `minDate`/`maxDate` 범위로
 앱이 소유한 preset 값을 state 생성 전에 정규화해야 한다면 `items.coerceDateRange(...)`를 사용하세요.
-이 helper는 양쪽 경계를 가장 가까운 선택 가능 날짜로 보정하고 정렬된 `DateRange`를 반환합니다. 앱이
-form field 값을 `LocalDate`로 만들기 전에 inclusive range 포함 여부를 확인해야 한다면
-`range.contains(year, month, day)`를 사용하세요.
+또는 `rememberDateRangePickerState(items = ..., initialStartDate = ..., initialEndDate = ...)`를
+사용하세요. 이 API들은 양쪽 경계를 가장 가까운 선택 가능 날짜로 보정하고 정렬된 `DateRange`를
+반환하거나 생성합니다. 앱이 form field 값을 `LocalDate`로 만들기 전에 inclusive range 포함 여부를
+확인해야 한다면 `range.contains(year, month, day)`를 사용하세요.
 inclusive date와 range 확인에는 `date in range`, `childRange in range`,
 `range.overlaps(blockedRange)`를 사용할 수 있습니다. 앱이 공유되는 하위 범위 자체가 필요하다면
 `range.intersection(blockedRange)`를 사용하세요. 하루만 선택된 범위는 `range.isSingleDay`로 확인하고,

--- a/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
+++ b/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
@@ -300,6 +300,36 @@ class PickerStateRestorationRobolectricTest {
     }
 
     @Test
+    fun rememberDateRangePickerState_withItemsAndUnorderedDatesCoercesInitialSelection() {
+        lateinit var state: DateRangePickerState
+        val items = PickerDefaults.datePickerItems(
+            yearItems = listOf(2026),
+            monthItems = (1..12).toList(),
+            dayItems = (1..31).toList(),
+            minDate = LocalDate(2026, 5, 10),
+            maxDate = LocalDate(2026, 6, 20)
+        )
+
+        composeRule.setContent {
+            state = rememberDateRangePickerState(
+                items = items,
+                initialStartDate = LocalDate(2026, 12, 31),
+                initialEndDate = LocalDate(2026, 1, 1)
+            )
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(
+                DateRange(
+                    startDate = LocalDate(2026, 5, 10),
+                    endDate = LocalDate(2026, 6, 20)
+                ),
+                state.selectedDateRange
+            )
+        }
+    }
+
+    @Test
     fun rememberDateRangePickerState_restoresProgrammaticSelectionSummaryAfterSaveRestore() {
         lateinit var state: DateRangePickerState
         val restorationTester = StateRestorationTester(composeRule)

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
@@ -236,6 +236,8 @@ fun rememberDateRangePickerState(
  * Creates and remembers a [DateRangePickerState] whose initial values are coerced by [items].
  *
  * Initial values and [items] are read when the state is first created.
+ * This overload accepts unordered [initialStartDate] and [initialEndDate] values. Both dates are
+ * coerced by [items] and then ordered before the state is created.
  *
  * @param items Selectable values used to coerce [initialStartDate] and [initialEndDate].
  * @param initialStartDate The requested range start date.
@@ -256,15 +258,9 @@ fun rememberDateRangePickerState(
         rememberedInitialStartDate,
         rememberedInitialEndDate
     ) {
-        require(rememberedInitialStartDate <= rememberedInitialEndDate) {
-            "initialStartDate must be on or before initialEndDate. " +
-                    "initialStartDate=$rememberedInitialStartDate, " +
-                    "initialEndDate=$rememberedInitialEndDate. " +
-                    dateRangeOrderedAdvice()
-        }
-        orderedDateRange(
-            startDate = rememberedItems.coerceDate(rememberedInitialStartDate),
-            endDate = rememberedItems.coerceDate(rememberedInitialEndDate)
+        rememberedItems.coerceDateRange(
+            startDate = rememberedInitialStartDate,
+            endDate = rememberedInitialEndDate
         )
     }
     return rememberDateRangePickerState(
@@ -300,6 +296,7 @@ fun rememberDateRangePickerState(
  *
  * Initial values and [items] are read when the state is first created. If a day is greater than the
  * maximum day for its year/month, it is clamped before [items] coercion.
+ * This overload accepts unordered resulting dates and orders them before the state is created.
  *
  * @param items Selectable values used to coerce the requested start and end dates.
  * @param initialStartYear The requested range start year.
@@ -645,9 +642,6 @@ private fun dateFromParts(year: Int, month: Int, day: Int): LocalDate {
         day = day.coerceAtMost(daysInMonth(year, month))
     )
 }
-
-private fun orderedDateRange(startDate: LocalDate, endDate: LocalDate): DateRange =
-    DateRange.ordered(startDate = startDate, endDate = endDate)
 
 private fun dateRangeOrderedAdvice(): String =
     "If app-owned start/end inputs may arrive in either order, use DateRange.ordered(...) before " +


### PR DESCRIPTION
## Summary
- Let `rememberDateRangePickerState(items = ..., initialStartDate = ..., initialEndDate = ...)` accept unordered initial boundaries.
- Reuse `DatePickerItems.coerceDateRange(...)` so both boundaries are coerced with custom date items/min-max bounds and then ordered before first composition.
- Add Robolectric coverage and update README/README_KO/CHANGELOG guidance.

## Verification
- `./gradlew :datetimepicker:testDebugUnitTest --no-daemon`
- `./gradlew :datetimepicker:checkLegacyAbi --no-daemon`
- `git diff --check origin/main...HEAD`

## ABI
- No public signature changes. `datetimepicker/api/` diff is empty.