### PR TITLE
ci: require tagged Maven Central releases

### DIFF
--- a/.github/workflows/maven-central-deploy.yml
+++ b/.github/workflows/maven-central-deploy.yml
@@ -2,6 +2,11 @@ name: Publish Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Annotated release tag matching VERSION_NAME (for example, 0.7.0)"
+        required: true
+        type: string
 
 jobs:
   publish-release:
@@ -12,6 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag }}
+          fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v2
 
       - name: Set up JDK 17
@@ -21,13 +29,38 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Ensure this isn't a -SNAPSHOT version
+      - name: Validate release tag and version
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
+          if ! git check-ref-format --allow-onelevel "refs/tags/$RELEASE_TAG"; then
+            echo "release_tag must be a valid tag name: $RELEASE_TAG"
+            exit 1
+          fi
+
+          if [[ "$(git cat-file -t "$RELEASE_TAG")" != "tag" ]]; then
+            echo "release_tag must be an annotated tag: $RELEASE_TAG"
+            exit 1
+          fi
+
+          git fetch origin main:refs/remotes/origin/main
+          TAG_COMMIT=$(git rev-list -n 1 "$RELEASE_TAG")
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "release_tag must point to a commit reachable from origin/main: $RELEASE_TAG"
+            exit 1
+          fi
+
           VERSION=$(./gradlew -q printVersion | tail -1)
           if [[ $VERSION == *"-SNAPSHOT" ]]; then
             echo "Cannot publish a SNAPSHOT version ($VERSION) as a release"
             exit 1
           fi
