### PR TITLE
fix: coerce unordered date range item selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - `rememberDateRangePickerState(items = ..., initialStartDate = ..., initialEndDate = ...)` now
   accepts unordered initial boundaries, coerces each boundary with the provided date picker items,
   and creates an ordered initial range.
+- `DateRangePickerState.selectDateRange(..., items)` now accepts unordered boundaries, coerces each
+  boundary with the provided date picker items, and selects an ordered range.
 - Fixed picker row height calculation and default vertical item padding so selected text no longer
   appears clipped against the selection dividers.
 - Fixed picker row height consistency across mixed Korean, numeric, and Latin font fallback so

--- a/README.md
+++ b/README.md
@@ -773,10 +773,10 @@ or `state.selectEndDate(...)` with `DateRange`, `LocalDate`, or explicit year/mo
 `DateRange` can also be created from explicit start/end year, month, and day parts. If app-owned
 start/end fields may be entered in either order, use `DateRange.ordered(startDate, endDate)` or the
 matching year/month/day overload before passing the value to state. When custom `items` or
-`minDate`/`maxDate` bounds should normalize app-owned presets before state creation, use
-`items.coerceDateRange(...)` or `rememberDateRangePickerState(items = ..., initialStartDate = ...,
-initialEndDate = ...)`; they coerce both boundaries to the closest selectable dates and return or
-create an ordered `DateRange`. Use `range.contains(year, month,
+`minDate`/`maxDate` bounds should normalize app-owned presets, use `items.coerceDateRange(...)`,
+`rememberDateRangePickerState(items = ..., initialStartDate = ..., initialEndDate = ...)`, or the
+`state.selectDateRange(..., items)` overloads; they coerce both boundaries to the closest selectable
+dates and return, create, or select an ordered `DateRange`. Use `range.contains(year, month,
 day)` when app-owned form fields need an inclusive range check before creating a `LocalDate`. Use
 `date in range`, `childRange in range`, and `range.overlaps(blockedRange)` for inclusive date and
 range checks. Use `range.intersection(blockedRange)` when apps need the shared sub-range itself.

--- a/README_KO.md
+++ b/README_KO.md
@@ -764,11 +764,12 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 목록
 `DateRange`도 명시적인 시작/종료 year, month, day 값으로 만들 수 있습니다. 앱의 시작/종료 field가
 어느 순서로든 입력될 수 있다면 state에 전달하기 전에 `DateRange.ordered(startDate, endDate)` 또는
 대응되는 year/month/day overload를 사용하세요. custom `items` 또는 `minDate`/`maxDate` 범위로
-앱이 소유한 preset 값을 state 생성 전에 정규화해야 한다면 `items.coerceDateRange(...)`를 사용하세요.
-또는 `rememberDateRangePickerState(items = ..., initialStartDate = ..., initialEndDate = ...)`를
-사용하세요. 이 API들은 양쪽 경계를 가장 가까운 선택 가능 날짜로 보정하고 정렬된 `DateRange`를
-반환하거나 생성합니다. 앱이 form field 값을 `LocalDate`로 만들기 전에 inclusive range 포함 여부를
-확인해야 한다면 `range.contains(year, month, day)`를 사용하세요.
+앱이 소유한 preset 값을 정규화해야 한다면 `items.coerceDateRange(...)`,
+`rememberDateRangePickerState(items = ..., initialStartDate = ..., initialEndDate = ...)`, 또는
+`state.selectDateRange(..., items)` overload를 사용하세요. 이 API들은 양쪽 경계를 가장 가까운 선택
+가능 날짜로 보정하고 정렬된 `DateRange`를 반환, 생성, 또는 선택합니다. 앱이 form field 값을
+`LocalDate`로 만들기 전에 inclusive range 포함 여부를 확인해야 한다면
+`range.contains(year, month, day)`를 사용하세요.
 inclusive date와 range 확인에는 `date in range`, `childRange in range`,
 `range.overlaps(blockedRange)`를 사용할 수 있습니다. 앱이 공유되는 하위 범위 자체가 필요하다면
 `range.intersection(blockedRange)`를 사용하세요. 하루만 선택된 범위는 `range.isSingleDay`로 확인하고,

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DateRangePickerState.kt
@@ -477,12 +477,11 @@ class DateRangePickerState(
 
     /**
      * Programmatically selects the closest date range allowed by [items].
+     *
+     * This overload accepts unordered [startDate] and [endDate] values. Both dates are coerced by
+     * [items] and then ordered before selection.
      */
     fun selectDateRange(startDate: LocalDate, endDate: LocalDate, items: DatePickerItems) {
-        require(startDate <= endDate) {
-            "startDate must be on or before endDate. startDate=$startDate, endDate=$endDate. " +
-                    dateRangeOrderedAdvice()
-        }
         val coercedRange = items.coerceDateRange(startDate = startDate, endDate = endDate)
         selectDateRange(
             startDate = coercedRange.startDate,
@@ -505,7 +504,7 @@ class DateRangePickerState(
      * Programmatically selects the closest date range to the requested date parts allowed by [items].
      *
      * If a day is greater than the maximum day for its year/month, it is clamped before [items]
-     * coercion.
+     * coercion. This overload accepts unordered resulting dates and orders them before selection.
      */
     fun selectDateRange(
         startYear: Int,

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/date/DateRangePickerStateTest.kt
@@ -497,6 +497,37 @@ class DateRangePickerStateTest {
     }
 
     @Test
+    fun dateRangePickerState_selectDateRangeWithItems_ordersUnorderedSelection() {
+        val state = DateRangePickerState(
+            initialStartDate = LocalDate(2026, 5, 10),
+            initialEndDate = LocalDate(2026, 6, 10)
+        )
+        val items = DatePickerItems(
+            yearItems = listOf(2026),
+            monthItems = (1..12).toList(),
+            dayItems = (1..31).toList(),
+            constraints = DatePickerConstraints(
+                minDate = LocalDate(2026, Month.MAY, 10),
+                maxDate = LocalDate(2026, Month.JUNE, 20)
+            )
+        )
+
+        state.selectDateRange(
+            startDate = LocalDate(2026, Month.DECEMBER, 31),
+            endDate = LocalDate(2026, Month.JANUARY, 1),
+            items = items
+        )
+
+        assertEquals(
+            DateRange(
+                startDate = LocalDate(2026, Month.MAY, 10),
+                endDate = LocalDate(2026, Month.JUNE, 20)
+            ),
+            state.selectedDateRange
+        )
+    }
+
+    @Test
     fun dateRangePickerState_selectDateRangePartsWithItems_coercesSelection() {
         val state = DateRangePickerState(
             initialStartDate = LocalDate(2026, 5, 10),


### PR DESCRIPTION
## Summary
- Let `DateRangePickerState.selectDateRange(..., items)` accept unordered boundaries.
- Reuse `DatePickerItems.coerceDateRange(...)` so programmatic presets get the same custom item/min-max coercion and ordering as initial state.
- Add common state coverage and update README/README_KO/CHANGELOG guidance.

## Verification
- `./gradlew :datetimepicker:test --no-daemon`
- `./gradlew :datetimepicker:checkLegacyAbi --no-daemon`
- `git diff --check origin/main...HEAD`

## ABI
- No public signature changes. `datetimepicker/api/` diff is empty.