### PR TITLE
test: add Android picker macrobenchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 ### Added
 
+- Add a reproducible Android Macrobenchmark harness for generic 10/100/10,000-item picker startup and bounded-versus-exact 9,000-year `DatePicker` rendering comparisons.
 - Added `PickerDividerWidth` (`Fill`, `Fraction`, `Fixed`) and the `dividerWidth` parameter to
   `PickerStyle` / `PickerDefaults.style(...)` so the selection divider length can be a fraction of
   the column width or a fixed `Dp` instead of always filling the column. The divider stays centered

--- a/benchmark-app/build.gradle.kts
+++ b/benchmark-app/build.gradle.kts
@@ -1,0 +1,55 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin {
+    jvmToolchain(17)
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
+}
+
+android {
+    namespace = "com.kez.picker.benchmark.target"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "com.kez.picker.benchmark.target"
+        minSdk = 24
+        targetSdk = 36
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        create("benchmark") {
+            initWith(getByName("release"))
+            isDebuggable = false
+            isMinifyEnabled = true
+            signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += "release"
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(project(":datetimepicker"))
+    implementation(libs.androidx.activityCompose)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.ui)
+    implementation(libs.kotlinx.datetime)
+}

--- a/benchmark-app/src/main/AndroidManifest.xml
+++ b/benchmark-app/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="Picker Benchmark"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        <profileable android:shell="true" />
+        <activity
+            android:name=".PickerBenchmarkActivity"
+            android:exported="true" />
+    </application>
+</manifest>