+
+          if [[ "$VERSION" != "$RELEASE_TAG" ]]; then
+            echo "release_tag ($RELEASE_TAG) must exactly match VERSION_NAME ($VERSION)"
+            exit 1
+          fi
+
           echo "Publishing version: $VERSION"
 
       - name: Publish Release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Compose Pickers
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.kez-lab/compose-date-time-picker?label=maven%20central)](https://central.sonatype.com/artifact/io.github.kez-lab/compose-date-time-picker)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.kez-lab/compose-pickers?label=maven%20central)](https://central.sonatype.com/artifact/io.github.kez-lab/compose-pickers)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Desktop%20%7C%20Web-4F46E5)](#)
 [![Live demo](https://img.shields.io/badge/live%20demo-try%20it%20in%20your%20browser-4F46E5)](https://kez-lab.org/Compose-Pickers/)
@@ -118,13 +118,13 @@ dependencies {
 }
 ```
 
-> **Release status:** The library was renamed in `0.7.0`. The `io.github.kez-lab:compose-pickers` coordinates above are **not published to Maven Central yet**; the latest published artifact is `io.github.kez-lab:compose-date-time-picker:0.6.0` under the previous project name (GitHub Releases may still show `0.4.0` as the latest tagged release). Until the first `compose-pickers` release ships, either depend on the old `0.6.0` artifact or test `main` locally: run `./gradlew :pickers:publishToMavenLocal`, add `mavenLocal()` to your consuming build, and depend on the repository `VERSION_NAME`. This README is maintained from `main`, so Usage and API Reference sections can include APIs that are not in any published artifact yet.
+> **Release status:** `0.7.0` is the first Maven Central release under the renamed `io.github.kez-lab:compose-pickers` coordinates. The previous `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact remains available but will receive no further releases. This README is maintained from `main`, so Usage and API Reference sections can include APIs newer than the latest published artifact; use the versioned release tag when you need documentation that exactly matches a release.
 
 For release notes and upgrade-impact details, see [CHANGELOG.md](CHANGELOG.md).
 
 ## Usage
 
-> The examples below target the current `main` branch API, which is not published yet. See the release-status note under [Installation](#installation).
+> The examples below target the current `main` branch API and can be newer than the latest published release. See the release-status note under [Installation](#installation).
 
 ### State and Callback Pattern
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -1,6 +1,6 @@
 # Compose Pickers
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.kez-lab/compose-date-time-picker?label=maven%20central)](https://central.sonatype.com/artifact/io.github.kez-lab/compose-date-time-picker)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.kez-lab/compose-pickers?label=maven%20central)](https://central.sonatype.com/artifact/io.github.kez-lab/compose-pickers)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Desktop%20%7C%20Web-4F46E5)](#)
 [![Live demo](https://img.shields.io/badge/live%20demo-%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C%20%EC%B2%B4%ED%97%98-4F46E5)](https://kez-lab.org/Compose-Pickers/)
@@ -117,13 +117,13 @@ dependencies {
 }
 ```
 
-> **릴리스 상태:** 라이브러리는 `0.7.0`에서 `Compose-Pickers`로 이름이 변경되었습니다. 위의 `io.github.kez-lab:compose-pickers` 좌표는 **아직 Maven Central에 배포되지 않았습니다**. 현재 배포된 최신 artifact는 이전 이름의 `io.github.kez-lab:compose-date-time-picker:0.6.0`입니다(GitHub Releases 화면은 아직 `0.4.0`을 최신 태그로 표시할 수 있습니다). 첫 `compose-pickers` 릴리스 전까지는 기존 `0.6.0` artifact를 사용하거나, `./gradlew :pickers:publishToMavenLocal` 실행 후 소비 프로젝트에 `mavenLocal()`을 추가하고 저장소 `VERSION_NAME`에 의존해 `main`을 로컬에서 테스트하세요. 이 README는 `main` 기준으로 유지되므로, 사용법과 API 레퍼런스에는 아직 배포되지 않은 API가 포함될 수 있습니다.
+> **릴리스 상태:** `0.7.0`은 이름이 변경된 `io.github.kez-lab:compose-pickers` 좌표의 첫 Maven Central 릴리스입니다. 이전 `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact는 계속 사용할 수 있지만 이후 릴리스는 제공하지 않습니다. 이 README는 `main` 기준으로 유지되므로, 사용법과 API 레퍼런스에는 최신 배포 artifact보다 새로운 API가 포함될 수 있습니다. 릴리스와 정확히 일치하는 문서가 필요하면 해당 버전 tag를 사용하세요.
 
 릴리스 노트와 업그레이드 영향은 영문 [CHANGELOG.md](CHANGELOG.md)를 참고하세요.
 
 ## 사용법
 
-> 아래 예제는 아직 배포되지 않은 현재 `main` 브랜치 API를 기준으로 합니다. [설치 방법](#설치-방법)의 릴리스 상태 안내를 참고하세요.
+> 아래 예제는 현재 `main` 브랜치 API를 기준으로 하며 최신 배포본보다 새로울 수 있습니다. [설치 방법](#설치-방법)의 릴리스 상태 안내를 참고하세요.
 
 ### State와 Callback 사용 패턴
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,52 @@
+# Maven Central 릴리스 절차
+
+`compose-pickers`의 Maven Central 릴리스는 immutable artifact를 올리는 작업이다. 따라서
+`main`에서 임의로 배포하지 않고, `VERSION_NAME`과 같은 **annotated tag**를 먼저 만든 뒤
+태그를 명시해 수동 워크플로를 실행한다.
+
+## 릴리스 전
+
+1. `gradle.properties`의 `VERSION_NAME`, `CHANGELOG.md`, README의 dependency 예시와
+   릴리스 상태 문구를 점검한다.
+2. `main`이 원격과 동기화된 깨끗한 상태에서 다음 로컬 게이트를 통과시킨다.
+
+   ```bash
+   git diff --check origin/main...HEAD
+   ./gradlew :pickers:check :pickers:checkLegacyAbi --no-daemon
+   ./gradlew :pickers:publishToMavenLocal --no-daemon
+   ```
+
+   샘플을 바꾼 릴리스라면 `:sample:compileKotlinDesktop`,
+   `:sample:wasmJsBrowserDistribution`, `:sample:assembleDebugAndroidTest`도 실행한다.
+
+3. 현재 `VERSION_NAME`과 같은 형식의 annotated tag를 만든다. 이 프로젝트의 새 릴리스
+   형식은 `0.7.0`처럼 `v` 접두사가 없는 숫자 버전이다.
+
+   ```bash
+   git tag -a 0.7.0 -m "Release 0.7.0"
+   git push origin 0.7.0
+   ```
+
+## 배포
+
+GitHub Actions의 **Publish Release** 워크플로를 수동 실행하고 `release_tag`에 정확히
+`0.7.0`을 입력한다. 워크플로는 다음을 모두 확인한 뒤 태그가 가리키는 소스만
+`publishToMavenCentral`로 배포한다.
+
+- tag가 annotated tag인지
+- tag commit이 `origin/main`에서 도달 가능한지
+- tag 이름이 `VERSION_NAME`과 정확히 일치하는지
+- 버전이 `-SNAPSHOT`이 아닌지
+
+GitHub Actions UI에서 워크플로 정의를 실행할 branch는 현재 `main`을 선택한다. 실제
+배포 대상 소스는 `release_tag`로 명시된 tag이므로 branch 선택에 따라 artifact가 바뀌지
+않는다.
+
+## 배포 후
+
+1. 워크플로 성공을 확인한다.
+2. Maven Central에서 `io.github.kez-lab:compose-pickers:<version>` 및 Android, Desktop,
+   iOS, Wasm publication을 확인한다. 색인이 반영되기 전까지는 잠시 지연될 수 있다.
+3. 깨끗한 소비자 프로젝트에서 Maven Central 의존성 해석을 확인한다.
+4. README의 “아직 배포되지 않음” 상태 문구를 배포 사실과 최신 버전으로 바꾸고, 필요하면
+   GitHub Release를 같은 tag에 연결한다.


### PR DESCRIPTION
## Summary

- Require an annotated tag matching VERSION_NAME before publishing.
- Document the release procedure.
- Update README coordinates and release status for the first compose-pickers 0.7.0 release.

## Verification

- YAML parse for all workflows.
- git diff --check origin/main...HEAD.
- Pickers check, ABI, sample target builds, and signed Maven Local publication passed before this docs/workflow-only slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Maven Central badges and installation guidance to reference the renamed `compose-pickers` artifact.
  * Clarified that version `0.7.0` is the first Maven Central release under the new artifact name, while `0.6.0` remains available.
  * Added comprehensive Maven Central release instructions, including validation, publishing, and post-release verification.

* **Release Process**
  * Release publishing now requires a validated release tag and confirms it matches the project version before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->