### PR TITLE
ci: release Maven Central deployments automatically

### DIFF
--- a/.github/workflows/maven-central-deploy.yml
+++ b/.github/workflows/maven-central-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           echo "Publishing version: $VERSION"
 
       - name: Publish Release
-        run: ./gradlew publishToMavenCentral
+        run: ./gradlew publishAndReleaseToMavenCentral
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ dependencies {
 }
 ```
 
-> **Release status:** `0.7.0` is the first Maven Central release under the renamed `io.github.kez-lab:compose-pickers` coordinates. The previous `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact remains available but will receive no further releases. This README is maintained from `main`, so Usage and API Reference sections can include APIs newer than the latest published artifact; use the versioned release tag when you need documentation that exactly matches a release.
+> **Release status:** `0.7.0` is the first release prepared under the renamed `io.github.kez-lab:compose-pickers` coordinates and is awaiting Maven Central publication. Until it is publicly available, use the previous `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact. This README is maintained from `main`, so Usage and API Reference sections can include APIs newer than the latest published artifact; use the versioned release tag when you need documentation that exactly matches a release.
 
 For release notes and upgrade-impact details, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -117,7 +117,7 @@ dependencies {
 }
 ```
 
-> **릴리스 상태:** `0.7.0`은 이름이 변경된 `io.github.kez-lab:compose-pickers` 좌표의 첫 Maven Central 릴리스입니다. 이전 `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact는 계속 사용할 수 있지만 이후 릴리스는 제공하지 않습니다. 이 README는 `main` 기준으로 유지되므로, 사용법과 API 레퍼런스에는 최신 배포 artifact보다 새로운 API가 포함될 수 있습니다. 릴리스와 정확히 일치하는 문서가 필요하면 해당 버전 tag를 사용하세요.
+> **릴리스 상태:** `0.7.0`은 이름이 변경된 `io.github.kez-lab:compose-pickers` 좌표로 준비된 첫 릴리스이며 Maven Central 공개를 기다리고 있습니다. 공개되기 전까지는 이전 `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact를 사용하세요. 이 README는 `main` 기준으로 유지되므로, 사용법과 API 레퍼런스에는 최신 배포 artifact보다 새로운 API가 포함될 수 있습니다. 릴리스와 정확히 일치하는 문서가 필요하면 해당 버전 tag를 사용하세요.
 
 릴리스 노트와 업그레이드 영향은 영문 [CHANGELOG.md](CHANGELOG.md)를 참고하세요.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -31,12 +31,16 @@
 
 GitHub Actions의 **Publish Release** 워크플로를 수동 실행하고 `release_tag`에 정확히
 `0.7.0`을 입력한다. 워크플로는 다음을 모두 확인한 뒤 태그가 가리키는 소스만
-`publishToMavenCentral`로 배포한다.
+`publishAndReleaseToMavenCentral`로 배포·공개한다. 이 task는 Central Portal deployment가
+검증된 뒤 공개될 때까지 기다리므로, Portal에서 별도로 **Publish**를 누를 필요가 없다.
 
 - tag가 annotated tag인지
 - tag commit이 `origin/main`에서 도달 가능한지
 - tag 이름이 `VERSION_NAME`과 정확히 일치하는지
 - 버전이 `-SNAPSHOT`이 아닌지
+
+GitHub Actions 성공만으로 끝내지 말고, 아래 배포 후 확인에서 공개 Maven repository의
+artifact까지 확인한다.
 
 GitHub Actions UI에서 워크플로 정의를 실행할 branch는 현재 `main`을 선택한다. 실제
 배포 대상 소스는 `release_tag`로 명시된 tag이므로 branch 선택에 따라 artifact가 바뀌지


### PR DESCRIPTION
## Summary

- Run publishAndReleaseToMavenCentral after tagged-release validation.
- Document automatic Central Portal publication.
- Keep README release status accurate while 0.7.0 awaits publication.

## Verification

- YAML parse for all workflows.
- git diff --check origin/main...HEAD.
- Confirmed the Gradle automatic release task exists.