### PR TITLE
fix: stop DurationPicker hour/minute columns from looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ This project tracks notable user-facing and maintainer-facing changes here. The 
   adoption-evidence migration gate on 2026-08-05, and the pre-rename exact-name collision check for
   `compose-pickers` was repeated on the same date with no conflicts found.
 
+### Fixed
+
+- Fixed `DurationPicker` looping its hour and minute columns instead of stopping at the source
+  bounds. A duration is a bounded elapsed quantity, not a cyclic one, but both columns used the
+  default infinite scroll, so a small `hourItems` source (for example `listOf(0, 1)`) rendered as
+  0 h / 1 h / 0 h / 1 h / 0 h with the same value appearing above and below the selection. Both
+  columns now scroll bounded, matching how `TimePicker`'s AM/PM column and `DatePicker`'s year and
+  day columns already treat non-cyclic values.
+
 ### Added
 
 - Added a browser demo of the sample app, published to GitHub Pages from the Kotlin/Wasm build on

--- a/pickers/src/androidUnitTest/kotlin/com/kez/picker/DurationPickerRobolectricTest.kt
+++ b/pickers/src/androidUnitTest/kotlin/com/kez/picker/DurationPickerRobolectricTest.kt
@@ -86,6 +86,38 @@ class DurationPickerRobolectricTest {
     }
 
     @Test
+    fun hourColumnScrollsBoundedInsteadOfLooping() {
+        lateinit var state: DurationPickerState
+        val items = PickerDefaults.durationPickerItems(
+            hourItems = listOf(0, 1),
+            minuteItems = (0..55 step 5).toList(),
+            maxDuration = 90.minutes
+        )
+
+        composeRule.setContent {
+            state = rememberDurationPickerState(items = items, initialDuration = 45.minutes)
+            DurationPicker(
+                state = state,
+                items = items,
+                style = PickerDefaults.style(visibleItemsCount = 5),
+                format = testDurationFormat(),
+                semantics = testDurationSemantics()
+            )
+        }
+
+        // hourItems has only two values, fewer than the five visible rows. A looping/infinite
+        // wheel fills the extra rows by repeating the two values, so the unselected "1 hours" row
+        // renders twice: once above and once below the selected "0 hours" row. A bounded wheel
+        // pads the extra rows with empty space instead, so "1 hours" renders exactly once.
+        composeRule.runOnIdle {
+            assertEquals(
+                1,
+                composeRule.onAllNodes(hasContentDescription("Hours: 1 hours")).fetchSemanticsNodes().size
+            )
+        }
+    }
+
+    @Test
     fun programmaticSelectionCancelsInFlightUserSettleWithoutCallback() {
         lateinit var state: DurationPickerState
         val committedDurations = mutableListOf<Duration>()

--- a/pickers/src/commonMain/kotlin/com/kez/picker/duration/DurationPicker.kt
+++ b/pickers/src/commonMain/kotlin/com/kez/picker/duration/DurationPicker.kt
@@ -148,6 +148,7 @@ fun DurationPicker(
                                     enabled = enabled,
                                     format = format.hour,
                                     style = columnStyle,
+                                    isInfinity = false,
                                     semantics = semantics.hour
                                 )
 
@@ -164,6 +165,7 @@ fun DurationPicker(
                                     enabled = enabled,
                                     format = format.minute,
                                     style = columnStyle,
+                                    isInfinity = false,
                                     semantics = semantics.minute
                                 )
                             }


### PR DESCRIPTION
## Summary

`DurationPicker`'s hour and minute columns loop instead of stopping at the source bounds. A duration is a bounded elapsed quantity, not a cyclic one, but both internal `Picker(...)` calls in `DurationPicker.kt` left `isInfinity` at its default (`true`). With a small `hourItems` source like `listOf(0, 1)` — exactly what `README.md`'s and the sample app's `DurationPicker` examples use — the wheel renders 0 h / 1 h / 0 h / 1 h / 0 h, showing the same value both above and below the selected row and implying the duration wraps from its maximum back to zero. This was visible in the sample screenshot added in #145.

This codebase already has a clear, consistent convention for this: bounded/non-cyclic columns set `isInfinity = false` explicitly (`TimePicker`'s AM/PM column, `DatePicker`'s year and day columns, `YearMonthPicker`'s year column), while genuinely cyclic columns (hour-of-day, minute-of-hour, month-within-year) keep the default. `DurationPicker`'s hour/minute columns were simply missing this.

## Fix

Add `isInfinity = false` to both `Picker(...)` calls in `DurationPicker.kt`. No public API surface changes — this is an internal call-site parameter, not a new composable parameter — so no ABI dump updates are needed.

## Test

Added `hourColumnScrollsBoundedInsteadOfLooping` to `DurationPickerRobolectricTest`: with a 2-item hour source and a 5-row visible window, an unselected hour value must render as exactly one semantics node. I confirmed this fails against the pre-fix code (`AssertionError: expected 1, got 2`) before adding the fix, then confirmed it passes after.

Note on how I got to this assertion: my first attempt asserted uniqueness for the *selected* value's content description, which failed for an unrelated, pre-existing reason — every `Picker` column has both an outer collection-semantics node and a per-row node, and both carry the same content description for whichever value is currently selected. That's expected structural behavior, not this bug. Asserting on an *unselected* sibling value sidesteps that and isolates the actual looping symptom.

## Verification
- `./gradlew :pickers:testDebugUnitTest :pickers:testReleaseUnitTest :pickers:test --no-daemon` passed (343+ tests).
- `./gradlew :pickers:checkLegacyAbi --no-daemon` passed — confirms no unintended public API change.
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)