### PR TITLE
docs: show date range year bounds preset

### DIFF
--- a/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
+++ b/sample/src/androidInstrumentedTest/kotlin/com/kez/picker/sample/SampleAppSmokeAndroidTest.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.kez.picker.date.DateRange
 import com.kez.picker.util.currentDate
+import kotlinx.datetime.LocalDate
 import org.junit.Rule
 import org.junit.Test
 
@@ -76,8 +78,14 @@ class SampleAppSmokeAndroidTest {
     @Test
     fun dateRangePickerMenuAction_updatesSelectedRangeFromButtons() {
         val today = currentDate()
-        val expectedSummary = "Selected range, $today..$today, Single day. Days selected: 1. " +
+        val expectedTodaySummary = "Selected range, $today..$today, Single day. Days selected: 1. " +
                 "Last user change: No user change. Selectable year: ${today.year}"
+        val yearStart = LocalDate(today.year, 1, 1)
+        val yearEnd = LocalDate(today.year, 12, 31)
+        val expectedYearRange = DateRange(startDate = yearStart, endDate = yearEnd)
+        val expectedYearSummary = "Selected range, $yearStart..$yearEnd, Date range. " +
+                "Days selected: ${expectedYearRange.dayCount}. Last user change: No user change. " +
+                "Selectable year: ${today.year}"
 
         composeRule
             .onNodeWithTag("sample-menu-date-range-picker")
@@ -93,7 +101,15 @@ class SampleAppSmokeAndroidTest {
             .performClick()
 
         composeRule
-            .onNode(hasContentDescriptionStartingWith(expectedSummary))
+            .onNode(hasContentDescriptionStartingWith(expectedTodaySummary))
+            .assertIsDisplayed()
+
+        composeRule
+            .onNodeWithText("Year bounds")
+            .performClick()
+
+        composeRule
+            .onNode(hasContentDescriptionStartingWith(expectedYearSummary))
             .assertIsDisplayed()
     }
 

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DateRangePickerSampleScreen.kt
@@ -132,6 +132,19 @@ internal fun DateRangePickerSampleScreen(
                 ) {
                     Text("Today only")
                 }
+
+                OutlinedButton(
+                    onClick = {
+                        state.selectDateRange(
+                            startDate = yearEnd,
+                            endDate = yearStart,
+                            items = items
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Year bounds")
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
## Summary
- Add a DateRange sample preset that intentionally passes unordered year boundary dates to `state.selectDateRange(..., items)`.
- Extend the sample smoke test to assert the year-bounds preset summary and inclusive day count.

## Verification
- `./gradlew :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution :sample:assembleDebugAndroidTest --no-daemon`
- `git diff --check origin/main...HEAD`

## Notes
- The Wasm webpack task emitted existing bundle-size warnings but completed successfully.