### PR TITLE
feat: add 12-hour display time coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 - Added `TimePickerItems.coerceTime(hour, minute, timeFormat)` and
   `rememberTimePickerState(items = ..., initialHour = ..., initialMinute = ...)` for apps that store
   time form state as primitive fields.
+- Added `TimePickerItems.coerceTime(displayHour, minute, period)`,
+  `TimePickerItems.contains(displayHour, minute, period)`, and matching
+  `TimePickerState.selectTime(displayHour, minute, period, ...)` overloads for apps that store
+  12-hour form state as display-hour plus AM/PM values.
 - Added `remember*State(items = ..., initial... = ...)` overloads so initial picker state can be
   coerced by the same custom item lists before first composition.
 - Added `rememberYearMonthPickerState(initialYearMonth = ...)` and the matching `items` overload so

--- a/README.md
+++ b/README.md
@@ -703,7 +703,10 @@ or parts should be coerced before first composition.
 To change the selection after state creation, call `state.selectTime(LocalTime(...))` or
 `state.selectTime(hour, minute)`. Use the overloads that accept `items` when custom item lists or
 time bounds should be applied at the same time. The integer hour is interpreted as hour-of-day in
-`0..23`.
+`0..23`. If app-owned 12-hour form or preset values are stored as a display hour plus AM/PM, use
+`items.coerceTime(displayHour = ..., minute = ..., period = ...)` or
+`state.selectTime(displayHour = ..., minute = ..., period = ..., items = ...)`; `displayHour` is in
+`1..12`.
 
 Invalid custom item values, duplicate items, empty required lists, or current selections missing from custom lists or time bounds throw `IllegalArgumentException` during composition. Treat custom item lists as immutable after passing them to the picker; create a new `items` object when available values change. In 12-hour mode, `PickerDefaults.timePickerItems(hour12Items = ...)` uses format-hour values (`1..12`): `initialHour = 13` becomes `state.selectedHour == 1` with `PM`.
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -693,7 +693,11 @@ DatePicker(
 
 상태 생성 이후 선택값을 바꾸려면 `state.selectTime(LocalTime(...))` 또는
 `state.selectTime(hour, minute)`을 호출합니다. custom item 목록이나 시간 범위를 함께 적용해야 한다면
-`items`를 받는 overload를 사용하세요. 정수 `hour`는 `0..23` 범위의 hour-of-day로 해석됩니다.
+`items`를 받는 overload를 사용하세요. 정수 `hour`는 `0..23` 범위의 hour-of-day로 해석됩니다. 앱이
+소유한 12시간제 form 또는 preset 값이 표시 시간과 AM/PM으로 저장된다면
+`items.coerceTime(displayHour = ..., minute = ..., period = ...)` 또는
+`state.selectTime(displayHour = ..., minute = ..., period = ..., items = ...)`를 사용하세요.
+`displayHour`는 `1..12` 범위입니다.
 
 custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 필수 목록이 비어 있거나, 현재 선택값이 custom 목록 또는 시간 범위 밖이면 composition 중 `IllegalArgumentException`이 발생합니다. custom item 목록은 picker에 전달한 뒤 불변으로 다루고, 선택 가능한 값이 바뀌면 새 `items` 객체를 만들어 전달하세요. 12시간 형식의 `PickerDefaults.timePickerItems(hour12Items = ...)`는 표시 시간 기준(`1..12`)입니다. 예를 들어 `initialHour = 13`은 `state.selectedHour == 1`, `PM`으로 변환됩니다.
 

--- a/datetimepicker/api/android/datetimepicker.api
+++ b/datetimepicker/api/android/datetimepicker.api
@@ -400,6 +400,7 @@ public final class com/kez/picker/TimePickerItems {
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/TimePickerConstraints;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/TimePickerConstraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun coerceTime (IILcom/kez/picker/util/TimeFormat;)Lkotlinx/datetime/LocalTime;
+	public final fun coerceTime (IILcom/kez/picker/util/TimePeriod;)Lkotlinx/datetime/LocalTime;
 	public final fun coerceTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)Lkotlinx/datetime/LocalTime;
 	public static synthetic fun coerceTime$default (Lcom/kez/picker/TimePickerItems;IILcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Lkotlinx/datetime/LocalTime;
 	public static synthetic fun coerceTime$default (Lcom/kez/picker/TimePickerItems;Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Lkotlinx/datetime/LocalTime;
@@ -409,6 +410,7 @@ public final class com/kez/picker/TimePickerItems {
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Lcom/kez/picker/TimePickerConstraints;
 	public final fun contains (IILcom/kez/picker/util/TimeFormat;)Z
+	public final fun contains (IILcom/kez/picker/util/TimePeriod;)Z
 	public final fun contains (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)Z
 	public static synthetic fun contains$default (Lcom/kez/picker/TimePickerItems;IILcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Z
 	public static synthetic fun contains$default (Lcom/kez/picker/TimePickerItems;Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Z
@@ -779,6 +781,8 @@ public final class com/kez/picker/time/TimePickerState {
 	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
 	public final fun selectTime (II)V
 	public final fun selectTime (IILcom/kez/picker/TimePickerItems;)V
+	public final fun selectTime (IILcom/kez/picker/util/TimePeriod;)V
+	public final fun selectTime (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/TimePickerItems;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/TimePickerItems;)V
 }

--- a/datetimepicker/api/datetimepicker.klib.api
+++ b/datetimepicker/api/datetimepicker.klib.api
@@ -287,6 +287,8 @@ final class com.kez.picker.time/TimePickerState { // com.kez.picker.time/TimePic
         final fun <get-timeFormat>(): com.kez.picker.util/TimeFormat // com.kez.picker.time/TimePickerState.timeFormat.<get-timeFormat>|<get-timeFormat>(){}[0]
 
     final fun selectTime(kotlin/Int, kotlin/Int) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlin.Int;kotlin.Int){}[0]
+    final fun selectTime(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod){}[0]
+    final fun selectTime(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod, com.kez.picker/TimePickerItems) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod;com.kez.picker.TimePickerItems){}[0]
     final fun selectTime(kotlin/Int, kotlin/Int, com.kez.picker/TimePickerItems) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlin.Int;kotlin.Int;com.kez.picker.TimePickerItems){}[0]
     final fun selectTime(kotlinx.datetime/LocalTime) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlinx.datetime.LocalTime){}[0]
     final fun selectTime(kotlinx.datetime/LocalTime, com.kez.picker/TimePickerItems) // com.kez.picker.time/TimePickerState.selectTime|selectTime(kotlinx.datetime.LocalTime;com.kez.picker.TimePickerItems){}[0]
@@ -610,6 +612,7 @@ final class com.kez.picker/TimePickerItems { // com.kez.picker/TimePickerItems|n
         final fun <get-periodItems>(): kotlin.collections/List<com.kez.picker.util/TimePeriod> // com.kez.picker/TimePickerItems.periodItems.<get-periodItems>|<get-periodItems>(){}[0]
 
     final fun coerceTime(kotlin/Int, kotlin/Int, com.kez.picker.util/TimeFormat = ...): kotlinx.datetime/LocalTime // com.kez.picker/TimePickerItems.coerceTime|coerceTime(kotlin.Int;kotlin.Int;com.kez.picker.util.TimeFormat){}[0]
+    final fun coerceTime(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod): kotlinx.datetime/LocalTime // com.kez.picker/TimePickerItems.coerceTime|coerceTime(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod){}[0]
     final fun coerceTime(kotlinx.datetime/LocalTime, com.kez.picker.util/TimeFormat = ...): kotlinx.datetime/LocalTime // com.kez.picker/TimePickerItems.coerceTime|coerceTime(kotlinx.datetime.LocalTime;com.kez.picker.util.TimeFormat){}[0]
     final fun component1(): kotlin.collections/List<kotlin/Int> // com.kez.picker/TimePickerItems.component1|component1(){}[0]
     final fun component2(): kotlin.collections/List<kotlin/Int> // com.kez.picker/TimePickerItems.component2|component2(){}[0]
@@ -617,6 +620,7 @@ final class com.kez.picker/TimePickerItems { // com.kez.picker/TimePickerItems|n
     final fun component4(): kotlin.collections/List<com.kez.picker.util/TimePeriod> // com.kez.picker/TimePickerItems.component4|component4(){}[0]
     final fun component5(): com.kez.picker/TimePickerConstraints // com.kez.picker/TimePickerItems.component5|component5(){}[0]
     final fun contains(kotlin/Int, kotlin/Int, com.kez.picker.util/TimeFormat = ...): kotlin/Boolean // com.kez.picker/TimePickerItems.contains|contains(kotlin.Int;kotlin.Int;com.kez.picker.util.TimeFormat){}[0]
+    final fun contains(kotlin/Int, kotlin/Int, com.kez.picker.util/TimePeriod): kotlin/Boolean // com.kez.picker/TimePickerItems.contains|contains(kotlin.Int;kotlin.Int;com.kez.picker.util.TimePeriod){}[0]
     final fun contains(kotlinx.datetime/LocalTime, com.kez.picker.util/TimeFormat = ...): kotlin/Boolean // com.kez.picker/TimePickerItems.contains|contains(kotlinx.datetime.LocalTime;com.kez.picker.util.TimeFormat){}[0]
     final fun copy(kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<com.kez.picker.util/TimePeriod> = ..., com.kez.picker/TimePickerConstraints = ...): com.kez.picker/TimePickerItems // com.kez.picker/TimePickerItems.copy|copy(kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<com.kez.picker.util.TimePeriod>;com.kez.picker.TimePickerConstraints){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // com.kez.picker/TimePickerItems.equals|equals(kotlin.Any?){}[0]

--- a/datetimepicker/api/desktop/datetimepicker.api
+++ b/datetimepicker/api/desktop/datetimepicker.api
@@ -400,6 +400,7 @@ public final class com/kez/picker/TimePickerItems {
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/TimePickerConstraints;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/kez/picker/TimePickerConstraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun coerceTime (IILcom/kez/picker/util/TimeFormat;)Lkotlinx/datetime/LocalTime;
+	public final fun coerceTime (IILcom/kez/picker/util/TimePeriod;)Lkotlinx/datetime/LocalTime;
 	public final fun coerceTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)Lkotlinx/datetime/LocalTime;
 	public static synthetic fun coerceTime$default (Lcom/kez/picker/TimePickerItems;IILcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Lkotlinx/datetime/LocalTime;
 	public static synthetic fun coerceTime$default (Lcom/kez/picker/TimePickerItems;Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Lkotlinx/datetime/LocalTime;
@@ -409,6 +410,7 @@ public final class com/kez/picker/TimePickerItems {
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Lcom/kez/picker/TimePickerConstraints;
 	public final fun contains (IILcom/kez/picker/util/TimeFormat;)Z
+	public final fun contains (IILcom/kez/picker/util/TimePeriod;)Z
 	public final fun contains (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;)Z
 	public static synthetic fun contains$default (Lcom/kez/picker/TimePickerItems;IILcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Z
 	public static synthetic fun contains$default (Lcom/kez/picker/TimePickerItems;Lkotlinx/datetime/LocalTime;Lcom/kez/picker/util/TimeFormat;ILjava/lang/Object;)Z
@@ -779,6 +781,8 @@ public final class com/kez/picker/time/TimePickerState {
 	public final fun getTimeFormat ()Lcom/kez/picker/util/TimeFormat;
 	public final fun selectTime (II)V
 	public final fun selectTime (IILcom/kez/picker/TimePickerItems;)V
+	public final fun selectTime (IILcom/kez/picker/util/TimePeriod;)V
+	public final fun selectTime (IILcom/kez/picker/util/TimePeriod;Lcom/kez/picker/TimePickerItems;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;)V
 	public final fun selectTime (Lkotlinx/datetime/LocalTime;Lcom/kez/picker/TimePickerItems;)V
 }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/PickerItems.kt
@@ -95,6 +95,24 @@ data class TimePickerItems(
     }
 
     /**
+     * Returns whether [displayHour], [minute], and [period] are directly selectable in 12-hour mode.
+     *
+     * [displayHour] is interpreted as the format-hour shown to users in `1..12`. Values outside the
+     * supported display-hour or minute ranges return false.
+     */
+    fun contains(displayHour: Int, minute: Int, period: TimePeriod): Boolean {
+        if (displayHour !in 1..12 || minute !in 0..59) return false
+        return contains(
+            time = displayTimeFromParts(
+                displayHour = displayHour,
+                minute = minute,
+                period = period
+            ),
+            timeFormat = TimeFormat.HOUR_12
+        )
+    }
+
+    /**
      * Returns the closest selectable time for [time] under [timeFormat].
      *
      * This is useful before calling [com.kez.picker.time.TimePickerState.selectTime] when app-owned
@@ -124,6 +142,26 @@ data class TimePickerItems(
         coerceTime(
             time = LocalTime(hour = hour, minute = minute),
             timeFormat = timeFormat
+        )
+
+    /**
+     * Returns the closest selectable time for a 12-hour display value.
+     *
+     * [displayHour] is interpreted as the format-hour shown to users in `1..12`; [period] supplies
+     * AM/PM. This is useful when app-owned form or preset values are stored as a display hour plus
+     * period instead of a 24-hour [LocalTime].
+     *
+     * @throws IllegalArgumentException if [displayHour] is outside `1..12`, [minute] is outside
+     * `0..59`, or the 12-hour item lists are invalid.
+     */
+    fun coerceTime(displayHour: Int, minute: Int, period: TimePeriod): LocalTime =
+        coerceTime(
+            time = displayTimeFromParts(
+                displayHour = displayHour,
+                minute = minute,
+                period = period
+            ),
+            timeFormat = TimeFormat.HOUR_12
         )
 
     internal fun hourItemsFor(timeFormat: TimeFormat): List<Int> =
@@ -656,3 +694,16 @@ private fun hourOfDayFor(displayHour: Int, period: TimePeriod): Int =
         period == TimePeriod.PM && displayHour != 12 -> displayHour + 12
         else -> displayHour
     }
+
+private fun displayTimeFromParts(displayHour: Int, minute: Int, period: TimePeriod): LocalTime {
+    require(displayHour in 1..12) {
+        "displayHour must be in range [1, 12], but was $displayHour"
+    }
+    require(minute in 0..59) {
+        "minute must be in range [0, 59], but was $minute"
+    }
+    return LocalTime(
+        hour = hourOfDayFor(displayHour = displayHour, period = period),
+        minute = minute
+    )
+}

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
@@ -193,6 +193,21 @@ private fun initialTimeFromParts(
     return LocalTime(hour = hourOfDay, minute = initialMinute)
 }
 
+private fun displayTimeFromParts(displayHour: Int, minute: Int, period: TimePeriod): LocalTime {
+    require(displayHour in 1..12) {
+        "displayHour must be in range [1, 12], but was $displayHour"
+    }
+    require(minute in 0..59) {
+        "minute must be in range [0, 59], but was $minute"
+    }
+    val hourOfDay = when {
+        period == TimePeriod.AM && displayHour == 12 -> 0
+        period == TimePeriod.PM && displayHour != 12 -> displayHour + 12
+        else -> displayHour
+    }
+    return LocalTime(hour = hourOfDay, minute = minute)
+}
+
 private fun timePickerStateSaver(timeFormat: TimeFormat): Saver<TimePickerState, Any> {
     return listSaver(
         save = { listOf(it.selectedHourOfDay, it.selectedMinute) },
@@ -322,6 +337,19 @@ class TimePickerState(
     }
 
     /**
+     * Programmatically selects a time from a 12-hour display value.
+     *
+     * [displayHour] is interpreted as the format-hour shown to users in `1..12`; [period] supplies
+     * AM/PM. The resulting time is stored as [selectedTime] and rendered in this state's
+     * [timeFormat].
+     *
+     * @throws IllegalArgumentException if [displayHour] or [minute] is outside the supported range.
+     */
+    fun selectTime(displayHour: Int, minute: Int, period: TimePeriod) {
+        selectTime(displayTimeFromParts(displayHour = displayHour, minute = minute, period = period))
+    }
+
+    /**
      * Programmatically selects the closest time to [time] that is allowed by [items].
      *
      * Use this overload when app-owned state can contain values outside custom picker lists or
@@ -338,6 +366,16 @@ class TimePickerState(
      */
     fun selectTime(hour: Int, minute: Int, items: TimePickerItems) {
         selectTime(LocalTime(hour = hour, minute = minute), items)
+    }
+
+    /**
+     * Programmatically selects the closest time to a 12-hour display value allowed by [items].
+     *
+     * [displayHour] is interpreted as the format-hour shown to users in `1..12`; [period] supplies
+     * AM/PM.
+     */
+    fun selectTime(displayHour: Int, minute: Int, period: TimePeriod, items: TimePickerItems) {
+        selectTime(items.coerceTime(displayHour = displayHour, minute = minute, period = period))
     }
 
     internal fun selectHour(hour: Int) {

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/TimePickerStateTest.kt
@@ -697,6 +697,23 @@ class TimePickerStateTest {
     }
 
     @Test
+    fun timePickerState_selectDisplayTimeParts_updates12HourSelection() {
+        val state = TimePickerState(
+            initialHour = 8,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+
+        state.selectTime(displayHour = 12, minute = 30, period = TimePeriod.AM)
+
+        assertEquals(12, state.selectedHour)
+        assertEquals(30, state.selectedMinute)
+        assertEquals(TimePeriod.AM, state.selectedPeriod)
+        assertEquals(LocalTime(0, 30), state.selectedTime)
+    }
+
+    @Test
     fun timePickerState_selectedTime_updatesWhenSelectionChanges() {
         val state = TimePickerState(
             initialHour = 12,
@@ -936,6 +953,37 @@ class TimePickerStateTest {
     }
 
     @Test
+    fun timePickerItems_coerceDisplayTimeParts_uses12HourDisplayAndPeriodItems() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = emptyList(),
+            hour12Items = listOf(1, 4),
+            periodItems = listOf(TimePeriod.PM)
+        )
+
+        assertEquals(
+            LocalTime(13, 30),
+            items.coerceTime(displayHour = 1, minute = 20, period = TimePeriod.PM)
+        )
+    }
+
+    @Test
+    fun timePickerItems_coerceDisplayTimeParts_rejectsInvalidDisplayHour() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0),
+            hour24Items = emptyList(),
+            hour12Items = listOf(12),
+            periodItems = listOf(TimePeriod.AM)
+        )
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            items.coerceTime(displayHour = 13, minute = 0, period = TimePeriod.AM)
+        }
+
+        assertTrue(error.message.orEmpty().contains("displayHour"))
+    }
+
+    @Test
     fun timePickerItems_contains_checks12HourDisplayAndPeriodMembership() {
         val items = TimePickerItems(
             minuteItems = listOf(0, 30),
@@ -947,6 +995,21 @@ class TimePickerStateTest {
         assertTrue(items.contains(LocalTime(9, 30), TimeFormat.HOUR_12))
         assertTrue(!items.contains(LocalTime(21, 30), TimeFormat.HOUR_12))
         assertTrue(!items.contains(LocalTime(9, 45), TimeFormat.HOUR_12))
+    }
+
+    @Test
+    fun timePickerItems_containsDisplayParts_checks12HourDisplayAndPeriodMembership() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = emptyList(),
+            hour12Items = listOf(9),
+            periodItems = listOf(TimePeriod.AM)
+        )
+
+        assertTrue(items.contains(displayHour = 9, minute = 30, period = TimePeriod.AM))
+        assertTrue(!items.contains(displayHour = 9, minute = 30, period = TimePeriod.PM))
+        assertTrue(!items.contains(displayHour = 13, minute = 30, period = TimePeriod.AM))
+        assertTrue(!items.contains(displayHour = 9, minute = 60, period = TimePeriod.AM))
     }
 
     @Test
@@ -1030,6 +1093,34 @@ class TimePickerStateTest {
         state.selectTime(hour = 14, minute = 20, items = items)
 
         assertEquals(LocalTime(17, 0), state.selectedTime)
+    }
+
+    @Test
+    fun timePickerState_selectDisplayTimePartsWithItems_coercesSelection() {
+        val state = TimePickerState(
+            initialHour = 12,
+            initialMinute = 0,
+            initialPeriod = TimePeriod.AM,
+            timeFormat = TimeFormat.HOUR_12
+        )
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = emptyList(),
+            hour12Items = listOf(1, 4),
+            periodItems = listOf(TimePeriod.PM)
+        )
+
+        state.selectTime(
+            displayHour = 1,
+            minute = 20,
+            period = TimePeriod.PM,
+            items = items
+        )
+
+        assertEquals(LocalTime(13, 30), state.selectedTime)
+        assertEquals(1, state.selectedHour)
+        assertEquals(30, state.selectedMinute)
+        assertEquals(TimePeriod.PM, state.selectedPeriod)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add TimePickerItems 12-hour display-hour + AM/PM contains/coerce helpers
- add matching TimePickerState.selectTime(displayHour, minute, period, ...) overloads
- document the 12-hour form/preset API and update ABI dumps

## Verification
- ./gradlew :datetimepicker:test --no-daemon
- ./gradlew :datetimepicker:updateLegacyAbi --no-daemon
- ./gradlew :datetimepicker:checkLegacyAbi --no-daemon
- git diff --check origin/main...HEAD