### PR TITLE
Harden DatePicker and TimePicker selection commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,19 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
 
 ### Changed
 
+- `DatePicker` and `TimePicker` now reduce each settled child-column interaction to one repaired,
+  selectable logical value before committing state and dispatching exactly one user callback.
+  Programmatic multi-field date/time updates apply in one Compose mutable snapshot, while
+  programmatic scroll synchronization and compatible item-source replacement remain callback-free.
+  Late child values that are no longer selectable in the active source are ignored, and an upstream
+  settle or app-driven state/item-source replacement cancels an invalidated in-flight child
+  interaction without dispatching it.
+- Item configuration validation is now remembered by the item source instead of repeating its full
+  empty/duplicate/range checks on every Date/Time selection change.
+- Items-aware `rememberDatePickerState` and `rememberTimePickerState` overloads now coerce saved
+  values against the recreated item source during restore, not only during initial creation.
+- Changing both `TimePicker` items and `timeFormat` now recreates items-aware state against the latest
+  item source; an items-only recomposition still does not reset the logical selection.
 - Clarified that the existing `Picker<T>.onSelectedItemChange` compatibility contract dispatches
   only after user interaction settles. `Picker` and `WheelPicker` share the same internal rendering,
   validation, semantics, styling, and programmatic synchronization path.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ UI, that state object is the source of truth for the currently selected value.
   `state.selectedDateRange`, or `state.selectedYearMonth`.
 - Use `onSelected*Change` when you need to mirror user-driven picker changes into app state,
   a `ViewModel`, or form data.
+- `TimePicker` and `DatePicker` dispatch that callback once after the changed column settles and all
+  dependent values are repaired. The callback receives the final selectable logical value, which is
+  already committed to the picker state; visual `columnOrder` does not change that transition.
+- A changed column value is preserved only while it still belongs to the active constrained source.
+  A late value that is no longer selectable in that source is ignored. If an upstream settle replaces
+  a dependent source while that child wheel is moving, the invalidated child interaction is cancelled
+  without a callback.
 - `onSelected*Change` is not called when your app calls `state.select*` programmatically. If a
   button, preset, or external value changes the picker, call `state.select*(...)` and update your
   app-owned value in the same handler.