--- a/benchmark-app/src/main/kotlin/com/kez/picker/benchmark/target/PickerBenchmarkActivity.kt
+++ b/benchmark-app/src/main/kotlin/com/kez/picker/benchmark/target/PickerBenchmarkActivity.kt
@@ -1,0 +1,88 @@
+package com.kez.picker.benchmark.target
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.kez.picker.Picker
+import com.kez.picker.PickerDefaults
+import com.kez.picker.date.DatePicker
+import com.kez.picker.date.rememberDatePickerState
+import kotlinx.datetime.LocalDate
+
+private const val BenchmarkScenarioExtra = "com.kez.picker.benchmark.target.BENCHMARK_SCENARIO"
+private const val DateDefaultScenario = "date-default"
+private const val DateExactScenario = "date-custom-exact"
+
+class PickerBenchmarkActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        val benchmarkScenario = requireNotNull(
+            intent.getStringExtra(BenchmarkScenarioExtra)
+        ) { "$BenchmarkScenarioExtra is required" }
+        setContent {
+            MaterialTheme {
+                PickerBenchmarkContent(benchmarkScenario)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PickerBenchmarkContent(scenario: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        when (scenario) {
+            DateDefaultScenario -> DatePicker(
+                state = rememberDatePickerState(
+                    initialDate = LocalDate(2024, 6, 15)
+                )
+            )
+
+            DateExactScenario -> DatePicker(
+                state = rememberDatePickerState(
+                    initialDate = LocalDate(2024, 6, 15)
+                ),
+                format = PickerDefaults.datePickerFormat(
+                    yearItemText = { it.toString() }
+                )
+            )
+
+            else -> GenericPickerBenchmark(
+                itemCount = scenario.removePrefix("generic-").toInt()
+            )
+        }
+    }
+}
+
+@Composable
+private fun GenericPickerBenchmark(itemCount: Int) {
+    val items = remember(itemCount) { (1..itemCount).toList() }
+    var selectedItem by remember(itemCount) {
+        mutableIntStateOf(items[itemCount / 2])
+    }
+
+    Picker(
+        items = items,
+        selectedItem = selectedItem,
+        onSelectedItemChange = { selectedItem = it },
+        modifier = Modifier.width(160.dp),
+        isInfinity = false
+    )
+}

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -1,0 +1,59 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.android.test)
+    alias(libs.plugins.kotlin.android)
+}
+
+kotlin {
+    jvmToolchain(17)
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
+}
+
+android {
+    namespace = "com.kez.picker.benchmark"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 28
+        targetSdk = 36
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    targetProjectPath = ":benchmark-app"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+
+    buildTypes {
+        create("benchmark") {
+            isDebuggable = true
+            signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += "release"
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    testOptions {
+        managedDevices {
+            localDevices {
+                create("pixel2Api35") {
+                    device = "Pixel 2"
+                    apiLevel = 35
+                    systemImageSource = "aosp-atd"
+                    require64Bit = true
+                }
+            }
+        }
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.benchmark.macro.junit4)
+    implementation(libs.androidx.test.ext.junit)
+    implementation(libs.androidx.test.runner)
+}

--- a/benchmark/src/main/AndroidManifest.xml
+++ b/benchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/benchmark/src/main/kotlin/com/kez/picker/benchmark/PickerStartupBenchmark.kt
+++ b/benchmark/src/main/kotlin/com/kez/picker/benchmark/PickerStartupBenchmark.kt
@@ -1,0 +1,58 @@
+package com.kez.picker.benchmark
+
+import android.content.Intent
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val TargetPackage = "com.kez.picker.benchmark.target"
+private const val TargetActivity = "$TargetPackage.PickerBenchmarkActivity"
+private const val BenchmarkScenarioExtra = "$TargetPackage.BENCHMARK_SCENARIO"
+private const val BenchmarkIterations = 10
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class PickerStartupBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun generic10Items() = benchmarkScenario("generic-10")
+
+    @Test
+    fun generic100Items() = benchmarkScenario("generic-100")
+
+    @Test
+    fun generic10000Items() = benchmarkScenario("generic-10000")
+
+    @Test
+    fun dateDefault9000Years() = benchmarkScenario("date-default")
+
+    @Test
+    fun dateCustomExact9000Years() = benchmarkScenario("date-custom-exact")
+
+    private fun benchmarkScenario(scenario: String) {
+        benchmarkRule.measureRepeated(
+            packageName = TargetPackage,
+            metrics = listOf(StartupTimingMetric()),
+            iterations = BenchmarkIterations,
+            compilationMode = CompilationMode.Full(),
+            startupMode = StartupMode.COLD
+        ) {
+            startActivityAndWait(
+                Intent(Intent.ACTION_MAIN).apply {
+                    setClassName(TargetPackage, TargetActivity)
+                    putExtra(BenchmarkScenarioExtra, scenario)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                }
+            )
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.test) apply false
     alias(libs.plugins.multiplatform) apply false
+    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose) apply false
     alias(libs.plugins.compose.compiler) apply false

--- a/docs/performance/picker-android-macrobenchmark.md
+++ b/docs/performance/picker-android-macrobenchmark.md
@@ -1,0 +1,83 @@
+# Picker Android Macrobenchmark
+
+## 목적과 가설
+
+이 benchmark는 `Picker`의 초기 Compose 렌더링 비용이 item 수와 높이 측정 경로에 따라 어떻게 달라지는지 end-to-end Android 화면 수준에서 측정한다. 독립 `benchmark-app` target과 전용 `PickerBenchmarkActivity`를 사용하므로 일반 sample APK와 `MainActivity` startup 경로에는 benchmark 코드나 분기가 포함되지 않는다.
+
+- generic `Picker<Int>`는 10, 100, 10,000 item에서 현재 exact text measurement 경로의 증가 비용을 드러내야 한다.
+- 기본 `DatePicker`의 9,000개 연도는 library-owned numeric probe를 사용하므로, 같은 문자열을 반환하지만 custom formatter를 사용해 exact path로 강제한 경우보다 빨라야 한다.
+- benchmark는 제품 public API를 추가하거나 benchmark 전용 최적화 flag를 노출하지 않는다.
+
+이것은 사용자 화면의 cold-start end-to-end benchmark다. generic 시나리오에는 호출자가 `(1..itemCount).toList()`를 만드는 비용도 포함되므로 내부 text measurement 함수만의 microbenchmark로 해석하면 안 된다. 내부 경로의 formatter 호출 수는 common test로 별도 검증하고, 여기서는 실제 앱이 list를 준비해 첫 frame을 표시하기까지의 합성 비용을 비교한다.
+
+## 시나리오
+
+| Test | 화면 | 높이 측정 경로 |
+|---|---|---|
+| `generic10Items` | generic `Picker<Int>`, 10 items | exact |
+| `generic100Items` | generic `Picker<Int>`, 100 items | exact |
+| `generic10000Items` | generic `Picker<Int>`, 10,000 items | exact |
+| `dateDefault9000Years` | 기본 `DatePicker`, 1000..9999 | bounded internal numeric probe |
+| `dateCustomExact9000Years` | 동일 `DatePicker`, custom year formatter | exact |
+
+각 test는 release 기반·non-debuggable·profileable `benchmark-app` APK를 대상으로 cold start를 10회 수행하고 `StartupTimingMetric`을 기록한다. `dateCustomExact9000Years`는 사용자가 custom formatter를 제공했을 때 fallback glyph를 안전하게 보존하는 현재 계약의 비교군이다. 스크롤 중 frame timing과 jank는 초기 렌더링과 다른 사용자 journey이므로 후속 interaction benchmark에서 다룬다.
+
+## Acceptance criteria
+
+1. `:benchmark:assembleBenchmark`와 `:benchmark-app:assembleBenchmark`가 컴파일된다.
+2. emulator dry run으로 모든 scenario가 launch되고 benchmark 결과 artifact가 생성된다.
+3. 최종 성능 주장은 API 34 이상의 물리 Android 기기에서 같은 commit과 명령으로 얻은 JSON을 근거로 한다.
+4. 결과에는 device model, Android version, build fingerprint, commit SHA, thermal 상태 및 JSON 경로를 함께 기록한다.
+5. emulator 결과는 harness 진단용으로만 쓰고 사용자 체감 성능이나 회귀 임계값으로 인용하지 않는다.
+
+## 실행
+
+물리 기기에서 대표 결과를 수집한다.
+
+```bash
+./gradlew :benchmark:connectedBenchmarkAndroidTest --no-daemon
+```
+
+연결 기기 없이 harness만 검증할 때는 기존 Gradle Managed Device를 dry-run으로 사용한다.
+
+```bash
+./gradlew :benchmark:pixel2Api35BenchmarkAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true \
+  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR \
+  --no-daemon
+```
+
+특정 scenario만 실행하려면 class argument를 추가한다.
+
+```bash
+./gradlew :benchmark:connectedBenchmarkAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.kez.picker.benchmark.PickerStartupBenchmark#generic10000Items \
+  --no-daemon
+```
+
+호스트로 복사된 JSON과 Perfetto trace는 다음 디렉터리 아래에서 확인한다.
+
+```text
+benchmark/build/outputs/connected_android_test_additional_output/benchmarkAndroidTest/connected/<device>/
+```
+
+Gradle Managed Device dry run artifact는 다음 경로에 생성된다.
+
+```text
+benchmark/build/outputs/managed_device_android_test_additional_output/benchmark/pixel2Api35/
+```
+
+## 현재 결과
+
+물리 기기 결과는 아직 없다. 이 항목은 emulator smoke 결과로 대체하지 않는다. 물리 기기가 연결되면 아래 표를 실제 JSON 값과 artifact 경로로 갱신한다.
+
+| Commit | Device / Android | generic 10 / 100 / 10,000 | date bounded / exact | Evidence |
+|---|---|---|---|---|
+| 미측정 | 연결된 물리 기기 없음 | 미측정 | 미측정 | 미측정 |
+
+2026-07-17에 API 35 Gradle Managed Device에서 `dryRunMode`로 5개 scenario가 모두 통과했고 scenario별 Perfetto trace가 생성됐다. 이 결과는 설치·launch·artifact 경로 검증이며 성능 수치가 아니다.
+
+## 참고
+
+- [Android Macrobenchmark overview](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview)
+- [Android Benchmark library releases](https://developer.android.com/jetpack/androidx/releases/benchmark)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,12 +18,18 @@ buildConfig = "5.7.0"
 composeIcons = "1.1.1"
 vanniktech-maven = "0.34.0"
 coreSplashscreen = "1.2.0"
+androidx-benchmark = "1.4.1"
+androidx-testExtJunit = "1.3.0"
+androidx-testRunner = "1.7.0"
 
 [libraries]
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
 androidx-uitest-testManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-uiTest" }
 androidx-uitest-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-uiTest" }
+androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExtJunit" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-testRunner" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
@@ -49,7 +55,9 @@ multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotl
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-test = { id = "com.android.test", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 hotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "hotReload" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 room = { id = "androidx.room", version.ref = "room" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,4 +25,6 @@ dependencyResolutionManagement {
 rootProject.name = "Compose-DateTimePicker"
 include(":datetimepicker")
 include(":sample")
+include(":benchmark")
+include(":benchmark-app")
 include(":iosApp")


### PR DESCRIPTION
## 요약

- 독립 `benchmark-app` target과 `com.android.test` Macrobenchmark module을 추가합니다.
- generic `Picker<Int>` 10/100/10,000 items와 기본/custom exact `DatePicker` 9,000-year 시나리오를 고정합니다.
- 일반 `sample` module과 `MainActivity`에는 benchmark 코드나 variant 변경을 넣지 않습니다.
- 물리 기기 결과와 emulator dry-run을 구분하는 실행·증거 문서를 추가합니다.

## 측정 계약

각 시나리오는 non-debuggable/profileable/minified target에서 `CompilationMode.Full`, cold start 10회, `StartupTimingMetric`을 사용합니다.

generic 시나리오는 호출자의 `(1..itemCount).toList()` 생성 비용까지 포함하는 end-to-end 화면 benchmark입니다. 따라서 내부 text measurement만의 microbenchmark로 과장하지 않도록 문서에 경계를 명시했습니다.

`dateDefault9000Years`와 `dateCustomExact9000Years`는 화면 문자열은 같지만 기본 내부 numeric probe 경로와 fallback-safe exact 경로를 비교합니다.

## 검증

```bash
./gradlew :datetimepicker:testDebugUnitTest :datetimepicker:desktopTest :datetimepicker:checkLegacyAbi :sample:compileKotlinDesktop :sample:wasmJsBrowserDistribution :sample:assembleDebugAndroidTest :sample:compileKotlinIosSimulatorArm64 :sample:assembleDebug :benchmark-app:assembleBenchmark :benchmark:assembleBenchmark --no-daemon

./gradlew :benchmark:pixel2Api35BenchmarkAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true \
  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.suppressErrors=EMULATOR \
  --no-daemon

git diff --check
```

- 멀티플랫폼/ABI 묶음: BUILD SUCCESSFUL, 305 tasks
- API 35 Managed Device dry run: 5/5 통과, scenario별 Perfetto trace 생성
- target APK 직접 검사: `profileable` 및 전용 Activity manifest/dex 포함, debuggable=false
- Wasm large-bundle warning과 SDK XML tool-version warning만 있었고 실패는 없었습니다.

## 성능 수치 상태

물리 Android 기기가 연결되어 있지 않아 대표 timing 수치는 아직 기록하지 않았습니다. emulator test time은 성능 결과로 사용하지 않으며, 문서의 결과 표도 명시적으로 `미측정`으로 남겼습니다.

## 검토 투명성

이번 슬라이스에서 6-agent review를 호출했지만 reviewer 모델이 현재 Codex/ChatGPT 계정 조합에서 지원되지 않아 3개 호출이 모두 시작 전에 실패했습니다. 대신 다음 red-team 교정을 직접 적용했습니다.

- KMP sample custom variant 대신 독립 target app으로 격리
- dry-run과 물리 기기 결과를 분리
- generic list materialization 비용을 측정 범위에 명시
- startup과 scroll jank benchmark를 분리
- public API/ABI 변경 없음 확인

## 후속

물리 API 34+ 기기에서 문서의 `connectedBenchmarkAndroidTest`를 실행해 JSON/기기 정보/thermal 상태와 함께 대표 수치를 기록합니다. 이후 별도 interaction benchmark에서 scroll/snap frame timing을 측정합니다.