### PR TITLE
docs: mark Compose-Pickers 0.7.0 as published

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ dependencies {
 }
 ```
 
-> **Release status:** `0.7.0` is the first release prepared under the renamed `io.github.kez-lab:compose-pickers` coordinates and is awaiting Maven Central publication. Until it is publicly available, use the previous `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact. This README is maintained from `main`, so Usage and API Reference sections can include APIs newer than the latest published artifact; use the versioned release tag when you need documentation that exactly matches a release.
+> **Release status:** `0.7.0` is the first Maven Central release under the renamed `io.github.kez-lab:compose-pickers` coordinates. The previous `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact remains available but will receive no further releases. This README is maintained from `main`, so Usage and API Reference sections can include APIs newer than the latest published artifact; use the versioned release tag when you need documentation that exactly matches a release.
 
 For release notes and upgrade-impact details, see [CHANGELOG.md](CHANGELOG.md).
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -117,7 +117,7 @@ dependencies {
 }
 ```
 
-> **릴리스 상태:** `0.7.0`은 이름이 변경된 `io.github.kez-lab:compose-pickers` 좌표로 준비된 첫 릴리스이며 Maven Central 공개를 기다리고 있습니다. 공개되기 전까지는 이전 `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact를 사용하세요. 이 README는 `main` 기준으로 유지되므로, 사용법과 API 레퍼런스에는 최신 배포 artifact보다 새로운 API가 포함될 수 있습니다. 릴리스와 정확히 일치하는 문서가 필요하면 해당 버전 tag를 사용하세요.
+> **릴리스 상태:** `0.7.0`은 이름이 변경된 `io.github.kez-lab:compose-pickers` 좌표의 첫 Maven Central 릴리스입니다. 이전 `io.github.kez-lab:compose-date-time-picker:0.6.0` artifact는 계속 사용할 수 있지만 이후 릴리스는 제공하지 않습니다. 이 README는 `main` 기준으로 유지되므로, 사용법과 API 레퍼런스에는 최신 배포 artifact보다 새로운 API가 포함될 수 있습니다. 릴리스와 정확히 일치하는 문서가 필요하면 해당 버전 tag를 사용하세요.
 
 릴리스 노트와 업그레이드 영향은 영문 [CHANGELOG.md](CHANGELOG.md)를 참고하세요.
 


### PR DESCRIPTION
## Summary

- Mark the first compose-pickers coordinates as publicly available on Maven Central.
- Preserve the previous compose-date-time-picker 0.6.0 migration note.

## Verification

- Maven Central root, Android, Desktop, iOS, and Wasm metadata/POM requests returned HTTP 200.
- git diff --check origin/main...HEAD.