@@ -618,8 +625,10 @@ TimePicker(
 ### Programmatic Selection
 
 Create picker state with `remember*State`, pass it to the picker, then call the public selection method
-from an event handler or a `LaunchedEffect(externalValue)`. Do not recreate the state just to reset the
-selection.
+from an event handler or a `LaunchedEffect(externalValue)`. `LaunchedEffect` is suitable while the
+active item source still contains the current value. When replacing an item source or constraints,
+coerce the state with the replacement source before publishing that source to the picker. Do not
+recreate the state just to reset the selection.
 
 | State | Method |
 | :--- | :--- |
@@ -652,6 +661,16 @@ fun ProgrammaticTimePickerExample() {
 }
 ```
 
+For a dynamic item-source replacement, update the logical state and source in that order in the same
+event handler:
+
+```kotlin
+fun replaceItems(newItems: TimePickerItems, requestedTime: LocalTime) {
+    state.selectTime(requestedTime, newItems)
+    items = newItems
+}
+```
+
 The picker scroll position is synchronized when the current item lists contain the requested values. Custom
 item lists are strict: they must be non-empty, distinct, within the supported value ranges, and contain the
 current selected value. `TimePicker` filters hour, minute, and AM/PM columns through optional
@@ -661,12 +680,19 @@ configured bounds, call `items.contains(...)` to check primitive or value object
 value, or call the `state.select*(value, items)` overload or `items.coerce*` helper to move to the
 closest selectable value before rendering the picker.
 For first composition, use `remember*State(items = items, initial... = value)` to apply the same coercion
-before the picker is rendered.
+before the picker is rendered. These items-aware state overloads also coerce a saved value against the
+items supplied by the recreated composition, so changed constraints cannot restore an invalid logical
+value.
 
 `onSelectedTimeChange`, `onSelectedDateChange`, `onSelectedDateRangeChange`, and
 `onSelectedYearMonthChange` are called for user-driven picker changes. Programmatic `state.select*`
 calls update the state directly; update your app-owned value in the same event handler when you
-trigger programmatic changes.
+trigger programmatic changes. `TimePicker` and `DatePicker` wait for the changed child wheel to
+settle, repair dependent columns against the active constraints, commit one logical value, and then
+invoke the callback once. A compatible item-source replacement is app-driven and invokes no callback;
+if the new source excludes the current value, coerce the state with that new source before composing.
+Date repair preserves the accepted changed column and then repairs year/month/day dependencies; Time
+repair does the same in period/hour/minute dependency order. Numeric ties choose the smaller value.
 
 Use `PickerDefaults.timePickerLayout(...)`, `datePickerLayout(...)`, or `yearMonthPickerLayout(...)`
 when a composite picker needs different column proportions. Pass `null` for a column weight to let
@@ -694,7 +720,7 @@ is rendered only in 12-hour mode and ignored in 24-hour mode.
 | Parameter | Description | Default |
 | :--- | :--- | :--- |
 | `state` | The state object to control the picker. | `rememberTimePickerState()` |
-| `onSelectedTimeChange` | Called after user interaction changes the selected `LocalTime`. | `{}` |
+| `onSelectedTimeChange` | Called once with the committed selectable `LocalTime` after a changed column settles and dependent values are repaired. | `{}` |
 | `enabled` | Whether user scroll, click, and semantics selection actions are enabled. | `true` |
 | `items` | Selectable minute, 24-hour hour, 12-hour format-hour, and AM/PM item lists plus optional inclusive `minTime`/`maxTime` bounds. | `PickerDefaults.timePickerItems()` |
 | `format` | Visible item text and optional accessibility value descriptions for each picker column. | `PickerDefaults.timePickerFormat()` |
@@ -733,7 +759,7 @@ Invalid custom item values, duplicate items, empty required lists, or current se
 | Parameter           | Description                             | Default                     |
 |:--------------------|:----------------------------------------|:----------------------------|
 | `state`             | The state object to control the picker. | `rememberDatePickerState()` |
-| `onSelectedDateChange` | Called after user interaction changes the selected `LocalDate`. | `{}` |
+| `onSelectedDateChange` | Called once with the committed selectable `LocalDate` after a changed column settles and dependent values are repaired. | `{}` |
 | `enabled` | Whether user scroll, click, and semantics selection actions are enabled. | `true` |
 | `items`             | Selectable year/month/day item lists plus optional inclusive `minDate`/`maxDate` bounds. Values must be in `1000..9999`, `1..12`, and `1..31`. | `PickerDefaults.datePickerItems()` |
 | `format` | Visible item text and optional accessibility value descriptions for each picker column. | `PickerDefaults.datePickerFormat()` |

--- a/README_KO.md
+++ b/README_KO.md
@@ -70,6 +70,12 @@ truth는 이 state 객체입니다.
   `state.selectedYearMonth`에서 읽습니다.
 - 사용자 조작으로 바뀐 값을 앱 state, `ViewModel`, form data에 반영해야 할 때만 `onSelected*Change`를
   사용합니다.
+- `TimePicker`와 `DatePicker`는 변경한 column이 settle되고 모든 dependent 값이 보정된 뒤 callback을
+  한 번만 호출합니다. callback에는 picker state에 이미 commit된 최종 선택 가능 logical value가
+  전달되며, visual `columnOrder`는 이 transition 결과를 바꾸지 않습니다.
+- 변경된 column 값은 현재 constrained source에 계속 포함될 때만 보존됩니다. 그 source에서 더 이상
+  선택할 수 없는 late value는 무시합니다. upstream settle이 움직이는 dependent child source를 교체하면
+  그 무효화된 child interaction은 callback 없이 취소됩니다.
 - 앱이 버튼, preset, 외부 값 변경으로 `state.select*`를 직접 호출할 때는 `onSelected*Change`가 호출되지
   않습니다. 이 경우 같은 이벤트 핸들러 안에서 `state.select*(...)`와 앱이 소유한 값 갱신을 함께 수행하세요.
 - picker를 reset하려고 `remember*State`를 새로 만들지 마세요. 기존 state 객체를 유지하고 public
@@ -606,8 +612,10 @@ TimePicker(
 ### 프로그래밍 방식 선택
 
 `remember*State`로 picker state를 만들고 picker에 전달한 뒤, 이벤트 핸들러나
-`LaunchedEffect(externalValue)`에서 공개 선택 메서드를 호출하세요. 선택값을 다시 맞추기 위해
-state를 새로 만들 필요는 없습니다.
+`LaunchedEffect(externalValue)`에서 공개 선택 메서드를 호출하세요. `LaunchedEffect`는 active item
+source가 현재 값을 계속 포함할 때 적합합니다. item source나 constraint를 교체할 때는 replacement
+source로 state를 먼저 보정한 뒤 그 source를 picker에 게시하세요. 선택값을 다시 맞추기 위해 state를
+새로 만들 필요는 없습니다.
 
 | State | Method |
 | :--- | :--- |
@@ -640,6 +648,16 @@ fun ProgrammaticTimePickerExample() {
 }
 ```
 
+동적 item-source 교체에서는 같은 이벤트 핸들러 안에서 logical state를 먼저 갱신하고 source를 그다음
+게시하세요.
+
+```kotlin
+fun replaceItems(newItems: TimePickerItems, requestedTime: LocalTime) {
+    state.selectTime(requestedTime, newItems)
+    items = newItems
+}
+```
+
 요청한 값이 현재 item list에 포함되어 있으면 picker 스크롤 위치가 동기화됩니다. custom list는 엄격하게
 검증됩니다. 비어 있지 않아야 하고, 중복이 없어야 하며, 지원 범위 안의 값만 포함해야 하고, 현재 선택값도
 반드시 포함해야 합니다. `TimePicker`는 선택적 `minTime`/`maxTime` 범위에 맞춰 시간, 분, 오전/오후
@@ -649,12 +667,18 @@ column을 필터링합니다. `DatePicker`는 `dayItems`를 선택된 연/월의
 보정해야 한다면 `state.select*(value, items)` overload나 `items.coerce*` helper로 가장 가까운 선택 가능
 값으로 이동한 뒤 picker를 렌더링하세요.
 첫 composition의 초기값에도 같은 보정이 필요하면 `remember*State(items = items, initial... = value)`를
-사용하세요.
+사용하세요. 이 items-aware state overload는 저장값을 recreated composition이 제공한 items로 다시
+보정하므로 변경된 constraint 밖의 logical value를 복원하지 않습니다.
 
 `onSelectedTimeChange`, `onSelectedDateChange`, `onSelectedDateRangeChange`,
 `onSelectedYearMonthChange`는 사용자가 picker를 조작해서 값이 바뀔 때 호출됩니다. 프로그래밍 방식의
 `state.select*` 호출은 state를 직접 변경하므로, 그 이벤트 핸들러 안에서 앱이 소유한 값도 함께
-갱신하세요.
+갱신하세요. `TimePicker`와 `DatePicker`는 변경된 child wheel이 settle될 때까지 기다린 뒤 active
+constraint에 맞게 dependent column을 보정하고, 하나의 logical value를 commit한 다음 callback을 한 번
+호출합니다. 현재 값을 계속 포함하는 item-source 교체는 app-driven 변경이므로 callback을 호출하지
+않습니다. 새 source가 현재 값을 제외한다면 composition 전에 그 새 source로 state를 보정하세요.
+Date repair는 승인된 changed column을 보존한 뒤 year/month/day dependency 순서로 보정하고, Time repair는
+period/hour/minute 순서로 보정합니다. 숫자 거리가 같으면 더 작은 값을 선택합니다.
 
 composite picker의 column 비율을 조정해야 한다면 `PickerDefaults.timePickerLayout(...)`,
 `datePickerLayout(...)`, `yearMonthPickerLayout(...)`을 사용하세요. 특정 column의 weight를
@@ -682,7 +706,7 @@ DatePicker(
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberTimePickerState()` |
-| `onSelectedTimeChange` | 사용자 조작으로 선택된 `LocalTime`이 바뀐 뒤 호출됩니다. | `{}` |
+| `onSelectedTimeChange` | 변경한 column이 settle되고 dependent 값이 보정된 뒤, commit된 선택 가능 `LocalTime`으로 한 번 호출됩니다. | `{}` |
 | `enabled` | 사용자 scroll, click, semantics 선택 action을 허용할지 여부입니다. | `true` |
 | `items` | 선택 가능한 분, 24시간제 시간, 12시간제 표시 시간, 오전/오후 목록과 선택적 `minTime`/`maxTime` 범위입니다. | `PickerDefaults.timePickerItems()` |
 | `format` | 각 picker column의 화면 표시 텍스트와 선택적 접근성 값 설명입니다. | `PickerDefaults.timePickerFormat()` |
@@ -721,7 +745,7 @@ custom item 값이 유효 범위를 벗어나거나, 중복이 있거나, 필수
 | 파라미터 | 설명 | 기본값 |
 | :--- | :--- | :--- |
 | `state` | Picker를 제어하기 위한 상태 객체입니다. | `rememberDatePickerState()` |
-| `onSelectedDateChange` | 사용자 조작으로 선택된 `LocalDate`가 바뀐 뒤 호출됩니다. | `{}` |
+| `onSelectedDateChange` | 변경한 column이 settle되고 dependent 값이 보정된 뒤, commit된 선택 가능 `LocalDate`로 한 번 호출됩니다. | `{}` |
 | `enabled` | 사용자 scroll, click, semantics 선택 action을 허용할지 여부입니다. | `true` |
 | `items` | 선택 가능한 연도/월/일 목록과 선택적 `minDate`/`maxDate` inclusive 범위입니다. 값은 `1000..9999`, `1..12`, `1..31` 범위여야 합니다. | `PickerDefaults.datePickerItems()` |
 | `format` | 각 picker column의 화면 표시 텍스트와 선택적 접근성 값 설명입니다. | `PickerDefaults.datePickerFormat()` |

--- a/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/MultiWheelSelectionContractRobolectricTest.kt
+++ b/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/MultiWheelSelectionContractRobolectricTest.kt
@@ -1,0 +1,361 @@
+package com.kez.picker
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.isSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import com.kez.picker.date.DatePicker
+import com.kez.picker.date.DatePickerState
+import com.kez.picker.date.rememberDatePickerState
+import com.kez.picker.time.TimePicker
+import com.kez.picker.time.TimePickerState
+import com.kez.picker.time.rememberTimePickerState
+import com.kez.picker.util.TimeFormat
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class MultiWheelSelectionContractRobolectricTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun datePicker_nonDefaultOrderCommitsOneRepairedLogicalDate() {
+        lateinit var state: DatePickerState
+        val committedDates = mutableListOf<LocalDate>()
+        val items = PickerDefaults.datePickerItems(
+            yearItems = listOf(2025),
+            monthItems = listOf(1, 2),
+            dayItems = listOf(15, 31)
+        )
+
+        composeRule.setContent {
+            state = rememberDatePickerState(
+                items = items,
+                initialDate = LocalDate(2025, 1, 31)
+            )
+            DatePicker(
+                state = state,
+                items = items,
+                onSelectedDateChange = { date ->
+                    assertEquals(date, state.selectedDate)
+                    committedDates += date
+                },
+                layout = PickerDefaults.datePickerLayout(
+                    columnOrder = listOf(
+                        DatePickerColumn.DAY,
+                        DatePickerColumn.MONTH,
+                        DatePickerColumn.YEAR
+                    )
+                ),
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.datePickerFormat(
+                    monthItemContentDescription = { "$it month" },
+                    dayItemContentDescription = { "$it day" }
+                ),
+                semantics = PickerDefaults.datePickerSemantics(
+                    monthPickerLabel = "Month",
+                    dayPickerLabel = "Day"
+                )
+            )
+        }
+
+        composeRule.onAllNodes(hasContentDescription("Month: 2 month"))[0].performClick()
+        waitUntilSelected("Month: 2 month")
+        waitUntilSelected("Day: 15 day")
+
+        composeRule.runOnIdle {
+            assertEquals(LocalDate(2025, 2, 15), state.selectedDate)
+            assertEquals(listOf(LocalDate(2025, 2, 15)), committedDates)
+            assertTrue(items.contains(state.selectedDate))
+        }
+    }
+
+    @Test
+    fun timePicker_nonDefaultOrderCommitsOneRepairedLogicalTime() {
+        lateinit var state: TimePickerState
+        val committedTimes = mutableListOf<LocalTime>()
+        val items = PickerDefaults.timePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = listOf(10, 11),
+            minTime = LocalTime(10, 30),
+            maxTime = LocalTime(11, 0)
+        )
+
+        composeRule.setContent {
+            state = rememberTimePickerState(
+                items = items,
+                initialTime = LocalTime(10, 30),
+                timeFormat = TimeFormat.HOUR_24
+            )
+            TimePicker(
+                state = state,
+                items = items,
+                onSelectedTimeChange = { time ->
+                    assertEquals(time, state.selectedTime)
+                    committedTimes += time
+                },
+                layout = PickerDefaults.timePickerLayout(
+                    columnOrder = listOf(
+                        TimePickerColumn.MINUTE,
+                        TimePickerColumn.HOUR,
+                        TimePickerColumn.PERIOD
+                    )
+                ),
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.timePickerFormat(
+                    hourItemContentDescription = { "$it hour" },
+                    minuteItemContentDescription = { "$it minute" }
+                ),
+                semantics = PickerDefaults.timePickerSemantics(
+                    hourPickerLabel = "Hour",
+                    minutePickerLabel = "Minute"
+                )
+            )
+        }
+
+        composeRule.onAllNodes(hasContentDescription("Hour: 11 hour"))[0].performClick()
+        waitUntilSelected("Hour: 11 hour")
+        waitUntilSelected("Minute: 0 minute")
+
+        composeRule.runOnIdle {
+            assertEquals(LocalTime(11, 0), state.selectedTime)
+            assertEquals(listOf(LocalTime(11, 0)), committedTimes)
+            assertTrue(items.contains(state.selectedTime, TimeFormat.HOUR_24))
+        }
+    }
+
+    @Test
+    fun datePicker_programmaticSelectionSynchronizesChildrenWithoutUserCallback() {
+        lateinit var state: DatePickerState
+        val committedDates = mutableListOf<LocalDate>()
+        val items = PickerDefaults.datePickerItems(
+            yearItems = listOf(2025, 2026),
+            monthItems = listOf(1, 2),
+            dayItems = listOf(15, 28, 31)
+        )
+
+        composeRule.setContent {
+            state = rememberDatePickerState(
+                items = items,
+                initialDate = LocalDate(2025, 1, 31)
+            )
+            DatePicker(
+                state = state,
+                items = items,
+                onSelectedDateChange = committedDates::add,
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.datePickerFormat(
+                    yearItemContentDescription = { "$it year" },
+                    monthItemContentDescription = { "$it month" },
+                    dayItemContentDescription = { "$it day" }
+                ),
+                semantics = PickerDefaults.datePickerSemantics(
+                    yearPickerLabel = "Year",
+                    monthPickerLabel = "Month",
+                    dayPickerLabel = "Day"
+                )
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectDate(LocalDate(2026, 2, 28), items)
+        }
+        waitUntilSelected("Year: 2026 year")
+        waitUntilSelected("Month: 2 month")
+        waitUntilSelected("Day: 28 day")
+
+        composeRule.runOnIdle {
+            assertEquals(LocalDate(2026, 2, 28), state.selectedDate)
+            assertEquals(emptyList<LocalDate>(), committedDates)
+        }
+    }
+
+    @Test
+    fun datePicker_compatibleItemSourceReplacementDispatchesNoUserCallback() {
+        lateinit var itemsState: MutableState<DatePickerItems>
+        lateinit var state: DatePickerState
+        val committedDates = mutableListOf<LocalDate>()
+
+        composeRule.setContent {
+            itemsState = remember {
+                mutableStateOf(
+                    PickerDefaults.datePickerItems(
+                        yearItems = listOf(2025, 2026),
+                        monthItems = listOf(1, 2),
+                        dayItems = listOf(15, 31)
+                    )
+                )
+            }
+            state = rememberDatePickerState(
+                items = itemsState.value,
+                initialDate = LocalDate(2025, 1, 15)
+            )
+            DatePicker(
+                state = state,
+                items = itemsState.value,
+                onSelectedDateChange = committedDates::add,
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.datePickerFormat(
+                    yearItemContentDescription = { "$it year" }
+                ),
+                semantics = PickerDefaults.datePickerSemantics(yearPickerLabel = "Year")
+            )
+        }
+
+        composeRule.runOnIdle {
+            itemsState.value = PickerDefaults.datePickerItems(
+                yearItems = listOf(2025, 2027),
+                monthItems = listOf(1, 2),
+                dayItems = listOf(15, 31)
+            )
+        }
+        waitUntilSelected("Year: 2025 year")
+
+        composeRule.runOnIdle {
+            assertEquals(LocalDate(2025, 1, 15), state.selectedDate)
+            assertEquals(emptyList<LocalDate>(), committedDates)
+        }
+    }
+
+    @Test
+    fun datePicker_itemSourceReplacementCancelsAnInFlightStillSelectableTarget() {
+        lateinit var itemsState: MutableState<DatePickerItems>
+        lateinit var state: DatePickerState
+        val committedDates = mutableListOf<LocalDate>()
+        val originalItems = PickerDefaults.datePickerItems(
+            yearItems = listOf(2025),
+            monthItems = listOf(1, 2),
+            dayItems = (1..31).toList()
+        )
+        val replacementItems = PickerDefaults.datePickerItems(
+            yearItems = listOf(2025, 2026),
+            monthItems = listOf(1, 2),
+            dayItems = (1..31).toList()
+        )
+
+        composeRule.setContent {
+            itemsState = remember { mutableStateOf(originalItems) }
+            state = rememberDatePickerState(
+                items = itemsState.value,
+                initialDate = LocalDate(2025, 1, 31)
+            )
+            DatePicker(
+                state = state,
+                items = itemsState.value,
+                onSelectedDateChange = committedDates::add,
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.datePickerFormat(
+                    monthItemContentDescription = { "$it month" }
+                ),
+                semantics = PickerDefaults.datePickerSemantics(monthPickerLabel = "Month")
+            )
+        }
+
+        composeRule.mainClock.autoAdvance = false
+        val monthTargetTopsBefore = nodeTops("Month: 2 month")
+        composeRule.onAllNodes(hasContentDescription("Month: 2 month"))[0].performClick()
+        composeRule.mainClock.advanceTimeBy(100)
+        val monthTargetTopsDuring = nodeTops("Month: 2 month")
+        assertTrue(
+            "The source must be replaced after the previous child animation has started.",
+            monthTargetTopsDuring != monthTargetTopsBefore
+        )
+        composeRule.runOnIdle {
+            itemsState.value = replacementItems
+        }
+        composeRule.mainClock.advanceTimeBy(5_000)
+        composeRule.mainClock.autoAdvance = true
+        composeRule.waitForIdle()
+
+        waitUntilSelected("Month: 1 month")
+        composeRule.runOnIdle {
+            assertEquals(LocalDate(2025, 1, 31), state.selectedDate)
+            assertEquals(emptyList<LocalDate>(), committedDates)
+        }
+    }
+
+    @Test
+    fun datePicker_upstreamSettleCancelsInvalidatedDependentAnimationWithoutCallback() {
+        lateinit var state: DatePickerState
+        val committedDates = mutableListOf<LocalDate>()
+        val items = PickerDefaults.datePickerItems(
+            yearItems = listOf(2025),
+            monthItems = listOf(1, 2),
+            dayItems = (1..31).toList()
+        )
+
+        composeRule.setContent {
+            state = rememberDatePickerState(
+                items = items,
+                initialDate = LocalDate(2025, 1, 31)
+            )
+            DatePicker(
+                state = state,
+                items = items,
+                onSelectedDateChange = committedDates::add,
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.datePickerFormat(
+                    monthItemContentDescription = { "$it month" },
+                    dayItemContentDescription = { "$it day" }
+                ),
+                semantics = PickerDefaults.datePickerSemantics(
+                    monthPickerLabel = "Month",
+                    dayPickerLabel = "Day"
+                )
+            )
+        }
+
+        composeRule.mainClock.autoAdvance = false
+        composeRule.onAllNodes(hasContentDescription("Month: 2 month"))[0].performClick()
+        composeRule.mainClock.advanceTimeBy(16)
+        val dayTargetTopsBefore = nodeTops("Day: 30 day")
+        composeRule.onAllNodes(hasContentDescription("Day: 30 day"))[0].performClick()
+        composeRule.mainClock.advanceTimeBy(100)
+        val dayTargetTopsDuring = nodeTops("Day: 30 day")
+        assertTrue(
+            "The dependent child animation must start before the upstream repair invalidates it.",
+            dayTargetTopsDuring != dayTargetTopsBefore
+        )
+        composeRule.mainClock.advanceTimeBy(5_000)
+        composeRule.mainClock.autoAdvance = true
+        composeRule.waitForIdle()
+
+        waitUntilSelected("Month: 2 month")
+        waitUntilSelected("Day: 28 day")
+
+        composeRule.runOnIdle {
+            val repairedDate = LocalDate(2025, 2, 28)
+            assertEquals(repairedDate, state.selectedDate)
+            assertEquals(listOf(repairedDate), committedDates)
+            assertTrue(items.contains(state.selectedDate))
+        }
+    }
+
+    private fun waitUntilSelected(contentDescription: String) {
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule
+                .onAllNodes(hasContentDescription(contentDescription) and isSelected())
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+    }
+
+    private fun nodeTops(contentDescription: String): List<Float> =
+        composeRule
+            .onAllNodes(hasContentDescription(contentDescription))
+            .fetchSemanticsNodes()
+            .map { it.boundsInRoot.top }
+}

--- a/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
+++ b/datetimepicker/src/androidUnitTest/kotlin/com/kez/picker/PickerStateRestorationRobolectricTest.kt
@@ -1,5 +1,8 @@
 package com.kez.picker
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.hasContentDescription
@@ -114,6 +117,105 @@ class PickerStateRestorationRobolectricTest {
     }
 
     @Test
+    fun timePicker_itemsAndFormatChangeRecreatesStateAgainstTheLatestSource() {
+        lateinit var state: TimePickerState
+        lateinit var itemsState: MutableState<TimePickerItems>
+        lateinit var formatState: MutableState<TimeFormat>
+        val originalItems = PickerDefaults.timePickerItems(
+            minuteItems = listOf(0),
+            hour24Items = listOf(8),
+            hour12Items = listOf(8)
+        )
+        val replacementItems = PickerDefaults.timePickerItems(
+            minuteItems = listOf(30),
+            hour24Items = listOf(9),
+            hour12Items = listOf(9),
+            periodItems = listOf(TimePeriod.PM)
+        )
+
+        composeRule.setContent {
+            itemsState = remember { mutableStateOf(originalItems) }
+            formatState = remember { mutableStateOf(TimeFormat.HOUR_24) }
+            state = rememberTimePickerState(
+                items = itemsState.value,
+                initialHour = 8,
+                initialMinute = 0,
+                timeFormat = formatState.value
+            )
+            TimePicker(
+                state = state,
+                items = itemsState.value
+            )
+        }
+
+        composeRule.runOnIdle {
+            itemsState.value = replacementItems
+            formatState.value = TimeFormat.HOUR_12
+        }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle {
+            assertEquals(TimeFormat.HOUR_12, state.timeFormat)
+            assertEquals(LocalTime(21, 30), state.selectedTime)
+        }
+    }
+
+    @Test
+    fun timePicker_itemsAwareRestoreCoercesSavedValueWithTheRecreatedSource() {
+        lateinit var state: TimePickerState
+        val committedTimes = mutableListOf<LocalTime>()
+        val restorationTester = StateRestorationTester(composeRule)
+        val originalItems = PickerDefaults.timePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = listOf(8, 17)
+        )
+        var recreatedItems = originalItems
+
+        restorationTester.setContent {
+            state = rememberTimePickerState(
+                items = recreatedItems,
+                initialTime = LocalTime(8, 0)
+            )
+            TimePicker(
+                state = state,
+                items = recreatedItems,
+                onSelectedTimeChange = committedTimes::add,
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.timePickerFormat(
+                    hourItemContentDescription = { "$it hour" },
+                    minuteItemContentDescription = { "$it minute" }
+                ),
+                semantics = PickerDefaults.timePickerSemantics(
+                    hourPickerLabel = "Hour",
+                    minutePickerLabel = "Minute"
+                )
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectTime(LocalTime(17, 30), originalItems)
+            recreatedItems = PickerDefaults.timePickerItems(
+                minuteItems = listOf(30),
+                hour24Items = listOf(9)
+            )
+        }
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeRule.waitForIdle()
+
+        composeRule
+            .onAllNodes(hasContentDescription("Hour: 9 hour") and isSelected())[0]
+            .assertExists()
+        composeRule
+            .onAllNodes(hasContentDescription("Minute: 30 minute") and isSelected())[0]
+            .assertExists()
+        composeRule.runOnIdle {
+            assertEquals(LocalTime(9, 30), state.selectedTime)
+            assertEquals(emptyList<LocalTime>(), committedTimes)
+        }
+    }
+
+    @Test
     fun timePicker_restoresSelectionIntoRenderedSemanticsAfterSaveRestore() {
         lateinit var state: TimePickerState
         val restorationTester = StateRestorationTester(composeRule)
@@ -211,6 +313,68 @@ class PickerStateRestorationRobolectricTest {
 
         composeRule.runOnIdle {
             assertEquals(LocalDate(year = 2026, month = 5, day = 10), state.selectedDate)
+        }
+    }
+
+    @Test
+    fun datePicker_itemsAwareRestoreCoercesSavedValueWithTheRecreatedSource() {
+        lateinit var state: DatePickerState
+        val committedDates = mutableListOf<LocalDate>()
+        val restorationTester = StateRestorationTester(composeRule)
+        val originalItems = PickerDefaults.datePickerItems(
+            yearItems = listOf(2025, 2026),
+            monthItems = listOf(1, 2),
+            dayItems = listOf(15, 28, 31)
+        )
+        var recreatedItems = originalItems
+
+        restorationTester.setContent {
+            state = rememberDatePickerState(
+                items = recreatedItems,
+                initialDate = LocalDate(2025, 1, 31)
+            )
+            DatePicker(
+                state = state,
+                items = recreatedItems,
+                onSelectedDateChange = committedDates::add,
+                style = PickerDefaults.style(visibleItemsCount = 3),
+                format = PickerDefaults.datePickerFormat(
+                    yearItemContentDescription = { "$it year" },
+                    monthItemContentDescription = { "$it month" },
+                    dayItemContentDescription = { "$it day" }
+                ),
+                semantics = PickerDefaults.datePickerSemantics(
+                    yearPickerLabel = "Year",
+                    monthPickerLabel = "Month",
+                    dayPickerLabel = "Day"
+                )
+            )
+        }
+
+        composeRule.runOnIdle {
+            state.selectDate(LocalDate(2026, 2, 28), originalItems)
+            recreatedItems = PickerDefaults.datePickerItems(
+                yearItems = listOf(2025),
+                monthItems = listOf(1),
+                dayItems = listOf(15)
+            )
+        }
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeRule.waitForIdle()
+
+        composeRule
+            .onAllNodes(hasContentDescription("Year: 2025 year") and isSelected())[0]
+            .assertExists()
+        composeRule
+            .onAllNodes(hasContentDescription("Month: 1 month") and isSelected())[0]
+            .assertExists()
+        composeRule
+            .onAllNodes(hasContentDescription("Day: 15 day") and isSelected())[0]
+            .assertExists()
+        composeRule.runOnIdle {
+            assertEquals(LocalDate(2025, 1, 15), state.selectedDate)
+            assertEquals(emptyList<LocalDate>(), committedDates)
         }
     }
 

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/MultiWheelSelection.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/MultiWheelSelection.kt
@@ -1,0 +1,31 @@
+package com.kez.picker
+
+import kotlin.math.abs
+
+/**
+ * Commits one already-repaired logical value produced by a multi-column user interaction.
+ *
+ * The state commit happens before [onSelectionCommitted], and unchanged values dispatch neither.
+ * App-driven state changes bypass this function so they cannot be confused with user commits.
+ */
+internal fun <State : Any> commitMultiWheelSelection(
+    currentState: State,
+    nextState: State,
+    commitState: (State) -> Unit,
+    onSelectionCommitted: (State) -> Unit
+): Boolean {
+    if (nextState == currentState) return false
+
+    commitState(nextState)
+    onSelectionCommitted(nextState)
+    return true
+}
+
+/** Returns the numerically closest value, preferring the smaller value on equal distance. */
+internal fun List<Int>.closestPickerValueTo(value: Int, sourceName: String): Int {
+    require(isNotEmpty()) { "$sourceName must contain at least one selectable value." }
+    return minWith(
+        compareBy<Int> { abs(it - value) }
+            .thenBy { it }
+    )
+}

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePicker.kt
@@ -24,11 +24,11 @@ import com.kez.picker.PickerDefaults
 import com.kez.picker.PickerSelectionBand
 import com.kez.picker.PickerSelectionIndicator
 import com.kez.picker.PickerStyle
+import com.kez.picker.commitMultiWheelSelection
 import com.kez.picker.maxPickerItemHeight
 import com.kez.picker.pickerColumnModifier
 import com.kez.picker.rememberPickerItemHeight
 import kotlinx.datetime.LocalDate
-import kotlin.math.abs
 
 /**
  * A date picker component that allows selecting year, month, and day.
@@ -36,7 +36,10 @@ import kotlin.math.abs
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
- * @param onSelectedDateChange Called after user interaction changes the selected date.
+ * @param onSelectedDateChange Called once after a user interaction settles on a new column value,
+ * dependent month/day values are repaired, and the final selectable date is committed to [state].
+ * If an upstream settle replaces a still-moving dependent column source, that invalidated child
+ * interaction is cancelled without a callback.
  * Programmatic [DatePickerState.selectDate] calls update [state] directly and do not invoke this
  * callback. When app code changes the picker from a button, preset, or external value, update any
  * app-owned state in the same handler.
@@ -69,32 +72,26 @@ fun DatePicker(
 ) {
     val columnStyle = remember(style) { style.copy(isDividerVisible = false) }
 
+    remember(items) {
+        validateDatePickerItemConfiguration(items = items)
+    }
     remember(items, state, state.selectedYear, state.selectedMonth, state.selectedDay) {
-        validateDatePickerItems(state = state, items = items)
+        validateDatePickerSelection(state = state, items = items)
     }
 
-    fun moveSelectionInsideAvailableItems() {
-        val availableMonthItems = items.selectableMonthItemsFor(state.selectedYear)
-        if (state.selectedMonth !in availableMonthItems) {
-            state.selectMonth(availableMonthItems.closestTo(state.selectedMonth))
-        }
-        val availableDayItems = items.selectableDayItemsFor(
-            year = state.selectedYear,
-            month = state.selectedMonth
+    fun commitColumnChange(column: DatePickerColumn, value: Int) {
+        val currentDate = state.selectedDate
+        val nextDate = items.repairedDateAfter(
+            currentDate = currentDate,
+            column = column,
+            value = value
         )
-        if (state.selectedDay !in availableDayItems) {
-            state.selectDay(availableDayItems.closestTo(state.selectedDay))
-        }
-    }
-
-    fun updateSelectedDate(update: () -> Unit) {
-        val previousDate = state.selectedDate
-        update()
-        moveSelectionInsideAvailableItems()
-        val nextDate = state.selectedDate
-        if (nextDate != previousDate) {
-            onSelectedDateChange(nextDate)
-        }
+        commitMultiWheelSelection(
+            currentState = currentDate,
+            nextState = nextDate,
+            commitState = state::selectDate,
+            onSelectionCommitted = onSelectedDateChange
+        )
     }
 
     Box(modifier = modifier) {
@@ -148,14 +145,14 @@ fun DatePicker(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     layout.columnOrder.forEach { column ->
-                        key(column) {
+                        key(column, state, items) {
                             when (column) {
                                 DatePickerColumn.YEAR -> {
                                     Picker(
                                         items = yearItems,
                                         selectedItem = state.selectedYear,
                                         onSelectedItemChange = { year ->
-                                            updateSelectedDate { state.selectYear(year) }
+                                            commitColumnChange(DatePickerColumn.YEAR, year)
                                         },
                                         modifier = pickerColumnModifier(pickerModifier, layout.yearWeight),
                                         enabled = enabled,
@@ -171,7 +168,7 @@ fun DatePicker(
                                         items = monthItems,
                                         selectedItem = state.selectedMonth,
                                         onSelectedItemChange = { month ->
-                                            updateSelectedDate { state.selectMonth(month) }
+                                            commitColumnChange(DatePickerColumn.MONTH, month)
                                         },
                                         modifier = pickerColumnModifier(pickerModifier, layout.monthWeight),
                                         enabled = enabled,
@@ -186,7 +183,7 @@ fun DatePicker(
                                         items = dayItems,
                                         selectedItem = state.selectedDay,
                                         onSelectedItemChange = { day ->
-                                            updateSelectedDate { state.selectDay(day) }
+                                            commitColumnChange(DatePickerColumn.DAY, day)
                                         },
                                         modifier = pickerColumnModifier(pickerModifier, layout.dayWeight),
                                         enabled = enabled,
@@ -209,6 +206,11 @@ internal fun validateDatePickerItems(
     state: DatePickerState,
     items: DatePickerItems
 ) {
+    validateDatePickerItemConfiguration(items = items)
+    validateDatePickerSelection(state = state, items = items)
+}
+
+private fun validateDatePickerItemConfiguration(items: DatePickerItems) {
     val yearItems = items.yearItems
     val monthItems = items.monthItems
     val dayItems = items.dayItems
@@ -244,14 +246,6 @@ internal fun validateDatePickerItems(
         "DatePicker dayItems must contain only values in range [1, 31]. " +
                 "Invalid values: $invalidDays"
     }
-    require(state.selectedYear in yearItems) {
-        "DatePicker yearItems must contain state.selectedYear=${state.selectedYear}. " +
-                datePickerStateItemsAdvice()
-    }
-    require(state.selectedMonth in monthItems) {
-        "DatePicker monthItems must contain state.selectedMonth=${state.selectedMonth}. " +
-                datePickerStateItemsAdvice()
-    }
     if (items.constraints.isUnbounded) {
         val minimumMaxDay = minimumMaxDayFor(yearItems, monthItems)
         require(dayItems.any { it <= minimumMaxDay }) {
@@ -259,12 +253,22 @@ internal fun validateDatePickerItems(
                     "year/month combination. Smallest maximum day is $minimumMaxDay."
         }
     }
-    val availableYearItems = items.selectableYearItems()
-    require(state.selectedYear in availableYearItems) {
-        "DatePicker constraints must allow state.selectedYear=${state.selectedYear}. " +
+}
+
+private fun validateDatePickerSelection(state: DatePickerState, items: DatePickerItems) {
+    require(state.selectedYear in items.yearItems) {
+        "DatePicker yearItems must contain state.selectedYear=${state.selectedYear}. " +
+                datePickerStateItemsAdvice()
+    }
+    require(state.selectedMonth in items.monthItems) {
+        "DatePicker monthItems must contain state.selectedMonth=${state.selectedMonth}. " +
                 datePickerStateItemsAdvice()
     }
     val availableMonthItems = items.selectableMonthItemsFor(state.selectedYear)
+    require(availableMonthItems.isNotEmpty()) {
+        "DatePicker constraints must allow state.selectedYear=${state.selectedYear}. " +
+                datePickerStateItemsAdvice()
+    }
     require(state.selectedMonth in availableMonthItems) {
         "DatePicker constraints must allow state.selectedMonth=${state.selectedMonth} " +
                 "for selectedYear=${state.selectedYear}. " +
@@ -288,12 +292,6 @@ private fun datePickerStateItemsAdvice(): String =
 
 private fun List<Int>.invalidValuesFor(range: IntRange): List<Int> =
     filterNot { it in range }.distinct()
-
-private fun List<Int>.closestTo(value: Int): Int =
-    minWith(
-        compareBy<Int> { abs(it - value) }
-            .thenBy { it }
-    )
 
 private fun minimumMaxDayFor(yearItems: List<Int>, monthItems: List<Int>): Int =
     monthItems.minOf { month ->

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerSelection.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerSelection.kt
@@ -1,0 +1,55 @@
+package com.kez.picker.date
+
+import com.kez.picker.DatePickerItems
+import com.kez.picker.DatePickerColumn
+import com.kez.picker.closestPickerValueTo
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
+
+/**
+ * Applies one DatePicker column change and repairs every dependent part as one logical value.
+ */
+internal fun DatePickerItems.repairedDateAfter(
+    currentDate: LocalDate,
+    column: DatePickerColumn,
+    value: Int
+): LocalDate {
+    val isActiveValue = when (column) {
+        DatePickerColumn.YEAR ->
+            value in yearItems && selectableMonthItemsFor(year = value).isNotEmpty()
+
+        DatePickerColumn.MONTH -> value in selectableMonthItemsFor(year = currentDate.year)
+        DatePickerColumn.DAY -> value in selectableDayItemsFor(
+            year = currentDate.year,
+            month = currentDate.month.number
+        )
+    }
+    if (!isActiveValue) return currentDate
+
+    val nextYear = if (column == DatePickerColumn.YEAR) value else currentDate.year
+    val availableMonths = selectableMonthItemsFor(year = nextYear)
+    val requestedMonth = when (column) {
+        DatePickerColumn.MONTH -> value
+        DatePickerColumn.YEAR,
+        DatePickerColumn.DAY -> currentDate.month.number
+    }
+    val nextMonth = availableMonths.closestPickerValueTo(
+        value = requestedMonth,
+        sourceName = "DatePicker dependent month items for year=$nextYear"
+    )
+    val availableDays = selectableDayItemsFor(year = nextYear, month = nextMonth)
+    val requestedDay = when (column) {
+        DatePickerColumn.DAY -> value
+        DatePickerColumn.YEAR,
+        DatePickerColumn.MONTH -> currentDate.day
+    }
+    val nextDay = availableDays.closestPickerValueTo(
+        value = requestedDay,
+        sourceName = "DatePicker dependent day items for year=$nextYear, month=$nextMonth"
+    )
+    return LocalDate(
+        year = nextYear,
+        month = nextMonth,
+        day = nextDay
+    )
+}

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/date/DatePickerState.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.setValue
 import com.kez.picker.DatePickerItems
 import com.kez.picker.util.currentDate
@@ -18,10 +19,8 @@ import kotlinx.datetime.number
  * Creates and remembers a [DatePickerState].
  * Initial date values are read when the state is first created.
  *
- * @param initialYear The initial year to be selected. Defaults to the current year.
- * @param initialMonth The initial month to be selected. Defaults to the current month.
- * @param initialDay The initial day to be selected. Defaults to the current day.
- * @return A [DatePickerState] initialized with the given date values.
+ * @param initialDate The initial date to be selected. Defaults to the current date.
+ * @return A [DatePickerState] initialized with [initialDate].
  */
 @Composable
 fun rememberDatePickerState(
@@ -40,13 +39,15 @@ fun rememberDatePickerState(
 /**
  * Creates and remembers a [DatePickerState] whose initial value is coerced by [items].
  *
- * Initial values and [items] are read when the state is first created. This is useful when the
- * picker is rendered with custom item lists or date bounds and restored app state may fall outside
- * those rules.
+ * Initial values and [items] are read when the state is first created. On recreation, the [items]
+ * supplied by the recreated composition also coerce the saved value, so the picker cannot restore
+ * outside its current custom lists or date bounds.
  *
  * @param items Selectable values used to coerce [initialDate] before creating the state.
  * @param initialDate The requested initial date.
  * @return A [DatePickerState] initialized to the closest selectable date.
+ * @throws IllegalArgumentException if the configured item lists are invalid or contain no date
+ * allowed by their constraints.
  */
 @Composable
 fun rememberDatePickerState(
@@ -58,7 +59,10 @@ fun rememberDatePickerState(
     val coercedInitialDate = remember(rememberedInitialDate, rememberedItems) {
         rememberedItems.coerceDate(rememberedInitialDate)
     }
-    return rememberDatePickerState(initialDate = coercedInitialDate)
+    val saver = remember(rememberedItems) { datePickerStateSaver(rememberedItems) }
+    return rememberSaveable(saver = saver) {
+        DatePickerState(initialDate = coercedInitialDate)
+    }
 }
 
 /**
@@ -66,12 +70,15 @@ fun rememberDatePickerState(
  *
  * Initial values and [items] are read when the state is first created. If [initialDay] is greater
  * than the maximum day for [initialYear] and [initialMonth], it is clamped before applying [items].
+ * On recreation, the [items] supplied by the recreated composition also coerce the saved value.
  *
  * @param items Selectable values used to coerce [initialYear], [initialMonth], and [initialDay].
  * @param initialYear The requested initial year. Must be in 1000..9999.
  * @param initialMonth The requested initial month. Must be in 1..12.
  * @param initialDay The requested initial day. Must be at least 1.
  * @return A [DatePickerState] initialized to the closest selectable date.
+ * @throws IllegalArgumentException if an initial date part is outside its supported range, or if
+ * the configured item lists are invalid or contain no date allowed by their constraints.
  */
 @Composable
 fun rememberDatePickerState(
@@ -96,8 +103,25 @@ fun rememberDatePickerState(
             day = rememberedInitialDay
         )
     }
-    return rememberDatePickerState(initialDate = coercedInitialDate)
+    return rememberDatePickerState(
+        items = rememberedItems,
+        initialDate = coercedInitialDate
+    )
 }
+
+private fun datePickerStateSaver(items: DatePickerItems): Saver<DatePickerState, Any> =
+    listSaver(
+        save = { listOf(it.selectedYear, it.selectedMonth, it.selectedDay) },
+        restore = {
+            DatePickerState(
+                initialDate = items.coerceDate(
+                    year = it[0] as Int,
+                    month = it[1] as Int,
+                    day = it[2] as Int
+                )
+            )
+        }
+    )
 
 /**
  * Creates and remembers a [DatePickerState] with explicit year, month, and day values.
@@ -197,6 +221,8 @@ class DatePickerState(
     /**
      * Programmatically selects [date].
      *
+     * The year, month, and day fields are applied together as one logical state update.
+     *
      * @throws IllegalArgumentException if [date]'s year is outside the supported range.
      */
     fun selectDate(date: LocalDate) {
@@ -246,35 +272,13 @@ class DatePickerState(
     val maxDay: Int
         get() = daysInMonth(selectedYear, selectedMonth)
 
-    internal fun selectYear(year: Int) {
-        updateDate(
-            year = year,
-            month = selectedMonth,
-            day = selectedDay
-        )
-    }
-
-    internal fun selectMonth(month: Int) {
-        updateDate(
-            year = selectedYear,
-            month = month,
-            day = selectedDay
-        )
-    }
-
-    internal fun selectDay(day: Int) {
-        updateDate(
-            year = selectedYear,
-            month = selectedMonth,
-            day = day
-        )
-    }
-
     private fun updateDate(year: Int, month: Int, day: Int) {
         val date = dateFromParts(year = year, month = month, day = day)
-        mutableSelectedYear = date.year
-        mutableSelectedMonth = date.month.number
-        mutableSelectedDay = date.day
+        Snapshot.withMutableSnapshot {
+            mutableSelectedYear = date.year
+            mutableSelectedMonth = date.month.number
+            mutableSelectedDay = date.day
+        }
     }
 
     private fun dateFromParts(year: Int, month: Int, day: Int): LocalDate {

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePicker.kt
@@ -22,6 +22,7 @@ import com.kez.picker.PickerDefaults
 import com.kez.picker.PickerSelectionBand
 import com.kez.picker.PickerSelectionIndicator
 import com.kez.picker.PickerStyle
+import com.kez.picker.commitMultiWheelSelection
 import com.kez.picker.TimePickerColumn
 import com.kez.picker.TimePickerFormat
 import com.kez.picker.TimePickerLayout
@@ -39,10 +40,12 @@ import kotlinx.datetime.LocalTime
  * @param modifier The modifier to be applied to the component.
  * @param pickerModifier The modifier to be applied to each picker.
  * @param state The state object to control the picker.
- * @param onSelectedTimeChange Called after user interaction changes the selected time.
- * Programmatic [TimePickerState.selectTime] calls update [state] directly and do not invoke this
- * callback. When app code changes the picker from a button, preset, or external value, update any
- * app-owned state in the same handler.
+ * @param onSelectedTimeChange Called once after a user interaction settles on a new column value,
+ * dependent period/hour/minute values are repaired, and the final selectable time is committed to
+ * [state]. If an upstream settle replaces a still-moving dependent column source, that invalidated
+ * child interaction is cancelled without a callback. Programmatic [TimePickerState.selectTime]
+ * calls update [state] directly and do not invoke this callback. When app code changes the picker
+ * from a button, preset, or external value, update any app-owned state in the same handler.
  * @param enabled Whether user scroll, click, and semantics selection actions are enabled.
  * @param items Selectable minute, hour, and period item lists for the picker.
  * @param format Visible item text and optional accessibility value descriptions for each picker column.
@@ -72,29 +75,22 @@ fun TimePicker(
 ) {
     val columnStyle = remember(style) { style.copy(isDividerVisible = false) }
 
+    remember(items, state.timeFormat) {
+        validateTimePickerItemConfiguration(timeFormat = state.timeFormat, items = items)
+    }
     remember(items, state, state.selectedTime, state.selectedHour, state.selectedPeriod, state.timeFormat) {
-        validateTimePickerItems(state = state, items = items)
+        validateTimePickerSelection(state = state, items = items)
     }
 
-    fun moveSelectionInsideAvailableItems() {
-        if (items.contains(state.selectedTime, state.timeFormat)) return
-
-        state.selectTime(
-            time = items.coerceTime(
-                time = state.selectedTime,
-                timeFormat = state.timeFormat
-            )
+    fun commitColumnChange(repair: (LocalTime) -> LocalTime) {
+        val currentTime = state.selectedTime
+        val nextTime = repair(currentTime)
+        commitMultiWheelSelection(
+            currentState = currentTime,
+            nextState = nextTime,
+            commitState = state::selectTime,
+            onSelectionCommitted = onSelectedTimeChange
         )
-    }
-
-    fun updateSelectedTime(update: () -> Unit) {
-        val previousTime = state.selectedTime
-        update()
-        moveSelectionInsideAvailableItems()
-        val nextTime = state.selectedTime
-        if (nextTime != previousTime) {
-            onSelectedTimeChange(nextTime)
-        }
     }
 
     val periodItems by remember(items) {
@@ -155,7 +151,7 @@ fun TimePicker(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     layout.columnOrder.forEach { column ->
-                        key(column) {
+                        key(column, state, items) {
                             when (column) {
                                 TimePickerColumn.PERIOD -> {
                                     if (state.timeFormat == TimeFormat.HOUR_12) {
@@ -163,7 +159,12 @@ fun TimePicker(
                                             items = periodItems,
                                             selectedItem = state.selectedPeriod,
                                             onSelectedItemChange = { period ->
-                                                updateSelectedTime { state.selectPeriod(period) }
+                                                commitColumnChange { currentTime ->
+                                                    items.repairedTimeAfterPeriod(
+                                                        currentTime = currentTime,
+                                                        period = period
+                                                    )
+                                                }
                                             },
                                             modifier = pickerColumnModifier(pickerModifier, layout.periodWeight),
                                             enabled = enabled,
@@ -180,7 +181,13 @@ fun TimePicker(
                                         items = hourItems,
                                         selectedItem = state.selectedHour,
                                         onSelectedItemChange = { hour ->
-                                            updateSelectedTime { state.selectHour(hour) }
+                                            commitColumnChange { currentTime ->
+                                                items.repairedTimeAfterHour(
+                                                    currentTime = currentTime,
+                                                    timeFormat = state.timeFormat,
+                                                    hour = hour
+                                                )
+                                            }
                                         },
                                         modifier = pickerColumnModifier(pickerModifier, layout.hourWeight),
                                         enabled = enabled,
@@ -195,7 +202,13 @@ fun TimePicker(
                                         items = minuteItems,
                                         selectedItem = state.selectedMinute,
                                         onSelectedItemChange = { minute ->
-                                            updateSelectedTime { state.selectMinute(minute) }
+                                            commitColumnChange { currentTime ->
+                                                items.repairedTimeAfterMinute(
+                                                    currentTime = currentTime,
+                                                    timeFormat = state.timeFormat,
+                                                    minute = minute
+                                                )
+                                            }
                                         },
                                         modifier = pickerColumnModifier(pickerModifier, layout.minuteWeight),
                                         enabled = enabled,
@@ -217,8 +230,16 @@ internal fun validateTimePickerItems(
     state: TimePickerState,
     items: TimePickerItems
 ) {
+    validateTimePickerItemConfiguration(timeFormat = state.timeFormat, items = items)
+    validateTimePickerSelection(state = state, items = items)
+}
+
+private fun validateTimePickerItemConfiguration(
+    timeFormat: TimeFormat,
+    items: TimePickerItems
+) {
     val minuteItems = items.minuteItems
-    val hourItems = items.hourItemsFor(state.timeFormat)
+    val hourItems = items.hourItemsFor(timeFormat)
     val periodItems = items.periodItems
 
     val minuteRange = 0..59
@@ -231,12 +252,7 @@ internal fun validateTimePickerItems(
         "TimePicker minuteItems must contain only values in range [0, 59]. " +
                 "Invalid values: $invalidMinutes"
     }
-    require(state.selectedMinute in minuteItems) {
-        "TimePicker minuteItems must contain state.selectedMinute=${state.selectedMinute}. " +
-                timePickerStateItemsAdvice()
-    }
-
-    val isHour12 = state.timeFormat == TimeFormat.HOUR_12
+    val isHour12 = timeFormat == TimeFormat.HOUR_12
     val hourItemsName = if (isHour12) "hour12Items" else "hour24Items"
     val hourRange = if (isHour12) 1..12 else 0..23
     val hourRangeLabel = if (isHour12) "1, 12" else "0, 23"
@@ -247,12 +263,7 @@ internal fun validateTimePickerItems(
     }
     require(invalidHours.isEmpty()) {
         "TimePicker $hourItemsName must contain only values in range [$hourRangeLabel] " +
-                "for timeFormat=${state.timeFormat}. Invalid values: $invalidHours"
-    }
-    require(state.selectedHour in hourItems) {
-        "TimePicker $hourItemsName must contain state.selectedHour=${state.selectedHour} " +
-                "for timeFormat=${state.timeFormat}. " +
-                timePickerStateItemsAdvice()
+                "for timeFormat=$timeFormat. Invalid values: $invalidHours"
     }
 
     if (isHour12) {
@@ -262,7 +273,24 @@ internal fun validateTimePickerItems(
         require(periodItems.distinct().size == periodItems.size) {
             "TimePicker periodItems must not contain duplicate values."
         }
-        require(state.selectedPeriod in periodItems) {
+    }
+}
+
+private fun validateTimePickerSelection(state: TimePickerState, items: TimePickerItems) {
+    require(state.selectedMinute in items.minuteItems) {
+        "TimePicker minuteItems must contain state.selectedMinute=${state.selectedMinute}. " +
+                timePickerStateItemsAdvice()
+    }
+    val hourItems = items.hourItemsFor(state.timeFormat)
+    val hourItemsName = if (state.timeFormat == TimeFormat.HOUR_12) "hour12Items" else "hour24Items"
+    require(state.selectedHour in hourItems) {
+        "TimePicker $hourItemsName must contain state.selectedHour=${state.selectedHour} " +
+                "for timeFormat=${state.timeFormat}. " +
+                timePickerStateItemsAdvice()
+    }
+
+    if (state.timeFormat == TimeFormat.HOUR_12) {
+        require(state.selectedPeriod in items.periodItems) {
             "TimePicker periodItems must contain state.selectedPeriod=${state.selectedPeriod}. " +
                     timePickerStateItemsAdvice()
         }

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerSelection.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerSelection.kt
@@ -1,0 +1,118 @@
+package com.kez.picker.time
+
+import com.kez.picker.TimePickerItems
+import com.kez.picker.closestPickerValueTo
+import com.kez.picker.util.TimeFormat
+import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalTime
+
+/**
+ * Applies one TimePicker hour-column change and repairs every dependent part as one logical value.
+ */
+internal fun TimePickerItems.repairedTimeAfterHour(
+    currentTime: LocalTime,
+    timeFormat: TimeFormat,
+    hour: Int
+): LocalTime {
+    val currentPeriod = periodFor(currentTime)
+    if (hour !in selectableHourItemsFor(timeFormat = timeFormat, period = currentPeriod)) {
+        return currentTime
+    }
+    return repairedTimeAfter(
+        currentTime = currentTime,
+        timeFormat = timeFormat,
+        requestedHour = hour
+    )
+}
+
+/**
+ * Applies one TimePicker minute-column change and repairs every dependent part as one logical value.
+ */
+internal fun TimePickerItems.repairedTimeAfterMinute(
+    currentTime: LocalTime,
+    timeFormat: TimeFormat,
+    minute: Int
+): LocalTime {
+    if (minute !in selectableMinuteItemsFor(hourOfDay = currentTime.hour)) return currentTime
+    return repairedTimeAfter(
+        currentTime = currentTime,
+        timeFormat = timeFormat,
+        requestedMinute = minute
+    )
+}
+
+/**
+ * Applies one TimePicker period-column change and repairs every dependent part as one logical value.
+ */
+internal fun TimePickerItems.repairedTimeAfterPeriod(
+    currentTime: LocalTime,
+    period: TimePeriod
+): LocalTime {
+    if (period !in selectablePeriodItems()) return currentTime
+    return repairedTimeAfter(
+        currentTime = currentTime,
+        timeFormat = TimeFormat.HOUR_12,
+        requestedPeriod = period
+    )
+}
+
+private fun TimePickerItems.repairedTimeAfter(
+    currentTime: LocalTime,
+    timeFormat: TimeFormat,
+    requestedHour: Int? = null,
+    requestedMinute: Int? = null,
+    requestedPeriod: TimePeriod? = null
+): LocalTime {
+    val nextPeriod = when (timeFormat) {
+        TimeFormat.HOUR_24 -> TimePeriod.AM
+        TimeFormat.HOUR_12 -> {
+            val availablePeriods = selectablePeriodItems()
+            require(availablePeriods.isNotEmpty()) {
+                "TimePicker dependent period items must contain at least one selectable value."
+            }
+            val period = requestedPeriod ?: periodFor(currentTime)
+            period.takeIf(availablePeriods::contains) ?: availablePeriods.first()
+        }
+    }
+    val availableHours = selectableHourItemsFor(
+        timeFormat = timeFormat,
+        period = nextPeriod
+    )
+    val hour = requestedHour ?: when (timeFormat) {
+            TimeFormat.HOUR_24 -> currentTime.hour
+            TimeFormat.HOUR_12 -> displayHourFor(currentTime)
+    }
+    val nextHour = availableHours.closestPickerValueTo(
+        value = hour,
+        sourceName = "TimePicker dependent hour items for timeFormat=$timeFormat, period=$nextPeriod"
+    )
+    val nextHourOfDay = when (timeFormat) {
+        TimeFormat.HOUR_24 -> nextHour
+        TimeFormat.HOUR_12 -> hourOfDay(displayHour = nextHour, period = nextPeriod)
+    }
+    val availableMinutes = selectableMinuteItemsFor(hourOfDay = nextHourOfDay)
+    val minute = requestedMinute ?: currentTime.minute
+    val nextMinute = availableMinutes.closestPickerValueTo(
+        value = minute,
+        sourceName = "TimePicker dependent minute items for hourOfDay=$nextHourOfDay"
+    )
+    return LocalTime(hour = nextHourOfDay, minute = nextMinute)
+}
+
+private fun displayHourFor(time: LocalTime): Int = (time.hour % 12).let { hour ->
+    if (hour == 0) 12 else hour
+}
+
+private fun periodFor(time: LocalTime): TimePeriod =
+    if (time.hour >= 12) TimePeriod.PM else TimePeriod.AM
+
+private fun hourOfDay(displayHour: Int, period: TimePeriod): Int {
+    require(displayHour in 1..12) {
+        "displayHour must be in range [1, 12], but was $displayHour"
+    }
+    return when {
+        period == TimePeriod.AM && displayHour == 12 -> 0
+        period == TimePeriod.PM && displayHour != 12 -> displayHour + 12
+        else -> displayHour
+    }
+}

--- a/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
+++ b/datetimepicker/src/commonMain/kotlin/com/kez/picker/time/TimePickerState.kt
@@ -5,9 +5,11 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.setValue
 import com.kez.picker.TimePickerItems
 import com.kez.picker.util.TimeFormat
@@ -79,14 +81,17 @@ fun rememberTimePickerState(
 /**
  * Creates and remembers a [TimePickerState] whose initial value is coerced by [items].
  *
- * Initial values and [items] are read when the state is first created. This is useful when the
- * picker is rendered with custom item lists or time bounds and restored app state may fall outside
- * those rules.
+ * Initial values and [items] are read when the state is first created. An items-only recomposition
+ * does not reset the state. If [timeFormat] changes, the state is recreated against the latest
+ * [items]. On recreation, the [items] supplied by the recreated composition also coerce the saved
+ * value, so the picker cannot restore outside its current custom lists or time bounds.
  *
  * @param items Selectable values used to coerce [initialTime] before creating the state.
  * @param initialTime The requested initial time.
  * @param timeFormat The time format (12-hour or 24-hour). Defaults to [TimeFormat.HOUR_24].
  * @return A [TimePickerState] initialized to the closest selectable time.
+ * @throws IllegalArgumentException if the item lists needed by [timeFormat] are invalid or contain
+ * no time allowed by their constraints.
  */
 @Composable
 fun rememberTimePickerState(
@@ -95,17 +100,20 @@ fun rememberTimePickerState(
     timeFormat: TimeFormat = TimeFormat.HOUR_24
 ): TimePickerState {
     val rememberedInitialTime = remember { initialTime }
-    val rememberedItems = remember { items }
-    val coercedInitialTime = remember(rememberedInitialTime, rememberedItems, timeFormat) {
-        rememberedItems.coerceTime(
+    val currentItems by rememberUpdatedState(items)
+    val itemsForState = remember(timeFormat) { currentItems }
+    val coercedInitialTime = remember(rememberedInitialTime, itemsForState, timeFormat) {
+        itemsForState.coerceTime(
             time = rememberedInitialTime,
             timeFormat = timeFormat
         )
     }
-    return rememberTimePickerState(
-        initialTime = coercedInitialTime,
-        timeFormat = timeFormat
-    )
+    val saver = remember(itemsForState, timeFormat) {
+        timePickerStateSaver(timeFormat = timeFormat, items = itemsForState)
+    }
+    return rememberSaveable(timeFormat, saver = saver) {
+        TimePickerState(initialTime = coercedInitialTime, timeFormat = timeFormat)
+    }
 }
 
 /**
@@ -115,6 +123,7 @@ fun rememberTimePickerState(
  * the same way as [rememberTimePickerState] without [items]: as an hour-of-day in `0..23`, then
  * converted to the active [timeFormat]. In 12-hour mode, [initialPeriod] can override the period
  * derived from [initialHour].
+ * On recreation, the [items] supplied by the recreated composition also coerce the saved value.
  *
  * @param items Selectable values used to coerce [initialHour] and [initialMinute].
  * @param initialHour The requested initial hour-of-day. Must be in 0..23.
@@ -122,6 +131,9 @@ fun rememberTimePickerState(
  * @param initialPeriod The requested AM/PM period when [timeFormat] is [TimeFormat.HOUR_12].
  * @param timeFormat The time format (12-hour or 24-hour). Defaults to [TimeFormat.HOUR_24].
  * @return A [TimePickerState] initialized to the closest selectable time.
+ * @throws IllegalArgumentException if [initialHour] or [initialMinute] is outside its supported
+ * range, or if the item lists needed by [timeFormat] are invalid or contain no time allowed by
+ * their constraints.
  */
 @Composable
 fun rememberTimePickerState(
@@ -134,7 +146,6 @@ fun rememberTimePickerState(
     val rememberedInitialHour = remember { initialHour }
     val rememberedInitialMinute = remember { initialMinute }
     val rememberedInitialPeriod = remember { initialPeriod }
-    val rememberedItems = remember { items }
     val requestedInitialTime = remember(
         rememberedInitialHour,
         rememberedInitialMinute,
@@ -148,14 +159,9 @@ fun rememberTimePickerState(
             timeFormat = timeFormat
         )
     }
-    val coercedInitialTime = remember(requestedInitialTime, rememberedItems, timeFormat) {
-        rememberedItems.coerceTime(
-            time = requestedInitialTime,
-            timeFormat = timeFormat
-        )
-    }
     return rememberTimePickerState(
-        initialTime = coercedInitialTime,
+        items = items,
+        initialTime = requestedInitialTime,
         timeFormat = timeFormat
     )
 }
@@ -208,17 +214,20 @@ private fun displayTimeFromParts(displayHour: Int, minute: Int, period: TimePeri
     return LocalTime(hour = hourOfDay, minute = minute)
 }
 
-private fun timePickerStateSaver(timeFormat: TimeFormat): Saver<TimePickerState, Any> {
+private fun timePickerStateSaver(
+    timeFormat: TimeFormat,
+    items: TimePickerItems? = null
+): Saver<TimePickerState, Any> {
     return listSaver(
         save = { listOf(it.selectedHourOfDay, it.selectedMinute) },
         restore = {
             val restoredHourOfDay = it[0] as Int
-            TimePickerState(
-                initialHour = initialHourForTimeFormat(restoredHourOfDay, timeFormat),
-                initialMinute = it[1] as Int,
-                initialPeriod = if (restoredHourOfDay >= 12) TimePeriod.PM else TimePeriod.AM,
-                timeFormat = timeFormat
+            val restoredTime = LocalTime(
+                hour = restoredHourOfDay,
+                minute = it[1] as Int
             )
+            val selectedTime = items?.coerceTime(restoredTime, timeFormat) ?: restoredTime
+            TimePickerState(initialTime = selectedTime, timeFormat = timeFormat)
         }
     )
 }
@@ -316,12 +325,14 @@ class TimePickerState(
      *
      * The hour is converted to the current [timeFormat]. In 12-hour mode, the AM/PM period is derived from
      * [time]. In 24-hour mode, [selectedPeriod] is still updated for consistency but is not formatted by
-     * [TimePicker].
+     * [TimePicker]. The hour, minute, and period fields are applied together as one logical state update.
      */
     fun selectTime(time: LocalTime) {
-        mutableSelectedHour = initialHourForTimeFormat(time.hour, timeFormat)
-        mutableSelectedMinute = time.minute
-        mutableSelectedPeriod = if (time.hour >= 12) TimePeriod.PM else TimePeriod.AM
+        Snapshot.withMutableSnapshot {
+            mutableSelectedHour = initialHourForTimeFormat(time.hour, timeFormat)
+            mutableSelectedMinute = time.minute
+            mutableSelectedPeriod = if (time.hour >= 12) TimePeriod.PM else TimePeriod.AM
+        }
     }
 
     /**
@@ -376,26 +387,6 @@ class TimePickerState(
      */
     fun selectTime(displayHour: Int, minute: Int, period: TimePeriod, items: TimePickerItems) {
         selectTime(items.coerceTime(displayHour = displayHour, minute = minute, period = period))
-    }
-
-    internal fun selectHour(hour: Int) {
-        val hourRange = if (timeFormat == TimeFormat.HOUR_12) 1..12 else 0..23
-        val hourRangeLabel = if (timeFormat == TimeFormat.HOUR_12) "1..12" else "0..23"
-        require(hour in hourRange) {
-            "hour must be in range $hourRangeLabel for timeFormat=$timeFormat, but was $hour"
-        }
-        mutableSelectedHour = hour
-    }
-
-    internal fun selectMinute(minute: Int) {
-        require(minute in 0..59) {
-            "minute must be in range 0..59, but was $minute"
-        }
-        mutableSelectedMinute = minute
-    }
-
-    internal fun selectPeriod(period: TimePeriod) {
-        mutableSelectedPeriod = period
     }
 
     companion object {

--- a/datetimepicker/src/commonTest/kotlin/com/kez/picker/MultiWheelSelectionContractTest.kt
+++ b/datetimepicker/src/commonTest/kotlin/com/kez/picker/MultiWheelSelectionContractTest.kt
@@ -1,0 +1,312 @@
+package com.kez.picker
+
+import androidx.compose.runtime.snapshots.Snapshot
+import com.kez.picker.date.DatePickerState
+import com.kez.picker.date.repairedDateAfter
+import com.kez.picker.time.TimePickerState
+import com.kez.picker.time.repairedTimeAfterHour
+import com.kez.picker.time.repairedTimeAfterMinute
+import com.kez.picker.time.repairedTimeAfterPeriod
+import com.kez.picker.util.TimeFormat
+import com.kez.picker.util.TimePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class MultiWheelSelectionContractTest {
+
+    @Test
+    fun commitMultiWheelSelection_commitsBeforeDispatchingExactlyOneCallback() {
+        var committedState = "before"
+        val callbackStates = mutableListOf<String>()
+
+        val changed = commitMultiWheelSelection(
+            currentState = "before",
+            nextState = "after",
+            commitState = { committedState = it },
+            onSelectionCommitted = { callbackValue ->
+                assertEquals(callbackValue, committedState)
+                callbackStates += callbackValue
+            }
+        )
+
+        assertTrue(changed)
+        assertEquals("after", committedState)
+        assertEquals(listOf("after"), callbackStates)
+    }
+
+    @Test
+    fun commitMultiWheelSelection_ignoresUnchangedLogicalValue() {
+        var commitCount = 0
+        var callbackCount = 0
+
+        val changed = commitMultiWheelSelection(
+            currentState = 7,
+            nextState = 7,
+            commitState = { commitCount++ },
+            onSelectionCommitted = { callbackCount++ }
+        )
+
+        assertEquals(false, changed)
+        assertEquals(0, commitCount)
+        assertEquals(0, callbackCount)
+    }
+
+    @Test
+    fun dateColumnChange_repairsDependentDayAsOneSelectableDate() {
+        val items = DatePickerItems(
+            yearItems = listOf(2025),
+            monthItems = listOf(1, 2),
+            dayItems = listOf(15, 31)
+        )
+
+        val nextDate = items.repairedDateAfter(
+            currentDate = LocalDate(2025, 1, 31),
+            column = DatePickerColumn.MONTH,
+            value = 2
+        )
+
+        assertEquals(LocalDate(2025, 2, 15), nextDate)
+        assertTrue(items.contains(nextDate))
+    }
+
+    @Test
+    fun dateMonthRepair_doesNotTraverseTheLargeYearSource() {
+        val items = DatePickerItems(
+            yearItems = FailOnReadIntList(size = 9_000),
+            monthItems = listOf(1, 2),
+            dayItems = listOf(15, 31)
+        )
+
+        val nextDate = items.repairedDateAfter(
+            currentDate = LocalDate(2025, 1, 31),
+            column = DatePickerColumn.MONTH,
+            value = 2
+        )
+
+        assertEquals(LocalDate(2025, 2, 15), nextDate)
+    }
+
+    @Test
+    fun dateColumnChanges_fromDifferentColumnsAlwaysReturnSelectableValues() {
+        val items = DatePickerItems(
+            yearItems = listOf(2024, 2025),
+            monthItems = listOf(1, 2),
+            dayItems = listOf(15, 29, 31),
+            constraints = DatePickerConstraints(
+                minDate = LocalDate(2024, 1, 15),
+                maxDate = LocalDate(2025, 2, 15)
+            )
+        )
+        val changes = listOf(
+            DatePickerColumn.MONTH to 2,
+            DatePickerColumn.YEAR to 2025,
+            DatePickerColumn.DAY to 31
+        )
+
+        val committedDates = changes.runningFold(LocalDate(2024, 1, 31)) { date, (column, value) ->
+            items.repairedDateAfter(currentDate = date, column = column, value = value)
+        }.drop(1)
+
+        assertEquals(
+            listOf(
+                LocalDate(2024, 2, 29),
+                LocalDate(2025, 2, 15),
+                LocalDate(2025, 2, 15)
+            ),
+            committedDates
+        )
+        assertTrue(committedDates.all(items::contains))
+    }
+
+    @Test
+    fun lateUnavailableDateColumnValuesKeepTheCurrentSelectableDate() {
+        val replacementItems = DatePickerItems(
+            yearItems = listOf(2025, 2026),
+            monthItems = listOf(1, 3),
+            dayItems = listOf(15, 31),
+            constraints = DatePickerConstraints(
+                minDate = LocalDate(2025, 1, 1),
+                maxDate = LocalDate(2025, 12, 31)
+            )
+        )
+        val currentDate = LocalDate(2025, 3, 31)
+
+        val lateResults = listOf(
+            DatePickerColumn.YEAR to 2026,
+            DatePickerColumn.MONTH to 2,
+            DatePickerColumn.DAY to 30
+        ).map { (column, value) ->
+            replacementItems.repairedDateAfter(
+                currentDate = currentDate,
+                column = column,
+                value = value
+            )
+        }
+
+        assertEquals(listOf(currentDate, currentDate, currentDate), lateResults)
+        assertTrue(lateResults.all(replacementItems::contains))
+    }
+
+    @Test
+    fun lateUnavailableTimeColumnValuesKeepTheCurrentSelectableTime() {
+        val replacementItems = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = listOf(0, 10, 12),
+            hour12Items = listOf(10, 12),
+            periodItems = listOf(TimePeriod.AM)
+        )
+        val currentTime = LocalTime(0, 0)
+
+        val lateResults = listOf(
+            replacementItems.repairedTimeAfterHour(
+                currentTime = currentTime,
+                timeFormat = TimeFormat.HOUR_24,
+                hour = 11
+            ),
+            replacementItems.repairedTimeAfterMinute(
+                currentTime = currentTime,
+                timeFormat = TimeFormat.HOUR_24,
+                minute = 15
+            ),
+            replacementItems.repairedTimeAfterPeriod(
+                currentTime = currentTime,
+                period = TimePeriod.PM
+            )
+        )
+
+        assertEquals(listOf(currentTime, currentTime, currentTime), lateResults)
+        assertTrue(lateResults.all { replacementItems.contains(it, TimeFormat.HOUR_24) })
+    }
+
+    @Test
+    fun timeColumnChange_repairsDependentMinuteAsOneSelectableTime() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = listOf(10, 11),
+            hour12Items = (1..12).toList(),
+            periodItems = com.kez.picker.util.TimePeriod.entries,
+            constraints = TimePickerConstraints(
+                minTime = LocalTime(10, 30),
+                maxTime = LocalTime(11, 0)
+            )
+        )
+
+        val nextTime = items.repairedTimeAfterHour(
+            currentTime = LocalTime(10, 30),
+            timeFormat = TimeFormat.HOUR_24,
+            hour = 11
+        )
+
+        assertEquals(LocalTime(11, 0), nextTime)
+        assertTrue(items.contains(nextTime, TimeFormat.HOUR_24))
+    }
+
+    @Test
+    fun timePeriodChange_repairsHourAndMinuteWithinTheRequestedPeriod() {
+        val items = TimePickerItems(
+            minuteItems = listOf(0, 30),
+            hour24Items = (0..23).toList(),
+            hour12Items = listOf(11),
+            periodItems = listOf(TimePeriod.AM, TimePeriod.PM)
+        )
+
+        val nextTime = items.repairedTimeAfterPeriod(
+            currentTime = LocalTime(11, 30),
+            period = TimePeriod.PM
+        )
+
+        assertEquals(LocalTime(23, 30), nextTime)
+        assertTrue(items.contains(nextTime, TimeFormat.HOUR_12))
+    }
+
+    @Test
+    fun invalidDependentSources_failDuringConfigurationValidation() {
+        val invalidDateItems = DatePickerItems(
+            yearItems = listOf(2025),
+            monthItems = listOf(2),
+            dayItems = emptyList()
+        )
+        val invalidTimeItems = TimePickerItems(
+            minuteItems = listOf(0),
+            hour24Items = listOf(10),
+            hour12Items = listOf(10),
+            periodItems = com.kez.picker.util.TimePeriod.entries,
+            constraints = TimePickerConstraints(
+                minTime = LocalTime(10, 15),
+                maxTime = LocalTime(10, 15)
+            )
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            com.kez.picker.date.validateDatePickerItems(
+                state = DatePickerState(initialDate = LocalDate(2025, 2, 1)),
+                items = invalidDateItems
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            com.kez.picker.time.validateTimePickerItems(
+                state = TimePickerState(
+                    initialTime = LocalTime(10, 0),
+                    timeFormat = TimeFormat.HOUR_24
+                ),
+                items = invalidTimeItems
+            )
+        }
+    }
+
+    @Test
+    fun programmaticMultiFieldUpdates_applyOneSnapshotPerLogicalValue() {
+        val dateState = DatePickerState(LocalDate(2024, 1, 31))
+        val timeState = TimePickerState(LocalTime(10, 5))
+        Snapshot.sendApplyNotifications()
+        val observedLogicalValues = mutableListOf<Pair<LocalDate, LocalTime>>()
+        val observer = Snapshot.registerApplyObserver { changed, _ ->
+            if (changed.isNotEmpty()) {
+                observedLogicalValues += dateState.selectedDate to timeState.selectedTime
+            }
+        }
+
+        try {
+            dateState.selectDate(LocalDate(2025, 2, 28))
+            timeState.selectTime(LocalTime(23, 45))
+            Snapshot.sendApplyNotifications()
+        } finally {
+            observer.dispose()
+        }
+
+        assertEquals(
+            listOf(
+                LocalDate(2025, 2, 28) to LocalTime(10, 5),
+                LocalDate(2025, 2, 28) to LocalTime(23, 45)
+            ),
+            observedLogicalValues
+        )
+        assertEquals(LocalDate(2025, 2, 28), dateState.selectedDate)
+        assertEquals(LocalTime(23, 45), timeState.selectedTime)
+    }
+
+    @Test
+    fun programmaticMultiFieldUpdates_canRunInsideAnExistingMutableSnapshot() {
+        val dateState = DatePickerState(LocalDate(2024, 1, 31))
+        val timeState = TimePickerState(LocalTime(10, 5))
+
+        Snapshot.withMutableSnapshot {
+            dateState.selectDate(LocalDate(2025, 2, 28))
+            timeState.selectTime(LocalTime(23, 45))
+        }
+
+        assertEquals(LocalDate(2025, 2, 28), dateState.selectedDate)
+        assertEquals(LocalTime(23, 45), timeState.selectedTime)
+    }
+
+    private class FailOnReadIntList(
+        override val size: Int
+    ) : AbstractList<Int>() {
+        override fun get(index: Int): Int =
+            error("The year source must not be traversed during a month/day repair.")
+    }
+}

--- a/docs/product/multi-wheel-selection-contract.md
+++ b/docs/product/multi-wheel-selection-contract.md
@@ -1,0 +1,79 @@
+# Multi-column selection contract
+
+## Slice hypothesis
+
+The minimum reusable model shared by `DatePicker` and `TimePicker` is not a public dependency-graph
+DSL. It is a deterministic logical-value transition:
+
+```text
+current valid logical value + typed column change
+  -> preset constraint repair
+  -> next valid logical value
+  -> one state commit
+  -> one user callback with the committed value
+```
+
+The transition owns dependency and repair rules. Visual column order does not participate in the
+transition. Child wheels keep the settled-only `Picker` contract for this slice. If an upstream
+column settles while a dependent wheel is still moving, the dependent item source and its
+`LazyListState` are replaced; that invalidated gesture is cancelled without a callback. If the
+dependent wheel settles first, its valid value commits first and the later upstream commit repairs
+from that value. Settlement order therefore decides which valid transitions commit, but no
+impossible intermediate logical value is emitted.
+
+A direct column change is accepted only when that value still belongs to the active constrained
+source. A late value that is no longer selectable in the active source is a no-op; this slice does
+not track source provenance or reject an old-source value that is also valid in the new source. Once
+accepted, Date repair preserves the changed column and repairs `year -> month -> day`; Time repair
+preserves the changed column and repairs `period -> hour -> minute`. Numeric dependent values use
+nearest distance and prefer the smaller value on an equal-distance tie.
+
+Programmatic state changes do not enter the user-transition path and therefore dispatch no user
+callback. Replacing item sources is also app-driven: the app must coerce its logical value with the
+new item object before composition. Empty, duplicate, out-of-range, or selection-omitting sources
+remain configuration errors and fail before child wheels are composed.
+
+## Acceptance criteria
+
+- A Date column change and its dependent month/day repair produce one selectable `LocalDate` and one
+  callback.
+- A Time column change and its dependent period/hour/minute repair produce one selectable
+  `LocalTime` and one callback.
+- The state is committed before the callback, so reading the state from the callback returns the
+  callback value.
+- A no-op user change, app-driven state change, or compatible item-source replacement dispatches no
+  callback.
+- Replacing the state object or item-source semantics recreates the child-wheel generation, so an
+  in-flight interaction from the previous generation cannot commit into the replacement.
+- Programmatic multi-field state updates are applied in one Compose mutable snapshot, preventing
+  observers from receiving a partially updated logical value.
+- Non-default visual column order yields the same repaired logical value.
+- Sequential completion of changes from different columns never commits a value rejected by the
+  active item constraints.
+- Normal month/day repair does not rescan, sort, or materialize the 9,000-year source. Full item
+  configuration validation is remembered by `items`; selection validation can still perform a
+  linear current-year membership check before inspecting dependent month/day lists. Component-level
+  startup and interaction cost therefore remains an Android benchmark question rather than a claim
+  inferred from the pure helper test.
+- Empty dependent selections have an explicit configuration-error path covered by focused tests.
+- KDoc, both READMEs, and `CHANGELOG.md` describe the atomic callback in one sentence.
+
+## Public API gate
+
+This slice deliberately adds no public `MultiWheelPicker<State>` surface. Date and Time must first
+pass the same transition contract without erased item types, a graph DSL, manual invalidation, or
+custom synchronization machinery. The next API proposal must reuse this proven model and also
+explain how live preview and all-columns-settled events work when dependent sources change.
+
+## Follow-up audit
+
+- `YearMonthPickerState` and `DateRangePickerState` still need the same one-snapshot logical update
+  audit before they can claim this contract.
+- Generic `Picker` still needs a focused slice for disabling during an active animation; the wheel
+  must recenter to its controlled value rather than leaving its visual center and semantics state
+  apart.
+- Infinite mode with a one-value source currently renders repeated visible rows whose equal values
+  all satisfy selected semantics. Audit single-value rendering so accessibility exposes one logical
+  selection rather than several selected duplicates.
+- A public engine remains gated on Duration and Quantity/Unit proving the same late-invalid-value,
+  dependency, restore, and settled-event model without preset-specific exceptions.

--- a/docs/product/wheel-picker-engine-direction.md
+++ b/docs/product/wheel-picker-engine-direction.md
@@ -1,7 +1,7 @@
 # Constraint-aware Wheel Picker Engine 제품 방향
 
 > 상태: 제품 가설 및 구현 순서 기준선
-> 근거 스냅샷: 2026-07-17
+> 근거 스냅샷: 2026-07-18
 > 범위: 저장소 이름, Maven 좌표, 공개 API를 즉시 변경하는 결정이 아니라 다음 구현 slice의 방향을 고정한다.
 
 ## 결론
@@ -61,6 +61,26 @@ presets이자 회귀 검증 기준이다. 이후 `DurationPicker`와 `QuantityUn
 이 가설을 외부 개발자 증거 없이 “시장 검증 완료”로 표현하면 안 된다. 현재 제품성 평가는 **유망하지만
 미검증**이다. 특히 지금 인지도 상태에서 이름만 `WheelPicker`로 바꾸면 검색 경쟁은 더 치열해지고 기존
 temporal 사용자에게 주던 명확성까지 잃을 수 있다.
+
+## Naming decision gate
+
+`WheelPicker`는 제품·저장소 브랜드 후보에서 제외한다. Compose Multiplatform에 이미 정확히 같은 범주의
+`KMP Wheel Picker`가 `com.swmansion.kmpwheelpicker:kmp-wheel-picker`로 Maven Central에 배포되고 있고,
+Android에는 Compose를 지원하는 `dev.aige.pub:WheelPicker`와 여러 `wheelpicker-compose` 계열 프로젝트가
+존재한다. 보통명사만으로 리브랜딩하면 법적 문제보다 먼저 검색성, 기억성, dependency 식별성이 나빠진다.
+
+브랜드와 API vocabulary는 분리한다.
+
+- 제품·저장소·문서 사이트는 검색 가능한 고유 브랜드를 별도 naming validation에서 결정한다.
+- 단일-column composable `WheelPicker<T>`는 UI control을 설명하는 API 보통명사로 유지할 수 있다.
+- `MultiWheelPicker<State>`는 아직 공개 API가 아니며, Duration/Quantity 검증 뒤 역할을 더 잘 드러내는 이름과
+  함께 다시 비교한다.
+- Maven artifact와 package migration은 외부 first-use/adoption 증거, 후보명 충돌 검색, migration 비용을
+  함께 평가하기 전에는 수행하지 않는다.
+
+후보 브랜드는 GitHub/Maven Central exact-name 충돌, 일반 검색 결과의 구분 가능성, 발음·철자 회상성,
+도메인/조직 namespace 가능성, temporal 전용으로 오해되지 않는지를 통과해야 한다. 이름이 engine의 실제
+채택 증거보다 먼저 제품 방향을 결정하게 두지 않는다.
 
 ## 경쟁 지형에서의 빈자리
 
@@ -282,5 +302,7 @@ picker에서 atomic/dependent selection 계약을 다음 증거로 고정한다.
 - [commandiron/WheelPickerCompose](https://github.com/commandiron/WheelPickerCompose)
 - [darkokoa/compose-datetime-wheel-picker](https://github.com/darkokoa/compose-datetime-wheel-picker)
 - [software-mansion-labs/kmp-wheel-picker](https://github.com/software-mansion-labs/kmp-wheel-picker)
+- [Maven Central — com.swmansion.kmpwheelpicker:kmp-wheel-picker](https://central.sonatype.com/artifact/com.swmansion.kmpwheelpicker/kmp-wheel-picker)
+- [devaige/WheelPicker](https://github.com/devaige/WheelPicker)
 - [zj565061763/compose-wheel-picker](https://github.com/zj565061763/compose-wheel-picker)
 - [KMP Awesome — Compose UI](https://github.com/terrakok/kmp-awesome#-compose-ui)

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/DatePickerSampleScreen.kt
@@ -17,7 +17,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
@@ -81,12 +85,15 @@ fun DatePickerSampleScreen(
                 initialMonth = today.month.number,
                 initialDay = today.day
             )
+            var lastUserDateText by rememberSaveable { mutableStateOf("No user change") }
+            var userCallbackCount by rememberSaveable { mutableIntStateOf(0) }
 
             SelectedValueCard(
                 icon = FeatherIcons.Calendar,
                 label = "Selected date",
                 value = state.selectedDate.toString(),
-                supportingText = "Range: $today..$leapDate · Days: ${allowedDays.joinToString()}"
+                supportingText = "Range: $today..$leapDate · User callbacks: $userCallbackCount · " +
+                        "Last: $lastUserDateText"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -122,6 +129,10 @@ fun DatePickerSampleScreen(
                 DatePicker(
                     state = state,
                     items = pickerItems,
+                    onSelectedDateChange = { date ->
+                        lastUserDateText = date.toString()
+                        userCallbackCount += 1
+                    },
                     format = PickerDefaults.datePickerFormat(
                         yearItemText = { "${it}년" },
                         monthItemText = { getMonthName(it) },

--- a/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
+++ b/sample/src/commonMain/kotlin/com/kez/picker/sample/ui/screen/TimePickerSampleScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -68,8 +69,8 @@ internal fun TimePickerSampleScreen(
         initialMinute = currentTime.minute
     )
     val demoTime = LocalTime(hour = 9, minute = 30)
-    var lastChangedHour by rememberSaveable { mutableIntStateOf(currentTime.hour) }
-    var lastChangedMinute by rememberSaveable { mutableIntStateOf(currentTime.minute) }
+    var lastUserTimeText by rememberSaveable { mutableStateOf("No user change") }
+    var userCallbackCount by rememberSaveable { mutableIntStateOf(0) }
 
     val ktxTimeFormat12 = LocalTime.Format {
         amPmHour(padding = Padding.ZERO)
@@ -115,9 +116,7 @@ internal fun TimePickerSampleScreen(
                 icon = FeatherIcons.Clock,
                 label = "Selected time",
                 value = selectedTimeText,
-                supportingText = "Last callback: ${
-                    LocalTime(lastChangedHour, lastChangedMinute).format(ktxTimeFormat24)
-                }"
+                supportingText = "User callbacks: $userCallbackCount · Last: $lastUserTimeText"
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -128,13 +127,6 @@ internal fun TimePickerSampleScreen(
                         val now = currentDateTime().time
                         timeState12.selectTime(now)
                         timeState24.selectTime(now, businessHoursItems)
-                        val selectedTime = if (selectedFormat == 0) {
-                            timeState12.selectedTime
-                        } else {
-                            timeState24.selectedTime
-                        }
-                        lastChangedHour = selectedTime.hour
-                        lastChangedMinute = selectedTime.minute
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -153,13 +145,6 @@ internal fun TimePickerSampleScreen(
                             minute = demoTime.minute,
                             items = businessHoursItems
                         )
-                        val selectedTime = if (selectedFormat == 0) {
-                            timeState12.selectedTime
-                        } else {
-                            timeState24.selectedTime
-                        }
-                        lastChangedHour = selectedTime.hour
-                        lastChangedMinute = selectedTime.minute
                     },
                     modifier = Modifier.fillMaxWidth()
                 ) {
@@ -189,8 +174,8 @@ internal fun TimePickerSampleScreen(
                         state = timeState12,
                         spacingBetweenPickers = 8.dp,
                         onSelectedTimeChange = {
-                            lastChangedHour = it.hour
-                            lastChangedMinute = it.minute
+                            lastUserTimeText = it.format(ktxTimeFormat24)
+                            userCallbackCount += 1
                         },
                         format = PickerDefaults.timePickerFormat(
                             hourItemText = { it.toString().padStart(2, '0') },
@@ -221,8 +206,8 @@ internal fun TimePickerSampleScreen(
                         state = timeState24,
                         spacingBetweenPickers = 8.dp,
                         onSelectedTimeChange = {
-                            lastChangedHour = it.hour
-                            lastChangedMinute = it.minute
+                            lastUserTimeText = it.format(ktxTimeFormat24)
+                            userCallbackCount += 1
                         },
                         items = businessHoursItems,
                         format = PickerDefaults.timePickerFormat(


### PR DESCRIPTION
## Summary

- reduce each settled DatePicker/TimePicker child change to one repaired selectable logical value, commit state first, then dispatch one user callback
- ignore late values that are no longer active and recreate child-wheel generations when state or item-source semantics change so in-flight interactions cannot leak into replacements
- apply multi-field state writes in one Compose mutable snapshot and coerce items-aware save/restore against the recreated source
- keep TimePicker state recreation aligned with the latest items when `timeFormat` changes without resetting state for items-only recomposition
- document the concrete multi-column contract, dynamic source replacement order, and naming gate that excludes `WheelPicker` as the product/repository brand while retaining it as API vocabulary
- update Date/Time samples to distinguish logical selection from user callback count and last callback value

## Review feedback addressed

- narrowed stale-event wording to the actual active-source membership contract
- added semantic generation cancellation for state/item replacement during animation
- added in-flight motion evidence to overlap/source replacement tests
- fixed callback-free restore coverage and items + timeFormat recreation coverage
- corrected items-aware KDoc, restore exceptions, and the existing `initialDate` KDoc mismatch
- documented the remaining generic Picker disable-mid-animation and single-item infinite semantics audits as follow-up slices

## Verification

- `./gradlew :datetimepicker:check --no-daemon`
- `./gradlew :datetimepicker:checkLegacyAbi --no-daemon`
- `./gradlew :sample:compileKotlinDesktop --no-daemon`
- `./gradlew :sample:compileKotlinIosSimulatorArm64 --no-daemon`
- `./gradlew :sample:wasmJsBrowserDistribution --no-daemon`
- `./gradlew :sample:assembleDebugAndroidTest --no-daemon`
- `git diff --check origin/main...HEAD`

No public signature or ABI dump changes are included. Hosted PR automation remains intentionally disabled; this PR uses the repository's local verification gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DatePicker and TimePicker now commit one repaired, selectable value after wheel interactions settle.
  * User callbacks fire once per committed interaction; invalidated interactions are cancelled without callbacks.
  * Restored selections are coerced to match the latest available items and constraints.
  * Dynamic item-source replacements preserve logical selections when valid.
  * Sample screens now display the latest user selection and callback count.

* **Documentation**
  * Expanded guidance on callback timing, programmatic selection, dynamic item replacement, and multi-wheel behavior.

* **Tests**
  * Added coverage for selection repair, callback contracts, cancellation, dynamic sources, and state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->